### PR TITLE
Support installed Microsoft GDK alongside vcpkg ms-gdk port

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,21 +3,28 @@
     "cmakeMinimumRequired": { "major": 3, "minor": 25, "patch": 0 },
     "configurePresets": [
         {
-            "name": "default",
-            "displayName": "Visual Studio 2022 x64",
+            "name": "_base",
+            "hidden": true,
             "generator": "Visual Studio 17 2022",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build",
-            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "cacheVariables": {
                 "CMAKE_CXX_STANDARD": "17",
-                "VCPKG_TARGET_TRIPLET": "x64-windows",
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDLL",
                 "CMAKE_MAP_IMPORTED_CONFIG_DEBUG": "Release;",
                 "CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO": "Release;",
                 "CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL": "Release;",
                 "BUILD_GODOT_GDK": "ON",
                 "BUILD_GODOT_GAMEINPUT": "ON"
+            }
+        },
+        {
+            "name": "default",
+            "displayName": "Visual Studio 2022 x64",
+            "inherits": "_base",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x64-windows"
             }
         },
         {
@@ -74,12 +81,11 @@
         },
         {
             "name": "installed-gdk",
-            "displayName": "Installed GDK (ms-gdk on disk; GameInput addon disabled)",
-            "inherits": "default",
+            "displayName": "Installed GDK on disk (no vcpkg required; GameInput addon disabled)",
+            "inherits": "_base",
             "binaryDir": "${sourceDir}/build/installed-gdk",
             "cacheVariables": {
                 "GDK_DEPENDENCY_SOURCE": "installed",
-                "VCPKG_MANIFEST_NO_DEFAULT_FEATURES": "ON",
                 "BUILD_GODOT_GAMEINPUT": "OFF"
             }
         }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,6 +71,17 @@
                 "BUILD_GODOT_GDK_PACKAGING": "ON",
                 "GDK_BUILD_TESTS": "OFF"
             }
+        },
+        {
+            "name": "installed-gdk",
+            "displayName": "Installed GDK (ms-gdk on disk; GameInput addon disabled)",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build/installed-gdk",
+            "cacheVariables": {
+                "GDK_DEPENDENCY_SOURCE": "installed",
+                "VCPKG_MANIFEST_NO_DEFAULT_FEATURES": "ON",
+                "BUILD_GODOT_GAMEINPUT": "OFF"
+            }
         }
     ],
     "buildPresets": [
@@ -161,6 +172,18 @@
                 "godot_playfab",
                 "godot_gameinput"
             ]
+        },
+        {
+            "name": "debug-installed-gdk",
+            "displayName": "Debug (installed GDK)",
+            "configurePreset": "installed-gdk",
+            "configuration": "Debug"
+        },
+        {
+            "name": "release-installed-gdk",
+            "displayName": "Release (installed GDK)",
+            "configurePreset": "installed-gdk",
+            "configuration": "Release"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,12 +81,12 @@
         },
         {
             "name": "installed-gdk",
-            "displayName": "Installed GDK on disk (no vcpkg required; GameInput addon disabled)",
+            "displayName": "Installed GDK on disk (no vcpkg required; GameInput via NuGet)",
             "inherits": "_base",
             "binaryDir": "${sourceDir}/build/installed-gdk",
             "cacheVariables": {
                 "GDK_DEPENDENCY_SOURCE": "installed",
-                "BUILD_GODOT_GAMEINPUT": "OFF"
+                "GAMEINPUT_SOURCE": "nuget"
             }
         }
     ],

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Godot for XBOX on PC
 
 > [!IMPORTANT]
-> **This is a source-only sample, not a product.** It is not a commercial release and there is no SLA for support or maintenance. The repository is MIT-licensed at the wrapper layer; the Microsoft GDK and PlayFab dependencies still require their own installs and license acceptance, consistent with other XBOX samples. We will watch the repo, monitor issues, and iterate where it makes sense.
+> **This is a source-only sample, not a product.** The repository is MIT-licensed at the wrapper layer; the Microsoft GDK and PlayFab dependencies still require their own installs and license acceptance, consistent with other XBOX samples. There is no specified update cadence for support or maintenance. We'll watch the repo, monitor issues, and iterate where it makes sense, but this isn't a commercial release. We are excited to hear your feedback, and see any community PRs, as we evolve this together.
 >
 > **This is a sample specific to XBOX on PC.** There is no specific support for Xbox Series X\|S or Xbox One. Please talk with your Microsoft representative if you'd like to learn more about support on those platforms.
 

--- a/cmake/GDKDependencies.cmake
+++ b/cmake/GDKDependencies.cmake
@@ -39,12 +39,22 @@ include_guard(GLOBAL)
 #     before this module runs -- always go through the `installed-gdk`
 #     preset.
 #
-# GameInput v3 is provided by the vcpkg `gameinput` port. The installed
-# GDK ships GameInput v1 only -- v3 is a separate Microsoft SDK release
-# that lives outside the main GDK bundle. The `installed-gdk` preset
-# therefore disables the `godot_gameinput` addon by default
-# (`BUILD_GODOT_GAMEINPUT=OFF`); developers who want controller support
-# should use the default preset (which restores `gameinput` from vcpkg).
+# GameInput v3 is sourced separately from the GDK because the installed
+# GDK ships GameInput v1 only -- v3 is published independently by
+# Microsoft. Source selection is controlled by `GAMEINPUT_SOURCE`:
+#
+#   - `vcpkg` (default): the `gameinput` vcpkg port. Used by the default
+#     preset and the other vcpkg-based presets.
+#   - `nuget`: pull the `Microsoft.GameInput` NuGet package directly from
+#     nuget.org via `file(DOWNLOAD)`, cached under
+#     `${CMAKE_BINARY_DIR}/_deps/`. No vcpkg toolchain required. Used by
+#     the `installed-gdk` preset so GameInput stays available even when
+#     vcpkg is not present.
+#
+# Both GameInput sources expose the same `Microsoft::GameInput` IMPORTED
+# target -- the godot_gameinput addon's CMakeLists is identical in both
+# cases. The vcpkg port and the NuGet path wrap the same upstream archive,
+# so behavior is identical at runtime.
 #
 # An explicit GDK install path can also be supplied as `-DGDK_INSTALL_DIR=<path>`.
 # The path may point at the version root (e.g. `...\260400\`), its
@@ -80,6 +90,28 @@ set(GDK_INSTALL_DIR "" CACHE PATH
 (e.g. `C:/Program Files (x86)/Microsoft GDK/260400/`), its `windows/` subdir, \
 or its `GRDK/` peer (auto-redirected to the sibling `windows/`). Only used \
 when GDK_DEPENDENCY_SOURCE is `installed`.")
+
+set(GAMEINPUT_SOURCE "vcpkg" CACHE STRING
+    "Source for the GameInput v3 dependency. One of: vcpkg, nuget. \
+Defaults to `vcpkg`: the `gameinput` port (which itself wraps the \
+`Microsoft.GameInput` NuGet package). The `installed-gdk` preset \
+overrides this to `nuget` so GameInput stays available without a vcpkg \
+toolchain -- the NuGet package is fetched directly from nuget.org via \
+`file(DOWNLOAD)` and cached under `${CMAKE_BINARY_DIR}/_deps/`. Both \
+sources expose the same `Microsoft::GameInput` IMPORTED target.")
+set_property(CACHE GAMEINPUT_SOURCE PROPERTY STRINGS vcpkg nuget)
+
+# Pinned version of the Microsoft.GameInput NuGet package fetched when
+# GAMEINPUT_SOURCE=nuget. Matches the version vcpkg's `gameinput` port
+# currently wraps (same upstream archive, same SHA512). Bump together
+# with the vcpkg port when refreshing.
+set(GDK_GAMEINPUT_NUGET_VERSION "3.1.26100.6879" CACHE STRING
+    "Version of the Microsoft.GameInput NuGet package fetched when GAMEINPUT_SOURCE=nuget.")
+set(GDK_GAMEINPUT_NUGET_SHA512
+    "7377a8cf9291318b99db4f94b6e2db6d8bd2a5afdac0b35bd38b3f51c75948a247e74dab155f2ba67d4ece78899e87c3e0e35510f1547bbc9b7c8202573a8ff6"
+    CACHE STRING
+    "SHA512 of the Microsoft.GameInput NuGet package archive. Used to verify the download.")
+mark_as_advanced(GDK_GAMEINPUT_NUGET_VERSION GDK_GAMEINPUT_NUGET_SHA512)
 
 # Internal cache. Populated by _gdk_resolve_dependency_source().
 set(_GDK_RESOLVED_SOURCE "" CACHE INTERNAL "Resolved GDK source: vcpkg or installed.")
@@ -473,14 +505,119 @@ function(gdk_require_ms_gdk)
     endif()
 endfunction()
 
-# Require GameInput (Microsoft::GameInput). Always vcpkg-backed -- the
-# installed GDK ships GameInput v1 only, and this repo targets v3 (a
-# separate Microsoft SDK release that the vcpkg `gameinput` port wraps).
-# The `installed-gdk` preset disables the godot_gameinput addon by
-# default so this is not called in pure-installed-GDK builds.
+# Fetch the Microsoft.GameInput NuGet package directly from nuget.org and
+# cache it under `${CMAKE_BINARY_DIR}/_deps/gameinput-nuget-<version>/`.
+# Idempotent -- second and subsequent configures reuse the cached extract.
+# Sets `<OUT_DIR>` in the parent scope to the extracted package root, which
+# contains:
+#
+#   native/include/GameInput.h          (v3 header; v0/v1/v2 subdirs ship
+#                                        backward-compat headers we don't use)
+#   native/lib/x64/GameInput.lib        (import lib)
+#   redist/GameInputRedist.msi          (runtime redistributable for
+#                                        deployment on target machines)
+#   LICENSE.txt
+#
+# The package is verified against GDK_GAMEINPUT_NUGET_SHA512 before
+# extraction. Bumping GDK_GAMEINPUT_NUGET_VERSION re-downloads because the
+# cache directory name embeds the version.
+function(_gdk_fetch_gameinput_nuget OUT_DIR)
+    set(_ver "${GDK_GAMEINPUT_NUGET_VERSION}")
+    set(_sha "${GDK_GAMEINPUT_NUGET_SHA512}")
+    set(_cache_dir "${CMAKE_BINARY_DIR}/_deps/gameinput-nuget-${_ver}")
+    set(_pkg "${CMAKE_BINARY_DIR}/_deps/gameinput-nuget-${_ver}.nupkg")
+    set(_fingerprint "${_cache_dir}/native/lib/x64/GameInput.lib")
+
+    if(NOT EXISTS "${_fingerprint}")
+        message(STATUS "Fetching Microsoft.GameInput ${_ver} from nuget.org "
+                       "(GAMEINPUT_SOURCE=nuget)")
+        file(MAKE_DIRECTORY "${_cache_dir}")
+        file(DOWNLOAD
+            "https://www.nuget.org/api/v2/package/Microsoft.GameInput/${_ver}"
+            "${_pkg}"
+            EXPECTED_HASH SHA512=${_sha}
+            STATUS _dl_status
+            SHOW_PROGRESS)
+        list(GET _dl_status 0 _dl_code)
+        if(NOT _dl_code EQUAL 0)
+            list(GET _dl_status 1 _dl_msg)
+            file(REMOVE "${_pkg}")
+            message(FATAL_ERROR
+                "Failed to download Microsoft.GameInput ${_ver} from nuget.org "
+                "(code ${_dl_code}): ${_dl_msg}.\n"
+                "Network access is required the first time you configure with "
+                "GAMEINPUT_SOURCE=nuget. To use a different version, override "
+                "-DGDK_GAMEINPUT_NUGET_VERSION=<version> "
+                "-DGDK_GAMEINPUT_NUGET_SHA512=<hash>. To skip GameInput, "
+                "set -DBUILD_GODOT_GAMEINPUT=OFF.")
+        endif()
+        file(ARCHIVE_EXTRACT INPUT "${_pkg}" DESTINATION "${_cache_dir}")
+        file(REMOVE "${_pkg}")
+        if(NOT EXISTS "${_fingerprint}")
+            message(FATAL_ERROR
+                "Microsoft.GameInput ${_ver} extracted from nuget.org but "
+                "expected file is missing: ${_fingerprint}. The NuGet package "
+                "layout may have changed.")
+        endif()
+    endif()
+
+    set(${OUT_DIR} "${_cache_dir}" PARENT_SCOPE)
+endfunction()
+
+# Define the `Microsoft::GameInput` IMPORTED target from an extracted
+# NuGet package directory. Target shape mirrors what vcpkg's `gameinput`
+# port exports (INTERFACE library with linked .lib + include dir) so
+# addon CMakeLists work against either source unchanged.
+#
+# Idempotent -- guarded by Microsoft::GameInput existence.
+function(_gdk_define_gameinput_nuget_target NUGET_DIR)
+    if(TARGET Microsoft::GameInput)
+        return()
+    endif()
+
+    set(_inc "${NUGET_DIR}/native/include")
+    set(_lib "${NUGET_DIR}/native/lib/x64/GameInput.lib")
+
+    if(NOT EXISTS "${_inc}/GameInput.h")
+        message(FATAL_ERROR
+            "Microsoft.GameInput NuGet package missing header: ${_inc}/GameInput.h")
+    endif()
+    if(NOT EXISTS "${_lib}")
+        message(FATAL_ERROR
+            "Microsoft.GameInput NuGet package missing import lib: ${_lib}")
+    endif()
+
+    add_library(Microsoft::GameInput INTERFACE IMPORTED)
+    set_target_properties(Microsoft::GameInput PROPERTIES
+        INTERFACE_LINK_LIBRARIES      "${_lib}"
+        INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+endfunction()
+
+# Require GameInput (Microsoft::GameInput). Dispatches on GAMEINPUT_SOURCE:
+#
+#   - `vcpkg` (default): the `gameinput` vcpkg port. Requires the vcpkg
+#     toolchain. This is what the `default` preset uses.
+#
+#   - `nuget`: pull the `Microsoft.GameInput` NuGet package from nuget.org
+#     directly (the same upstream the vcpkg port wraps). Requires no vcpkg
+#     toolchain -- the package is fetched via `file(DOWNLOAD)` and cached
+#     under `${CMAKE_BINARY_DIR}/_deps/`. This is what the `installed-gdk`
+#     preset uses so GameInput v3 stays available even without vcpkg.
+#
+# Both paths expose the same `Microsoft::GameInput` IMPORTED INTERFACE
+# target -- addon CMakeLists need no changes.
 function(gdk_require_gameinput)
-    _gdk_assert_vcpkg_toolchain()
-    find_package(gameinput CONFIG REQUIRED)
+    if(GAMEINPUT_SOURCE STREQUAL "nuget")
+        _gdk_fetch_gameinput_nuget(_nuget_dir)
+        _gdk_define_gameinput_nuget_target("${_nuget_dir}")
+    elseif(GAMEINPUT_SOURCE STREQUAL "vcpkg")
+        _gdk_assert_vcpkg_toolchain()
+        find_package(gameinput CONFIG REQUIRED)
+    else()
+        message(FATAL_ERROR
+            "Invalid GAMEINPUT_SOURCE='${GAMEINPUT_SOURCE}'. "
+            "Allowed values: vcpkg, nuget.")
+    endif()
 endfunction()
 
 # Absolute paths to the XSAPI Thunks DLLs that must be deployed alongside

--- a/cmake/GDKDependencies.cmake
+++ b/cmake/GDKDependencies.cmake
@@ -1,41 +1,97 @@
 include_guard(GLOBAL)
 
-# GDK build-time dependencies via vcpkg.
+# GDK build-time dependencies.
 #
-# This module brings in the Microsoft GDK (via the `ms-gdk[playfab]` port) and
-# GameInput (via the `gameinput` port). It exposes:
+# This module brings in the Microsoft GDK (Xbox::* + Xbox::PlayFab* targets)
+# and GameInput (Microsoft::GameInput), and exposes a small consumer surface:
 #
-#   Xbox::GameRuntime, Xbox::HTTPClient, Xbox::XCurl, Xbox::XSAPI,
-#   Xbox::GameChat2, Xbox::PlayFab{Core,Services,Multiplayer,Party,
-#   PartyLIVE,GameSave}                       -- from ms-gdk
-#   Microsoft::GameInput                      -- from gameinput
+#   gdk_require_ms_gdk()                  -- Xbox::* + Xbox::PlayFab*
+#   gdk_require_gameinput()               -- Microsoft::GameInput
+#   gdk_xsapi_thunks_dlls(OUT_VAR)        -- runtime DLLs to deploy
 #
-# In addition, it provides cache/cmake variables addons use to deploy SDK
-# runtime DLLs that are NOT exposed as proper imported targets — namely the
-# Microsoft.Xbox.Services.C.Thunks DLLs (per-config Debug/Release file names)
-# and the Microsoft.Xbox.Services.143.C.{Debug.pdb,pdb}. vcpkg lays these out
-# as bin/<file>.dll for Release and debug/bin/<file>.Debug.dll for Debug.
+# The `ms-gdk` dependency can be satisfied from either of two sources:
+#
+#   - **vcpkg** (default): the `ms-gdk[playfab]` port. Requires only a
+#     vcpkg checkout (no machine-wide GDK install). This is what CI uses.
+#
+#   - **installed GDK**: a developer's Microsoft GDK install on disk,
+#     typically at `C:\Program Files (x86)\Microsoft GDK\<version>\`.
+#     This module consumes the modern `windows\` subdirectory layout
+#     (`windows\include`, `windows\lib\x64`, `windows\bin\x64`) that GDK
+#     260400 / April 2026 and later ship. The legacy `GRDK\` peer layout
+#     (`ExtensionLibraries\*\Lib\x64\...`, per-library flat `Include\`)
+#     is **not** supported. Use the vcpkg source for older GDK versions.
+#
+# GameInput v3 is provided by the vcpkg `gameinput` port. The installed
+# GDK ships GameInput v1 only -- v3 is a separate Microsoft SDK release
+# that lives outside the main GDK bundle. The `installed-gdk` preset
+# therefore disables the `godot_gameinput` addon by default
+# (`BUILD_GODOT_GAMEINPUT=OFF`); developers who want controller support
+# can either use the default preset (which restores `gameinput` from
+# vcpkg) or explicitly opt in with `-DBUILD_GODOT_GAMEINPUT=ON
+# -DVCPKG_MANIFEST_FEATURES=godot-gameinput`.
+#
+# Source selection is controlled by the `GDK_DEPENDENCY_SOURCE` cache
+# variable, with values:
+#
+#   - `auto` (default): prefers an installed GDK when one is discoverable
+#     (via `-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`), otherwise
+#     falls back to the vcpkg port. This is the right choice for most
+#     developers, who already have a GDK installed for `makepkg.exe` /
+#     `wdapp.exe`.
+#   - `vcpkg`: force the vcpkg port (skip auto-detection). Useful for CI
+#     and machines where the installed GDK shouldn't be picked up. Errors
+#     if no toolchain file is set.
+#   - `installed`: force a discovered GDK install. Errors if none found.
+#     Set by the `installed-gdk` preset.
+#
+# An explicit GDK install path can also be supplied as `-DGDK_INSTALL_DIR=<path>`.
+# The path may point at the version root (e.g. `...\260400\`), its
+# `windows\` subdir, or its `GRDK\` peer (the latter is auto-redirected to
+# the sibling `windows\` directory).
 #
 # Consumer pattern (per-addon CMakeLists):
 #
 #   include(GDKDependencies)
-#   gdk_require_ms_gdk()        # addons that need Xbox::XSAPI / PlayFab*
-#   # or
-#   gdk_require_gameinput()     # addons that only need Microsoft::GameInput
+#   gdk_require_ms_gdk()
 #   target_link_libraries(my_addon PRIVATE Xbox::XSAPI Xbox::HTTPClient ...)
 #
-# Local prereq: developers must have a vcpkg checkout and either set
-# VCPKG_ROOT or pass `-DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake`.
-# The repo-default preset honors $env{VCPKG_ROOT}.
+# Imported targets exposed by `gdk_require_ms_gdk()` (identical names in
+# both modes -- addon CMakeLists need no changes):
+#
+#   Xbox::GameRuntime, Xbox::HTTPClient, Xbox::XCurl, Xbox::XSAPI,
+#   Xbox::GameChat2, Xbox::PlayFabCore, Xbox::PlayFabServices,
+#   Xbox::PlayFabMultiplayer, Xbox::PlayFabParty, Xbox::PlayFabPartyLIVE,
+#   Xbox::PlayFabGameSave
 
-# Validate that a vcpkg toolchain file is wired into the build. Fail with a
-# targeted message if VCPKG_ROOT was unset (the preset would expand to an
-# invalid path that still ends in vcpkg.cmake) or if the toolchain file
-# doesn't exist on disk.
+set(GDK_DEPENDENCY_SOURCE "auto" CACHE STRING
+    "Source for the Microsoft GDK dependency. One of: auto, vcpkg, installed. \
+Defaults to `auto`: uses an installed GDK if one is discoverable (via \
+`-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`), otherwise falls back \
+to the pinned `ms-gdk[playfab]` vcpkg port. Force vcpkg with \
+`-DGDK_DEPENDENCY_SOURCE=vcpkg`, or force the installed GDK (failing if \
+none is found) with the `installed-gdk` preset (or \
+`-DGDK_DEPENDENCY_SOURCE=installed`).")
+set_property(CACHE GDK_DEPENDENCY_SOURCE PROPERTY STRINGS auto vcpkg installed)
+
+set(GDK_INSTALL_DIR "" CACHE PATH
+    "Optional path to a Microsoft GDK install. May point at the version root \
+(e.g. `C:/Program Files (x86)/Microsoft GDK/260400/`), its `windows/` subdir, \
+or its `GRDK/` peer (auto-redirected to the sibling `windows/`). Only used \
+when GDK_DEPENDENCY_SOURCE is `installed` or resolves to `installed` via `auto`.")
+
+# Internal cache. Populated by _gdk_resolve_dependency_source().
+set(_GDK_RESOLVED_SOURCE "" CACHE INTERNAL "Resolved GDK source: vcpkg or installed.")
+set(_GDK_RESOLVED_WINDOWS_PATH "" CACHE INTERNAL "Resolved GDK install `windows/` subdir path (installed mode only).")
+set(_GDK_RESOLVED_FOR_INPUT "" CACHE INTERNAL "Input signature the resolution was computed from. Invalidates the resolution when the user changes GDK_DEPENDENCY_SOURCE, GDK_INSTALL_DIR, or the discovery env vars.")
+
+# Validate the vcpkg toolchain wiring. Fails with a targeted message if
+# VCPKG_ROOT was unset (the preset expands to a path that still ends in
+# vcpkg.cmake but doesn't exist) or if the file isn't on disk.
 function(_gdk_assert_vcpkg_toolchain)
     if(NOT DEFINED CMAKE_TOOLCHAIN_FILE OR NOT CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg.cmake$")
         message(FATAL_ERROR
-            "vcpkg toolchain file is required to build the GDK addons.\n"
+            "vcpkg toolchain file is required to satisfy this dependency.\n"
             "Set the VCPKG_ROOT environment variable to a vcpkg checkout (e.g. C:/vcpkg) "
             "and reconfigure using the `default` preset, or pass "
             "-DCMAKE_TOOLCHAIN_FILE=<vcpkg-root>/scripts/buildsystems/vcpkg.cmake explicitly.\n"
@@ -51,52 +107,424 @@ function(_gdk_assert_vcpkg_toolchain)
     endif()
 endfunction()
 
-# Require the `ms-gdk` port (Xbox::*, PlayFab*). Use this for the godot_gdk and
-# godot_playfab addons. Kept separate from gdk_require_gameinput() so selective
-# presets (gameinput-only, gdk-only, playfab-only) only restore what they need.
-function(gdk_require_ms_gdk)
-    _gdk_assert_vcpkg_toolchain()
-    find_package(ms-gdk CONFIG REQUIRED)
+# Normalize a user-supplied or env-derived path into the `windows/` subdir
+# of a Microsoft GDK install. Accepts:
+#   - `<root>\<version>\windows\` (canonical -- passes through)
+#   - `<root>\<version>\`        (with a `windows\` subdir -- joined)
+#   - `<root>\<version>\GRDK\`   (auto-redirects to the sibling `windows\`)
+# Sets `<OUT_VAR>` to the resolved `windows/` path, or empty if the input
+# doesn't look like a usable install. The fingerprint file is
+# `include/XGameRuntime.h`.
+function(_gdk_normalize_install_path INPUT OUT_VAR)
+    if(NOT INPUT)
+        set(${OUT_VAR} "" PARENT_SCOPE)
+        return()
+    endif()
+
+    file(TO_CMAKE_PATH "${INPUT}" _path)
+    string(REGEX REPLACE "/+$" "" _path "${_path}")
+
+    # Form 1: already pointing at the `windows/` subdir.
+    if(EXISTS "${_path}/include/XGameRuntime.h" AND EXISTS "${_path}/lib/x64/xgameruntime.lib")
+        set(${OUT_VAR} "${_path}" PARENT_SCOPE)
+        return()
+    endif()
+
+    # Form 2: pointing at the version root; join `windows`.
+    if(EXISTS "${_path}/windows/include/XGameRuntime.h")
+        set(${OUT_VAR} "${_path}/windows" PARENT_SCOPE)
+        return()
+    endif()
+
+    # Form 3: pointing at the GRDK peer; redirect to `../windows`.
+    get_filename_component(_basename "${_path}" NAME)
+    if(_basename STREQUAL "GRDK")
+        get_filename_component(_parent "${_path}" DIRECTORY)
+        if(EXISTS "${_parent}/windows/include/XGameRuntime.h")
+            set(${OUT_VAR} "${_parent}/windows" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+    set(${OUT_VAR} "" PARENT_SCOPE)
 endfunction()
 
-# Require the `gameinput` port (Microsoft::GameInput). Use this for the
-# godot_gameinput addon, which does not depend on any ms-gdk component.
+# Pick the highest numbered version directory under a `%GameDK%`-style root,
+# returning its `windows/` subdir in `<OUT_VAR>` (or empty string).
+function(_gdk_pick_latest_version GAMEDK_ROOT OUT_VAR)
+    set(${OUT_VAR} "" PARENT_SCOPE)
+    if(NOT GAMEDK_ROOT OR NOT EXISTS "${GAMEDK_ROOT}")
+        return()
+    endif()
+    file(GLOB _version_dirs RELATIVE "${GAMEDK_ROOT}" "${GAMEDK_ROOT}/*")
+    set(_best "")
+    set(_best_num 0)
+    foreach(_dir IN LISTS _version_dirs)
+        if(_dir MATCHES "^[0-9]+$")
+            # Numeric compare so e.g. "260400" sorts above "99999". STRGREATER
+            # is lexicographic and would mis-order versions that differ in
+            # digit count.
+            math(EXPR _dir_num "${_dir}")
+            if(_dir_num GREATER _best_num)
+                set(_best "${_dir}")
+                set(_best_num ${_dir_num})
+            endif()
+        endif()
+    endforeach()
+    if(_best AND EXISTS "${GAMEDK_ROOT}/${_best}/windows/include/XGameRuntime.h")
+        set(${OUT_VAR} "${GAMEDK_ROOT}/${_best}/windows" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Discover a GDK install `windows/` path from explicit override, then env
+# vars, in preference order. Returns empty string if none found.
+function(_gdk_discover_install_path OUT_VAR)
+    set(${OUT_VAR} "" PARENT_SCOPE)
+
+    # 1. Explicit override.
+    if(GDK_INSTALL_DIR)
+        _gdk_normalize_install_path("${GDK_INSTALL_DIR}" _normalized)
+        if(_normalized)
+            set(${OUT_VAR} "${_normalized}" PARENT_SCOPE)
+            return()
+        else()
+            message(FATAL_ERROR
+                "GDK_INSTALL_DIR='${GDK_INSTALL_DIR}' does not look like a GDK install with "
+                "the modern `windows/` layout.\n"
+                "Expected a path to the version root (e.g. C:/Program Files (x86)/Microsoft GDK/260400/), "
+                "its `windows/` subdir, or its `GRDK/` peer. The resolved `windows/` directory must "
+                "contain `include/XGameRuntime.h`. GDK versions older than 260400 / April 2026 do not "
+                "ship this layout -- use -DGDK_DEPENDENCY_SOURCE=vcpkg instead.")
+        endif()
+    endif()
+
+    # 2. %GRDKLatest% (points at <root>/<version>/GRDK; redirected to ../windows).
+    if(DEFINED ENV{GRDKLatest})
+        _gdk_normalize_install_path("$ENV{GRDKLatest}" _normalized)
+        if(_normalized)
+            set(${OUT_VAR} "${_normalized}" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+
+    # 3. %GameDK% (root with version subdirs; pick the highest).
+    #    Note: %GameDKLatest% is NOT used. On some installs it pins to an
+    #    older version even when a newer one is also installed; the version
+    #    sort under %GameDK% is more reliable.
+    if(DEFINED ENV{GameDK})
+        file(TO_CMAKE_PATH "$ENV{GameDK}" _gamedk)
+        _gdk_pick_latest_version("${_gamedk}" _win)
+        if(_win)
+            set(${OUT_VAR} "${_win}" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+endfunction()
+
+# Decide between vcpkg and installed sources. Honors an explicit
+# GDK_DEPENDENCY_SOURCE if set; otherwise auto-detects. Caches the resolved
+# value (and the discovered `windows/` path, if installed) for the duration
+# of the CMake project. Idempotent -- safe to call from each addon.
+#
+# Re-resolves whenever GDK_DEPENDENCY_SOURCE, GDK_INSTALL_DIR, or the env
+# vars used for discovery change across reconfigures (tracked via
+# _GDK_RESOLVED_FOR_INPUT). Without this, switching presets in the same
+# build dir would silently keep the prior resolution.
+function(_gdk_resolve_dependency_source)
+    set(_input_signature "${GDK_DEPENDENCY_SOURCE}|${GDK_INSTALL_DIR}|$ENV{GRDKLatest}|$ENV{GameDK}")
+    if(_GDK_RESOLVED_SOURCE AND _GDK_RESOLVED_FOR_INPUT STREQUAL "${_input_signature}")
+        return()
+    endif()
+
+    if(NOT GDK_DEPENDENCY_SOURCE MATCHES "^(auto|vcpkg|installed)$")
+        message(FATAL_ERROR
+            "Invalid GDK_DEPENDENCY_SOURCE='${GDK_DEPENDENCY_SOURCE}'. "
+            "Allowed values: auto, vcpkg, installed.")
+    endif()
+
+    set(_source "${GDK_DEPENDENCY_SOURCE}")
+
+    if(_source STREQUAL "auto")
+        _gdk_discover_install_path(_win)
+        if(_win)
+            set(_source "installed")
+            set(_GDK_RESOLVED_WINDOWS_PATH "${_win}" CACHE INTERNAL "" FORCE)
+            message(STATUS "GDK dependency source: installed (auto-detected at ${_win}). "
+                           "Override with -DGDK_DEPENDENCY_SOURCE=vcpkg to force vcpkg.")
+        else()
+            set(_source "vcpkg")
+            set(_GDK_RESOLVED_WINDOWS_PATH "" CACHE INTERNAL "" FORCE)
+            message(STATUS "GDK dependency source: vcpkg (auto-detected; no GDK install found). "
+                           "Set %GRDKLatest%/%GameDK% or -DGDK_INSTALL_DIR=<path> to use an installed GDK.")
+        endif()
+    elseif(_source STREQUAL "installed")
+        _gdk_discover_install_path(_win)
+        if(NOT _win)
+            message(FATAL_ERROR
+                "GDK_DEPENDENCY_SOURCE=installed was requested but no GDK install was found.\n"
+                "Pass -DGDK_INSTALL_DIR=<path> explicitly, or set the GRDKLatest / GameDK environment "
+                "variable to point at a Microsoft GDK install. The resolved `windows/` directory must "
+                "contain `include/XGameRuntime.h` (260400 / April 2026 or later).")
+        endif()
+        set(_GDK_RESOLVED_WINDOWS_PATH "${_win}" CACHE INTERNAL "" FORCE)
+        message(STATUS "GDK dependency source: installed (${_win})")
+    else() # vcpkg
+        set(_GDK_RESOLVED_WINDOWS_PATH "" CACHE INTERNAL "" FORCE)
+        message(STATUS "GDK dependency source: vcpkg (explicit)")
+    endif()
+
+    set(_GDK_RESOLVED_SOURCE "${_source}" CACHE INTERNAL "" FORCE)
+    set(_GDK_RESOLVED_FOR_INPUT "${_input_signature}" CACHE INTERNAL "" FORCE)
+endfunction()
+
+# Define the Xbox::* + Xbox::PlayFab* imported targets pointing at an
+# installed GDK's `windows/` subdir. The target shape (names, STATIC vs
+# SHARED, transitive link relationships, MAP_IMPORTED_CONFIG_* properties)
+# mirrors the vcpkg `ms-gdk` port's exported config so addon CMakeLists
+# are agnostic.
+#
+# The `windows/` subdir lays out libs flat under `lib/x64/`, DLLs under
+# `bin/x64/`, and headers under `include/`. PlayFab headers are nested at
+# `include/playfab/{core,services,multiplayer,party,gamesave}/`, matching
+# the vcpkg port's layout -- no header shimming is required.
+#
+# Idempotent -- guarded by Xbox::GameRuntime existence.
+function(_gdk_define_installed_targets WIN_ROOT)
+    if(TARGET Xbox::GameRuntime)
+        return()
+    endif()
+
+    set(_inc "${WIN_ROOT}/include")
+    set(_lib "${WIN_ROOT}/lib/x64")
+    set(_bin "${WIN_ROOT}/bin/x64")
+
+    # Sanity check: every consumer expects these specific paths to exist.
+    # Fail loudly here with the actual missing file rather than letting the
+    # downstream linker complain about LNK1181 on a generated lib path.
+    #
+    # Core files are always required (godot_gdk and godot_gameinput both
+    # depend on this surface). PlayFab files are only required when
+    # BUILD_GODOT_PLAYFAB is ON.
+    set(_required_files
+        "${_inc}/XGameRuntime.h"
+        "${_lib}/xgameruntime.lib"
+        "${_lib}/Microsoft.Xbox.Services.143.C.lib"
+        "${_lib}/Microsoft.Xbox.Services.143.C.Debug.lib"
+        "${_lib}/Microsoft.Xbox.Services.C.Thunks.lib"
+        "${_bin}/Microsoft.Xbox.Services.C.Thunks.dll"
+        "${_bin}/Microsoft.Xbox.Services.C.Thunks.Debug.dll"
+        "${_lib}/libHttpClient.lib"
+        "${_bin}/libHttpClient.dll"
+        "${_lib}/XCurl.lib"
+        "${_bin}/XCurl.dll"
+        "${_lib}/GameChat2.lib"
+        "${_bin}/GameChat2.dll")
+    if(BUILD_GODOT_PLAYFAB)
+        list(APPEND _required_files
+            "${_lib}/PlayFabCore.lib"
+            "${_bin}/PlayFabCore.dll"
+            "${_lib}/PlayFabServices.lib"
+            "${_bin}/PlayFabServices.dll"
+            "${_lib}/PlayFabGameSave.lib"
+            "${_bin}/PlayFabGameSave.dll"
+            "${_lib}/PlayFabMultiplayer.lib"
+            "${_bin}/PlayFabMultiplayer.dll"
+            "${_inc}/playfab/multiplayer/PFMultiplayer.h"
+            "${_inc}/playfab/multiplayer/PFLobby.h"
+            "${_inc}/playfab/multiplayer/PFMatchmaking.h"
+            "${_inc}/playfab/multiplayer/PFEntityKey.h"
+            "${_lib}/Party.lib"
+            "${_bin}/Party.dll"
+            "${_inc}/playfab/party/Party.h"
+            "${_inc}/playfab/party/PartyImpl.h"
+            "${_inc}/playfab/party/PartyTypes.h"
+            "${_lib}/PartyXboxLive.lib"
+            "${_bin}/PartyXboxLive.dll")
+    endif()
+    foreach(_f IN LISTS _required_files)
+        if(NOT EXISTS "${_f}")
+            message(FATAL_ERROR
+                "Installed GDK at ${WIN_ROOT} is missing required file:\n  ${_f}\n"
+                "This usually means the install is incomplete or this GDK version pre-dates the "
+                "`windows/` layout this addon expects (260400 / April 2026 or later). Reinstall the "
+                "full GDK from https://github.com/microsoft/GDK or switch to the vcpkg source with "
+                "-DGDK_DEPENDENCY_SOURCE=vcpkg.")
+        endif()
+    endforeach()
+
+    # Xbox::GameRuntime (STATIC)
+    add_library(Xbox::GameRuntime STATIC IMPORTED)
+    set_target_properties(Xbox::GameRuntime PROPERTIES
+        IMPORTED_LOCATION "${_lib}/xgameruntime.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_inc}"
+        INTERFACE_COMPILE_FEATURES "cxx_std_11"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+    # Xbox::XCurl (SHARED)
+    add_library(Xbox::XCurl SHARED IMPORTED)
+    set_target_properties(Xbox::XCurl PROPERTIES
+        IMPORTED_LOCATION "${_bin}/XCurl.dll"
+        IMPORTED_IMPLIB "${_lib}/XCurl.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+
+    # Xbox::HTTPClient (SHARED)
+    add_library(Xbox::HTTPClient SHARED IMPORTED)
+    set_target_properties(Xbox::HTTPClient PROPERTIES
+        IMPORTED_LOCATION "${_bin}/libHttpClient.dll"
+        IMPORTED_IMPLIB "${_lib}/libHttpClient.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+
+    # Xbox::XSAPI (STATIC, VS2022/v143)
+    #
+    # The installed GDK ships both Debug and Release variants under
+    # lib/x64/. CMAKE_MAP_IMPORTED_CONFIG_DEBUG=Release (set globally by
+    # the default preset and inherited by installed-gdk) maps the Debug
+    # addon build to the Release lib here, matching the vcpkg ms-gdk
+    # port's behavior.
+    add_library(Xbox::XSAPI STATIC IMPORTED)
+    set_target_properties(Xbox::XSAPI PROPERTIES
+        IMPORTED_LOCATION "${_lib}/Microsoft.Xbox.Services.143.C.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_inc}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+    target_link_libraries(Xbox::XSAPI INTERFACE
+        Xbox::HTTPClient Xbox::XCurl appnotify.lib winhttp.lib crypt32.lib)
+
+    # Xbox::GameChat2 (SHARED)
+    add_library(Xbox::GameChat2 SHARED IMPORTED)
+    set_target_properties(Xbox::GameChat2 PROPERTIES
+        IMPORTED_LOCATION "${_bin}/GameChat2.dll"
+        IMPORTED_IMPLIB "${_lib}/GameChat2.lib"
+        MAP_IMPORTED_CONFIG_MINSIZEREL ""
+        MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+        INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+
+    if(BUILD_GODOT_PLAYFAB)
+        # Xbox::PlayFabCore (SHARED)
+        add_library(Xbox::PlayFabCore SHARED IMPORTED)
+        set_target_properties(Xbox::PlayFabCore PROPERTIES
+            IMPORTED_LOCATION "${_bin}/PlayFabCore.dll"
+            IMPORTED_IMPLIB "${_lib}/PlayFabCore.lib"
+            MAP_IMPORTED_CONFIG_MINSIZEREL ""
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+            INTERFACE_INCLUDE_DIRECTORIES "${_inc}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+        # Xbox::PlayFabServices (SHARED, links PlayFabCore + XCurl)
+        add_library(Xbox::PlayFabServices SHARED IMPORTED)
+        set_target_properties(Xbox::PlayFabServices PROPERTIES
+            IMPORTED_LOCATION "${_bin}/PlayFabServices.dll"
+            IMPORTED_IMPLIB "${_lib}/PlayFabServices.lib"
+            IMPORTED_LINK_DEPENDENT_LIBRARIES Xbox::XCurl
+            MAP_IMPORTED_CONFIG_MINSIZEREL ""
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+            INTERFACE_INCLUDE_DIRECTORIES "${_inc}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+        target_link_libraries(Xbox::PlayFabServices INTERFACE Xbox::PlayFabCore Xbox::XCurl)
+
+        # Xbox::PlayFabGameSave (SHARED)
+        add_library(Xbox::PlayFabGameSave SHARED IMPORTED)
+        set_target_properties(Xbox::PlayFabGameSave PROPERTIES
+            IMPORTED_LOCATION "${_bin}/PlayFabGameSave.dll"
+            IMPORTED_IMPLIB "${_lib}/PlayFabGameSave.lib"
+            MAP_IMPORTED_CONFIG_MINSIZEREL ""
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+            INTERFACE_INCLUDE_DIRECTORIES "${_inc}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
+
+        # Xbox::PlayFabMultiplayer (SHARED, links XCurl)
+        add_library(Xbox::PlayFabMultiplayer SHARED IMPORTED)
+        set_target_properties(Xbox::PlayFabMultiplayer PROPERTIES
+            IMPORTED_LOCATION "${_bin}/PlayFabMultiplayer.dll"
+            IMPORTED_IMPLIB "${_lib}/PlayFabMultiplayer.lib"
+            IMPORTED_LINK_DEPENDENT_LIBRARIES Xbox::XCurl
+            MAP_IMPORTED_CONFIG_MINSIZEREL ""
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+            INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+        target_link_libraries(Xbox::PlayFabMultiplayer INTERFACE Xbox::XCurl)
+
+        # Xbox::PlayFabParty (SHARED)
+        add_library(Xbox::PlayFabParty SHARED IMPORTED)
+        set_target_properties(Xbox::PlayFabParty PROPERTIES
+            IMPORTED_LOCATION "${_bin}/Party.dll"
+            IMPORTED_IMPLIB "${_lib}/Party.lib"
+            MAP_IMPORTED_CONFIG_MINSIZEREL ""
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+            INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+
+        # Xbox::PlayFabPartyLIVE (SHARED, links PlayFabParty)
+        add_library(Xbox::PlayFabPartyLIVE SHARED IMPORTED)
+        set_target_properties(Xbox::PlayFabPartyLIVE PROPERTIES
+            IMPORTED_LOCATION "${_bin}/PartyXboxLive.dll"
+            IMPORTED_IMPLIB "${_lib}/PartyXboxLive.lib"
+            IMPORTED_LINK_DEPENDENT_LIBRARIES Xbox::PlayFabParty
+            MAP_IMPORTED_CONFIG_MINSIZEREL ""
+            MAP_IMPORTED_CONFIG_RELWITHDEBINFO ""
+            INTERFACE_INCLUDE_DIRECTORIES "${_inc}")
+        target_link_libraries(Xbox::PlayFabPartyLIVE INTERFACE Xbox::PlayFabParty)
+    endif()
+endfunction()
+
+# Require the GDK (Xbox::* + Xbox::PlayFab* targets). Dispatches on the
+# resolved source -- vcpkg's ms-gdk port or an installed GDK on disk.
+# Idempotent.
+function(gdk_require_ms_gdk)
+    _gdk_resolve_dependency_source()
+    if(_GDK_RESOLVED_SOURCE STREQUAL "vcpkg")
+        _gdk_assert_vcpkg_toolchain()
+        find_package(ms-gdk CONFIG REQUIRED)
+    else() # installed
+        _gdk_define_installed_targets("${_GDK_RESOLVED_WINDOWS_PATH}")
+    endif()
+endfunction()
+
+# Require GameInput (Microsoft::GameInput). Always vcpkg-backed -- the
+# installed GDK ships GameInput v1 only, and this repo targets v3 (a
+# separate Microsoft SDK release that the vcpkg `gameinput` port wraps).
+# The `installed-gdk` preset disables the godot_gameinput addon by
+# default so this is not called in pure-installed-GDK builds.
 function(gdk_require_gameinput)
     _gdk_assert_vcpkg_toolchain()
     find_package(gameinput CONFIG REQUIRED)
 endfunction()
 
-# Paths inside the vcpkg install tree for the XSAPI Thunks DLLs which are NOT
-# exposed as proper imported targets. vcpkg lays these out as bin/<file>.dll
-# for Release and debug/bin/<file>.Debug.dll for Debug.
-#
-# IMPORTANT: we deploy BOTH variants in BOTH configs (not one per config),
-# for two independent reasons:
-#
-#   1. With CMAKE_MAP_IMPORTED_CONFIG_DEBUG=Release the Debug addon links
-#      against Release Xbox::XSAPI .lib import entries (which reference
-#      `Microsoft.Xbox.Services.C.Thunks.dll`). A Debug-only deploy that
-#      ships only the `.Debug.dll` variant breaks addon loading on a clean
-#      machine without GDK on PATH.
-#   2. Empirically, dropping the `.Debug.dll` variant for Debug addon
-#      builds causes a deterministic signal-11 shutdown crash in xsapi
-#      teardown — XSAPI internals probe for the matching Debug Thunks DLL
-#      at runtime even though it isn't a static import.
-#
-# Shipping both is the only configuration that satisfies both constraints,
-# and the ~4.6 MiB extra in Release builds is an acceptable tradeoff for
-# self-contained loading on machines without a GDK install.
+# Absolute paths to the XSAPI Thunks DLLs that must be deployed alongside
+# the addon binaries. The Thunks DLLs are the XSAPI runtime bridge and
+# are not exposed as proper imported targets in either source.
 #
 # Usage:
 #   gdk_xsapi_thunks_dlls(OUT_VAR)
 #
-# Returns a CMake list of two absolute paths.
+# Returns TWO paths in both modes -- the Release
+# `Microsoft.Xbox.Services.C.Thunks.dll` and the renamed Debug
+# `Microsoft.Xbox.Services.C.Thunks.Debug.dll`. Both ship in every config
+# because (a) CMAKE_MAP_IMPORTED_CONFIG_DEBUG=Release means the Debug
+# addon links Release `.lib` import entries which reference
+# `Microsoft.Xbox.Services.C.Thunks.dll`, and (b) XSAPI internals probe
+# for a `.Debug.dll` variant at runtime in Debug builds even though it
+# isn't a static import. Shipping both prevents a deterministic SIGSEGV
+# in xsapi teardown.
 function(gdk_xsapi_thunks_dlls OUT_VAR)
-    if(NOT DEFINED VCPKG_INSTALLED_DIR)
-        message(FATAL_ERROR "VCPKG_INSTALLED_DIR is not set; call gdk_require_ms_gdk() first.")
+    _gdk_resolve_dependency_source()
+    if(_GDK_RESOLVED_SOURCE STREQUAL "vcpkg")
+        if(NOT DEFINED VCPKG_INSTALLED_DIR)
+            message(FATAL_ERROR "VCPKG_INSTALLED_DIR is not set; call gdk_require_ms_gdk() first.")
+        endif()
+        set(${OUT_VAR}
+            "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/Microsoft.Xbox.Services.C.Thunks.dll"
+            "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin/Microsoft.Xbox.Services.C.Thunks.Debug.dll"
+            PARENT_SCOPE)
+    else() # installed
+        set(${OUT_VAR}
+            "${_GDK_RESOLVED_WINDOWS_PATH}/bin/x64/Microsoft.Xbox.Services.C.Thunks.dll"
+            "${_GDK_RESOLVED_WINDOWS_PATH}/bin/x64/Microsoft.Xbox.Services.C.Thunks.Debug.dll"
+            PARENT_SCOPE)
     endif()
-    set(${OUT_VAR}
-        "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/Microsoft.Xbox.Services.C.Thunks.dll"
-        "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin/Microsoft.Xbox.Services.C.Thunks.Debug.dll"
-        PARENT_SCOPE)
 endfunction()

--- a/cmake/GDKDependencies.cmake
+++ b/cmake/GDKDependencies.cmake
@@ -254,15 +254,16 @@ function(_gdk_discover_install_path OUT_VAR)
     endif()
 endfunction()
 
-# Decide between vcpkg and installed sources. Honors an explicit
-# GDK_DEPENDENCY_SOURCE if set; otherwise auto-detects. Caches the resolved
-# value (and the discovered `windows/` path, if installed) for the duration
-# of the CMake project. Idempotent -- safe to call from each addon.
+# Validate GDK_DEPENDENCY_SOURCE and, when set to `installed`, discover
+# and cache the resolved `windows/` directory. There is no auto-detection
+# fallback: `vcpkg` is the default, and `installed` must be selected
+# explicitly (normally by the `installed-gdk` preset). Idempotent -- safe
+# to call from each addon.
 #
 # Re-resolves whenever GDK_DEPENDENCY_SOURCE, GDK_INSTALL_DIR, or the env
-# vars used for discovery change across reconfigures (tracked via
-# _GDK_RESOLVED_FOR_INPUT). Without this, switching presets in the same
-# build dir would silently keep the prior resolution.
+# vars used for installed-GDK discovery change across reconfigures
+# (tracked via _GDK_RESOLVED_FOR_INPUT). Without this, switching presets
+# in the same build dir would silently keep the prior resolution.
 function(_gdk_resolve_dependency_source)
     set(_input_signature "${GDK_DEPENDENCY_SOURCE}|${GDK_INSTALL_DIR}|$ENV{GRDKLatest}|$ENV{GameDK}")
     if(_GDK_RESOLVED_SOURCE AND _GDK_RESOLVED_FOR_INPUT STREQUAL "${_input_signature}")

--- a/cmake/GDKDependencies.cmake
+++ b/cmake/GDKDependencies.cmake
@@ -22,8 +22,9 @@ include_guard(GLOBAL)
 #     260400 / April 2026 and later ship. The legacy `GRDK\` peer layout
 #     (`ExtensionLibraries\*\Lib\x64\...`, per-library flat `Include\`)
 #     is **not** supported. Use the vcpkg source for older GDK versions.
-#     Selected by the `installed-gdk` preset, which also disables vcpkg
-#     manifest restore (no `ms-gdk[playfab]` round-trip).
+#     Selected by the `installed-gdk` preset, which does *not* load the
+#     vcpkg toolchain at all -- a vcpkg checkout (or `VCPKG_ROOT`) is not
+#     required when building in installed mode.
 #
 # Source selection is controlled by the `GDK_DEPENDENCY_SOURCE` cache
 # variable, with values:
@@ -31,21 +32,19 @@ include_guard(GLOBAL)
 #   - `vcpkg` (default): use the pinned `ms-gdk[playfab]` vcpkg port.
 #     Errors if no toolchain file is set.
 #   - `installed`: use a discovered GDK install. Errors if none is found.
-#     Set by the `installed-gdk` preset, which pairs it with
-#     `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON` so vcpkg does not also
-#     restore `ms-gdk[playfab]`. The default preset cannot be retargeted
-#     to installed via `-DGDK_DEPENDENCY_SOURCE=installed` alone because
-#     the vcpkg toolchain processes manifest features before this module
-#     runs -- always go through the `installed-gdk` preset.
+#     Set by the `installed-gdk` preset, which also drops the vcpkg
+#     toolchain so the build needs no vcpkg checkout. The default preset
+#     cannot be retargeted to installed via `-DGDK_DEPENDENCY_SOURCE=installed`
+#     alone because the vcpkg toolchain processes manifest features
+#     before this module runs -- always go through the `installed-gdk`
+#     preset.
 #
 # GameInput v3 is provided by the vcpkg `gameinput` port. The installed
 # GDK ships GameInput v1 only -- v3 is a separate Microsoft SDK release
 # that lives outside the main GDK bundle. The `installed-gdk` preset
 # therefore disables the `godot_gameinput` addon by default
 # (`BUILD_GODOT_GAMEINPUT=OFF`); developers who want controller support
-# can either use the default preset (which restores `gameinput` from
-# vcpkg) or explicitly opt in with `-DBUILD_GODOT_GAMEINPUT=ON
-# -DVCPKG_MANIFEST_FEATURES=godot-gameinput`.
+# should use the default preset (which restores `gameinput` from vcpkg).
 #
 # An explicit GDK install path can also be supplied as `-DGDK_INSTALL_DIR=<path>`.
 # The path may point at the version root (e.g. `...\260400\`), its
@@ -70,8 +69,8 @@ set(GDK_DEPENDENCY_SOURCE "vcpkg" CACHE STRING
     "Source for the Microsoft GDK dependency. One of: vcpkg, installed. \
 Defaults to `vcpkg`: the pinned `ms-gdk[playfab]` vcpkg port. To consume \
 an installed Microsoft GDK on disk instead, use the `installed-gdk` \
-preset (it sets `GDK_DEPENDENCY_SOURCE=installed` *and* disables vcpkg \
-manifest restore -- both are required). Setting `installed` on the \
+preset (it sets `GDK_DEPENDENCY_SOURCE=installed` *and* drops the vcpkg \
+toolchain so no `VCPKG_ROOT` is required). Setting `installed` on the \
 default preset will not work: the vcpkg toolchain processes manifest \
 features before this module runs.")
 set_property(CACHE GDK_DEPENDENCY_SOURCE PROPERTY STRINGS vcpkg installed)

--- a/cmake/GDKDependencies.cmake
+++ b/cmake/GDKDependencies.cmake
@@ -12,7 +12,8 @@ include_guard(GLOBAL)
 # The `ms-gdk` dependency can be satisfied from either of two sources:
 #
 #   - **vcpkg** (default): the `ms-gdk[playfab]` port. Requires only a
-#     vcpkg checkout (no machine-wide GDK install). This is what CI uses.
+#     vcpkg checkout (no machine-wide GDK install). This is what CI uses
+#     and what the `default` preset gives you.
 #
 #   - **installed GDK**: a developer's Microsoft GDK install on disk,
 #     typically at `C:\Program Files (x86)\Microsoft GDK\<version>\`.
@@ -21,6 +22,21 @@ include_guard(GLOBAL)
 #     260400 / April 2026 and later ship. The legacy `GRDK\` peer layout
 #     (`ExtensionLibraries\*\Lib\x64\...`, per-library flat `Include\`)
 #     is **not** supported. Use the vcpkg source for older GDK versions.
+#     Selected by the `installed-gdk` preset, which also disables vcpkg
+#     manifest restore (no `ms-gdk[playfab]` round-trip).
+#
+# Source selection is controlled by the `GDK_DEPENDENCY_SOURCE` cache
+# variable, with values:
+#
+#   - `vcpkg` (default): use the pinned `ms-gdk[playfab]` vcpkg port.
+#     Errors if no toolchain file is set.
+#   - `installed`: use a discovered GDK install. Errors if none is found.
+#     Set by the `installed-gdk` preset, which pairs it with
+#     `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON` so vcpkg does not also
+#     restore `ms-gdk[playfab]`. The default preset cannot be retargeted
+#     to installed via `-DGDK_DEPENDENCY_SOURCE=installed` alone because
+#     the vcpkg toolchain processes manifest features before this module
+#     runs -- always go through the `installed-gdk` preset.
 #
 # GameInput v3 is provided by the vcpkg `gameinput` port. The installed
 # GDK ships GameInput v1 only -- v3 is a separate Microsoft SDK release
@@ -30,20 +46,6 @@ include_guard(GLOBAL)
 # can either use the default preset (which restores `gameinput` from
 # vcpkg) or explicitly opt in with `-DBUILD_GODOT_GAMEINPUT=ON
 # -DVCPKG_MANIFEST_FEATURES=godot-gameinput`.
-#
-# Source selection is controlled by the `GDK_DEPENDENCY_SOURCE` cache
-# variable, with values:
-#
-#   - `auto` (default): prefers an installed GDK when one is discoverable
-#     (via `-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`), otherwise
-#     falls back to the vcpkg port. This is the right choice for most
-#     developers, who already have a GDK installed for `makepkg.exe` /
-#     `wdapp.exe`.
-#   - `vcpkg`: force the vcpkg port (skip auto-detection). Useful for CI
-#     and machines where the installed GDK shouldn't be picked up. Errors
-#     if no toolchain file is set.
-#   - `installed`: force a discovered GDK install. Errors if none found.
-#     Set by the `installed-gdk` preset.
 #
 # An explicit GDK install path can also be supplied as `-DGDK_INSTALL_DIR=<path>`.
 # The path may point at the version root (e.g. `...\260400\`), its
@@ -64,21 +66,21 @@ include_guard(GLOBAL)
 #   Xbox::PlayFabMultiplayer, Xbox::PlayFabParty, Xbox::PlayFabPartyLIVE,
 #   Xbox::PlayFabGameSave
 
-set(GDK_DEPENDENCY_SOURCE "auto" CACHE STRING
-    "Source for the Microsoft GDK dependency. One of: auto, vcpkg, installed. \
-Defaults to `auto`: uses an installed GDK if one is discoverable (via \
-`-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`), otherwise falls back \
-to the pinned `ms-gdk[playfab]` vcpkg port. Force vcpkg with \
-`-DGDK_DEPENDENCY_SOURCE=vcpkg`, or force the installed GDK (failing if \
-none is found) with the `installed-gdk` preset (or \
-`-DGDK_DEPENDENCY_SOURCE=installed`).")
-set_property(CACHE GDK_DEPENDENCY_SOURCE PROPERTY STRINGS auto vcpkg installed)
+set(GDK_DEPENDENCY_SOURCE "vcpkg" CACHE STRING
+    "Source for the Microsoft GDK dependency. One of: vcpkg, installed. \
+Defaults to `vcpkg`: the pinned `ms-gdk[playfab]` vcpkg port. To consume \
+an installed Microsoft GDK on disk instead, use the `installed-gdk` \
+preset (it sets `GDK_DEPENDENCY_SOURCE=installed` *and* disables vcpkg \
+manifest restore -- both are required). Setting `installed` on the \
+default preset will not work: the vcpkg toolchain processes manifest \
+features before this module runs.")
+set_property(CACHE GDK_DEPENDENCY_SOURCE PROPERTY STRINGS vcpkg installed)
 
 set(GDK_INSTALL_DIR "" CACHE PATH
     "Optional path to a Microsoft GDK install. May point at the version root \
 (e.g. `C:/Program Files (x86)/Microsoft GDK/260400/`), its `windows/` subdir, \
 or its `GRDK/` peer (auto-redirected to the sibling `windows/`). Only used \
-when GDK_DEPENDENCY_SOURCE is `installed` or resolves to `installed` via `auto`.")
+when GDK_DEPENDENCY_SOURCE is `installed`.")
 
 # Internal cache. Populated by _gdk_resolve_dependency_source().
 set(_GDK_RESOLVED_SOURCE "" CACHE INTERNAL "Resolved GDK source: vcpkg or installed.")
@@ -236,28 +238,15 @@ function(_gdk_resolve_dependency_source)
         return()
     endif()
 
-    if(NOT GDK_DEPENDENCY_SOURCE MATCHES "^(auto|vcpkg|installed)$")
+    if(NOT GDK_DEPENDENCY_SOURCE MATCHES "^(vcpkg|installed)$")
         message(FATAL_ERROR
             "Invalid GDK_DEPENDENCY_SOURCE='${GDK_DEPENDENCY_SOURCE}'. "
-            "Allowed values: auto, vcpkg, installed.")
+            "Allowed values: vcpkg, installed.")
     endif()
 
     set(_source "${GDK_DEPENDENCY_SOURCE}")
 
-    if(_source STREQUAL "auto")
-        _gdk_discover_install_path(_win)
-        if(_win)
-            set(_source "installed")
-            set(_GDK_RESOLVED_WINDOWS_PATH "${_win}" CACHE INTERNAL "" FORCE)
-            message(STATUS "GDK dependency source: installed (auto-detected at ${_win}). "
-                           "Override with -DGDK_DEPENDENCY_SOURCE=vcpkg to force vcpkg.")
-        else()
-            set(_source "vcpkg")
-            set(_GDK_RESOLVED_WINDOWS_PATH "" CACHE INTERNAL "" FORCE)
-            message(STATUS "GDK dependency source: vcpkg (auto-detected; no GDK install found). "
-                           "Set %GRDKLatest%/%GameDK% or -DGDK_INSTALL_DIR=<path> to use an installed GDK.")
-        endif()
-    elseif(_source STREQUAL "installed")
+    if(_source STREQUAL "installed")
         _gdk_discover_install_path(_win)
         if(NOT _win)
             message(FATAL_ERROR
@@ -270,7 +259,7 @@ function(_gdk_resolve_dependency_source)
         message(STATUS "GDK dependency source: installed (${_win})")
     else() # vcpkg
         set(_GDK_RESOLVED_WINDOWS_PATH "" CACHE INTERNAL "" FORCE)
-        message(STATUS "GDK dependency source: vcpkg (explicit)")
+        message(STATUS "GDK dependency source: vcpkg (ms-gdk[playfab] port)")
     endif()
 
     set(_GDK_RESOLVED_SOURCE "${_source}" CACHE INTERNAL "" FORCE)

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -105,8 +105,9 @@ native C++ sources
 > still need the full Microsoft GDK installed on their machine — see
 > [Editor tools](editor-tools.md) and [Packaging plugin](../packaging/plugin.md).
 > The same install can also be used as the source of build-time headers
-> and libs in place of vcpkg via the `installed-gdk` preset
-> ([Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency)).
+> and libs in place of vcpkg via the `installed-gdk` preset (which then
+> needs no vcpkg checkout at all) —
+> [Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency).
 
 ## Runtime loading path
 

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -75,9 +75,11 @@ The native addon is built by `addons\godot_gdk\CMakeLists.txt`.
 
 That target currently:
 
-1. resolves the GDK headers and import libs via vcpkg (`ms-gdk[playfab]`
-   port, configured by the repo-root `vcpkg.json` and consumed by the
-   CMake preset's vcpkg toolchain)
+1. resolves the GDK headers and import libs via the shared
+   `cmake/GDKDependencies.cmake` helper, which dispatches to either the
+   `ms-gdk[playfab]` vcpkg port or an installed Microsoft GDK on disk
+   (auto-detected by default — see
+   [Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency))
 2. builds `godot_gdk` as a shared library
 3. links against:
    - `godot::cpp`
@@ -102,6 +104,9 @@ native C++ sources
 > want to **run** `makepkg.exe`, `wdapp.exe`, or the Game Config Editor
 > still need the full Microsoft GDK installed on their machine — see
 > [Editor tools](editor-tools.md) and [Packaging plugin](../packaging/plugin.md).
+> The same install can also be used as the source of build-time headers
+> and libs in place of vcpkg via the `installed-gdk` preset
+> ([Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency)).
 
 ## Runtime loading path
 

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -77,8 +77,8 @@ That target currently:
 
 1. resolves the GDK headers and import libs via the shared
    `cmake/GDKDependencies.cmake` helper, which dispatches to either the
-   `ms-gdk[playfab]` vcpkg port or an installed Microsoft GDK on disk
-   (auto-detected by default — see
+   `ms-gdk[playfab]` vcpkg port (default) or an installed Microsoft GDK
+   on disk (opt-in via the `installed-gdk` preset — see
    [Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency))
 2. builds `godot_gdk` as a shared library
 3. links against:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -592,12 +592,16 @@ GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
 later**. The legacy `GRDK\` peer layout is not supported; use the
 `default` preset (vcpkg) for older GDK versions.
 
-**GameInput v3 is a separate SDK from the GDK**, so the `installed-gdk`
-preset disables the `godot_gameinput` addon by default
-(`BUILD_GODOT_GAMEINPUT=OFF`). The installed GDK ships GameInput v1
-only; the addon targets v3. Developers who want controller support
-should use the default preset, which restores the `gameinput` vcpkg
-port (which itself wraps the Microsoft.GameInput NuGet package).
+**GameInput in installed mode** — the installed GDK ships GameInput v1
+only, but the `godot_gameinput` addon targets v3. The `installed-gdk`
+preset solves this by setting `GAMEINPUT_SOURCE=nuget`, which fetches
+the `Microsoft.GameInput` NuGet package directly from nuget.org via
+`file(DOWNLOAD)` (cached under `build/installed-gdk/_deps/`). No vcpkg
+toolchain is involved; the first configure needs network access, and
+subsequent configures reuse the cached extract. This is the same
+upstream archive vcpkg's `gameinput` port wraps, so behavior is
+identical at runtime. Target machines still need `GameInputRedist.msi`
+installed (extracted to `build/installed-gdk/_deps/gameinput-nuget-<version>/redist/`).
 
 Source-selection options:
 
@@ -605,6 +609,11 @@ Source-selection options:
 |---|---|
 | `vcpkg` (default) | Use the `ms-gdk[playfab]` vcpkg port. Set automatically by the `default` preset. Requires `VCPKG_ROOT`. |
 | `installed` | Use a Microsoft GDK install on disk. Set automatically by the `installed-gdk` preset (which also drops the vcpkg toolchain — no `VCPKG_ROOT` required). Setting this alone on the `default` preset has no effect on the vcpkg restore. |
+
+| `GAMEINPUT_SOURCE` | Behavior |
+|---|---|
+| `vcpkg` (default) | Use the `gameinput` vcpkg port. Requires `VCPKG_ROOT`. |
+| `nuget` | Fetch the `Microsoft.GameInput` NuGet package directly from nuget.org (no vcpkg required). Set automatically by the `installed-gdk` preset. The pinned version + SHA512 are tracked in `cmake/GDKDependencies.cmake` (override with `-DGDK_GAMEINPUT_NUGET_VERSION=<version> -DGDK_GAMEINPUT_NUGET_SHA512=<hash>`). |
 
 ### CMake auto-detection
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -559,6 +559,68 @@ cmake --preset gameinput-only
 cmake --build --preset debug-gameinput
 ```
 
+### Source for the GDK dependency
+
+By default, the build prefers a Microsoft GDK install on disk when one is
+discoverable (via `-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`),
+and falls back to the `ms-gdk[playfab]` vcpkg port when none is found.
+Most developers already have a GDK installed (for `makepkg.exe` /
+`wdapp.exe`), so this picks up the install you already have.
+
+To force the installed GDK (and error out if none is found), use the
+`installed-gdk` preset:
+
+```powershell
+# Use an installed Microsoft GDK (auto-detected via %GRDKLatest% or %GameDK%)
+cmake --preset installed-gdk
+cmake --build --preset debug-installed-gdk
+
+# Override auto-detection with an explicit path
+cmake --preset installed-gdk -DGDK_INSTALL_DIR="C:/Program Files (x86)/Microsoft GDK/260400"
+```
+
+To force the vcpkg port (skipping auto-detection -- useful for CI or
+machines where the installed GDK shouldn't be picked up):
+
+```powershell
+cmake --preset default -DGDK_DEPENDENCY_SOURCE=vcpkg
+cmake --build build --preset debug
+```
+
+Installed mode consumes the modern `windows\` subdirectory layout of the
+GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
+`<install>/windows/bin/x64`) that ships in GDK **260400 / April 2026 and
+later**. The legacy `GRDK\` peer layout is not supported; use
+`-DGDK_DEPENDENCY_SOURCE=vcpkg` for older GDK versions.
+
+Either source path requires vcpkg (`VCPKG_ROOT` set) for the CMake
+toolchain file, even when no ports are restored. The default preset
+restores `ms-gdk[playfab]` and `gameinput` as needed; the `installed-gdk`
+preset restores nothing (the toolchain is loaded but is a no-op for
+dependency restore).
+
+**GameInput v3 is a separate SDK from the GDK**, so the `installed-gdk`
+preset disables the `godot_gameinput` addon by default
+(`BUILD_GODOT_GAMEINPUT=OFF`). Developers who want controller support
+have two options:
+
+* Use the default preset (which restores `gameinput` from vcpkg when
+  the GameInput addon is enabled).
+* Explicitly opt in from installed mode:
+
+  ```powershell
+  cmake --preset installed-gdk -DBUILD_GODOT_GAMEINPUT=ON -DVCPKG_MANIFEST_FEATURES=godot-gameinput
+  cmake --build --preset debug-installed-gdk
+  ```
+
+Source-selection options:
+
+| `GDK_DEPENDENCY_SOURCE` | Behavior |
+|---|---|
+| `auto` (default) | Prefer the installed GDK if discoverable via `-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`; fall back to vcpkg otherwise. |
+| `vcpkg` | Always use the `ms-gdk[playfab]` vcpkg port (skip auto-detection). |
+| `installed` | Always use a Microsoft GDK install on disk; error out if none is found. Set by the `installed-gdk` preset. |
+
 ### CMake auto-detection
 
 The build resolves its native dependencies via vcpkg manifest mode. CMake

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -561,17 +561,17 @@ cmake --build --preset debug-gameinput
 
 ### Source for the GDK dependency
 
-By default, the build prefers a Microsoft GDK install on disk when one is
-discoverable (via `-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`),
-and falls back to the `ms-gdk[playfab]` vcpkg port when none is found.
-Most developers already have a GDK installed (for `makepkg.exe` /
-`wdapp.exe`), so this picks up the install you already have.
+By default, the build resolves the GDK headers and import libs through
+the `ms-gdk[playfab]` vcpkg port (`default` preset). This requires only
+a vcpkg checkout — no machine-wide GDK install is needed at build time.
 
-To force the installed GDK (and error out if none is found), use the
-`installed-gdk` preset:
+If you already have a Microsoft GDK installed on disk (most developers
+do, for `makepkg.exe` / `wdapp.exe` / Game Config Editor), the
+`installed-gdk` preset consumes it directly and skips the vcpkg restore
+entirely:
 
 ```powershell
-# Use an installed Microsoft GDK (auto-detected via %GRDKLatest% or %GameDK%)
+# Consume an installed Microsoft GDK (auto-detected via %GRDKLatest% or %GameDK%)
 cmake --preset installed-gdk
 cmake --build --preset debug-installed-gdk
 
@@ -579,25 +579,23 @@ cmake --build --preset debug-installed-gdk
 cmake --preset installed-gdk -DGDK_INSTALL_DIR="C:/Program Files (x86)/Microsoft GDK/260400"
 ```
 
-To force the vcpkg port (skipping auto-detection -- useful for CI or
-machines where the installed GDK shouldn't be picked up):
-
-```powershell
-cmake --preset default -DGDK_DEPENDENCY_SOURCE=vcpkg
-cmake --build build --preset debug
-```
+> **Note:** the `installed-gdk` preset is the only supported way to
+> consume an installed GDK. Setting `-DGDK_DEPENDENCY_SOURCE=installed`
+> on the `default` preset does **not** work — the vcpkg toolchain
+> processes manifest features (and restores `ms-gdk[playfab]`) before
+> the GDK source-selection logic runs. The `installed-gdk` preset pairs
+> the source switch with `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON` so
+> vcpkg restores nothing.
 
 Installed mode consumes the modern `windows\` subdirectory layout of the
 GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
 `<install>/windows/bin/x64`) that ships in GDK **260400 / April 2026 and
-later**. The legacy `GRDK\` peer layout is not supported; use
-`-DGDK_DEPENDENCY_SOURCE=vcpkg` for older GDK versions.
+later**. The legacy `GRDK\` peer layout is not supported; use the
+`default` preset (vcpkg) for older GDK versions.
 
-Either source path requires vcpkg (`VCPKG_ROOT` set) for the CMake
-toolchain file, even when no ports are restored. The default preset
-restores `ms-gdk[playfab]` and `gameinput` as needed; the `installed-gdk`
-preset restores nothing (the toolchain is loaded but is a no-op for
-dependency restore).
+Either preset still requires `VCPKG_ROOT` to be set, because the
+inherited toolchain file is loaded in both cases. The `installed-gdk`
+preset simply restores zero ports.
 
 **GameInput v3 is a separate SDK from the GDK**, so the `installed-gdk`
 preset disables the `godot_gameinput` addon by default
@@ -617,9 +615,8 @@ Source-selection options:
 
 | `GDK_DEPENDENCY_SOURCE` | Behavior |
 |---|---|
-| `auto` (default) | Prefer the installed GDK if discoverable via `-DGDK_INSTALL_DIR=`, `%GRDKLatest%`, or `%GameDK%`; fall back to vcpkg otherwise. |
-| `vcpkg` | Always use the `ms-gdk[playfab]` vcpkg port (skip auto-detection). |
-| `installed` | Always use a Microsoft GDK install on disk; error out if none is found. Set by the `installed-gdk` preset. |
+| `vcpkg` (default) | Use the `ms-gdk[playfab]` vcpkg port. Set automatically by the `default` preset. |
+| `installed` | Use a Microsoft GDK install on disk. Set automatically by the `installed-gdk` preset (which also disables vcpkg manifest restore). Setting this alone on the `default` preset has no effect on the vcpkg restore. |
 
 ### CMake auto-detection
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -567,8 +567,8 @@ a vcpkg checkout — no machine-wide GDK install is needed at build time.
 
 If you already have a Microsoft GDK installed on disk (most developers
 do, for `makepkg.exe` / `wdapp.exe` / Game Config Editor), the
-`installed-gdk` preset consumes it directly and skips the vcpkg restore
-entirely:
+`installed-gdk` preset consumes it directly and **does not require vcpkg
+at all** — no `VCPKG_ROOT`, no vcpkg checkout, no port restore:
 
 ```powershell
 # Consume an installed Microsoft GDK (auto-detected via %GRDKLatest% or %GameDK%)
@@ -583,9 +583,8 @@ cmake --preset installed-gdk -DGDK_INSTALL_DIR="C:/Program Files (x86)/Microsoft
 > consume an installed GDK. Setting `-DGDK_DEPENDENCY_SOURCE=installed`
 > on the `default` preset does **not** work — the vcpkg toolchain
 > processes manifest features (and restores `ms-gdk[playfab]`) before
-> the GDK source-selection logic runs. The `installed-gdk` preset pairs
-> the source switch with `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON` so
-> vcpkg restores nothing.
+> the GDK source-selection logic runs. The `installed-gdk` preset
+> sidesteps this by not loading the vcpkg toolchain at all.
 
 Installed mode consumes the modern `windows\` subdirectory layout of the
 GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
@@ -593,30 +592,19 @@ GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
 later**. The legacy `GRDK\` peer layout is not supported; use the
 `default` preset (vcpkg) for older GDK versions.
 
-Either preset still requires `VCPKG_ROOT` to be set, because the
-inherited toolchain file is loaded in both cases. The `installed-gdk`
-preset simply restores zero ports.
-
 **GameInput v3 is a separate SDK from the GDK**, so the `installed-gdk`
 preset disables the `godot_gameinput` addon by default
-(`BUILD_GODOT_GAMEINPUT=OFF`). Developers who want controller support
-have two options:
-
-* Use the default preset (which restores `gameinput` from vcpkg when
-  the GameInput addon is enabled).
-* Explicitly opt in from installed mode:
-
-  ```powershell
-  cmake --preset installed-gdk -DBUILD_GODOT_GAMEINPUT=ON -DVCPKG_MANIFEST_FEATURES=godot-gameinput
-  cmake --build --preset debug-installed-gdk
-  ```
+(`BUILD_GODOT_GAMEINPUT=OFF`). The installed GDK ships GameInput v1
+only; the addon targets v3. Developers who want controller support
+should use the default preset, which restores the `gameinput` vcpkg
+port (which itself wraps the Microsoft.GameInput NuGet package).
 
 Source-selection options:
 
 | `GDK_DEPENDENCY_SOURCE` | Behavior |
 |---|---|
-| `vcpkg` (default) | Use the `ms-gdk[playfab]` vcpkg port. Set automatically by the `default` preset. |
-| `installed` | Use a Microsoft GDK install on disk. Set automatically by the `installed-gdk` preset (which also disables vcpkg manifest restore). Setting this alone on the `default` preset has no effect on the vcpkg restore. |
+| `vcpkg` (default) | Use the `ms-gdk[playfab]` vcpkg port. Set automatically by the `default` preset. Requires `VCPKG_ROOT`. |
+| `installed` | Use a Microsoft GDK install on disk. Set automatically by the `installed-gdk` preset (which also drops the vcpkg toolchain — no `VCPKG_ROOT` required). Setting this alone on the `default` preset has no effect on the vcpkg restore. |
 
 ### CMake auto-detection
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,7 +53,7 @@ unresolvable during CMake configure.
 
 **Cause:** vcpkg manifest mode could not resolve the `ms-gdk[playfab]` or
 `gameinput` ports defined in the repo's `vcpkg.json`. (The `installed-gdk`
-preset bypasses vcpkg for the GDK entirely — see
+preset does not require vcpkg at all — see
 [Source for the GDK dependency](getting-started.md#source-for-the-gdk-dependency).)
 
 **Fixes:**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,9 @@ CMake Error: Could not find a package configuration file provided by "gameinput"
 unresolvable during CMake configure.
 
 **Cause:** vcpkg manifest mode could not resolve the `ms-gdk[playfab]` or
-`gameinput` ports defined in the repo's `vcpkg.json`.
+`gameinput` ports defined in the repo's `vcpkg.json`. (The `installed-gdk`
+preset bypasses vcpkg for the GDK entirely — see
+[Source for the GDK dependency](getting-started.md#source-for-the-gdk-dependency).)
 
 **Fixes:**
 


### PR DESCRIPTION
Adds a build-time option to source the Microsoft GDK from an installed GDK on disk in addition to the existing `ms-gdk[playfab]` vcpkg port. Most developers already have a GDK install (for `makepkg.exe` / `wdapp.exe` / Game Config Editor) and shouldn't have to also install vcpkg just to compile the addon binaries.

## What changed

- **New cache var `GDK_DEPENDENCY_SOURCE`** (default `vcpkg`): selects between `vcpkg` and `installed`.
- **New cache var `GDK_INSTALL_DIR`**: explicit override of the GDK install path.
- **New cache var `GAMEINPUT_SOURCE`** (default `vcpkg`): selects between `vcpkg` (the `gameinput` port) and `nuget` (the `Microsoft.GameInput` NuGet package fetched directly from nuget.org). Both sources expose the same `Microsoft::GameInput` IMPORTED target.
- **New configure preset `installed-gdk`** (+ matching `debug-installed-gdk` / `release-installed-gdk` build presets): pins `GDK_DEPENDENCY_SOURCE=installed` + `GAMEINPUT_SOURCE=nuget`. **Does not load the vcpkg toolchain at all** — no `VCPKG_ROOT` required, no vcpkg checkout, no port restore. All three addons (godot_gdk, godot_playfab, godot_gameinput) build.
- **Hidden `_base` preset** holds the cache vars shared between `default` and `installed-gdk` (CXX standard, runtime, `MAP_IMPORTED_CONFIG_*`, default `BUILD_GODOT_*` toggles). `default` extends `_base` and adds `toolchainFile` + `VCPKG_TARGET_TRIPLET`; `installed-gdk` extends `_base` and adds neither.
- **`cmake/GDKDependencies.cmake`** rewritten to dispatch between the two sources and define equivalent `Xbox::*` IMPORTED targets when reading from a disk install. Adds `_gdk_fetch_gameinput_nuget` + `_gdk_define_gameinput_nuget_target` helpers that fetch the `Microsoft.GameInput` NuGet package via `file(DOWNLOAD)` (verified against a pinned SHA512) and cache it under `${CMAKE_BINARY_DIR}/_deps/gameinput-nuget-<version>/`. Pinned version (`3.1.26100.6879`) and SHA512 match what the vcpkg `gameinput` port currently wraps — same upstream archive.
- **README disclosure tweak**: "no SLA" replaced with "no specified update cadence for support or maintenance" + community-PR invite (per release-prep request).
- **Docs**: new `### Source for the GDK dependency` section in `docs/getting-started.md`; cross-references added in `docs/troubleshooting.md` and `docs/gdk/build-and-loading.md`.

## Why no `auto` mode

(Added in response to PR review.) A previous revision of this PR added an `auto` mode and made it the default. The Copilot reviewer correctly flagged that this could not work as documented: the vcpkg toolchain processes manifest features (and restores `ms-gdk[playfab]`) before `GDKDependencies.cmake` runs. On the default preset, vcpkg would still restore the GDK port even when `auto` then resolved to an installed GDK, and machines without a valid `VCPKG_ROOT` could not use the default preset to consume an installed GDK at all because the toolchain load itself fails. `auto` is now removed; the default is `vcpkg`, and the `installed-gdk` preset is the only way to reach installed mode (and now reaches it without loading the vcpkg toolchain at all).

## Usage

Default (vcpkg `ms-gdk[playfab]` + `gameinput` ports — no GDK install required, `VCPKG_ROOT` required):
```powershell
cmake --preset default
cmake --build build --preset debug
```

Installed GDK (no vcpkg required — no `VCPKG_ROOT`, no vcpkg checkout, no port restore; GameInput v3 fetched from nuget.org):
```powershell
cmake --preset installed-gdk
cmake --build --preset debug-installed-gdk
```

Explicit install path:
```powershell
cmake --preset installed-gdk -DGDK_INSTALL_DIR="C:/Program Files (x86)/Microsoft GDK/260400"
```

> **GameInput note:** the installed GDK ships GameInput v1 only, but the `godot_gameinput` addon targets v3. The `installed-gdk` preset solves this by setting `GAMEINPUT_SOURCE=nuget`, which fetches the `Microsoft.GameInput` NuGet package directly from nuget.org (cached under `build/installed-gdk/_deps/`). The first configure needs network access; subsequent configures reuse the cached extract. Same upstream archive as the vcpkg `gameinput` port — behavior is identical at runtime. Target machines still need `GameInputRedist.msi` installed.

## Layout requirement

Installed mode consumes the modern `windows\` subdirectory of the GDK install (`<install>/windows/include`, `<install>/windows/lib/x64`, `<install>/windows/bin/x64`), present in GDK **260400 / April 2026 and later**. The legacy `GRDK\` peer layout is not supported — use the `default` preset (vcpkg) for older GDK versions.

Discovery precedence (installed mode): `-DGDK_INSTALL_DIR=` → `%GRDKLatest%` → `%GameDK%` (numeric version sort).

## Out of scope

- **`tools/package_addons.ps1`** is not installed-GDK-aware (still sweeps and copies the vcpkg-shaped DLL set into addon `bin/`). Run a clean `bin/` between mode switches; full packaging-mode awareness is a follow-up.

## Validation

Local on `feat/dual-source-gdk-dependency` (6 commits):

- `cmake --preset default` + `cmake --build build --preset debug` — clean for all 3 addons (godot_gdk + godot_playfab + godot_gameinput).
- `cmake --preset installed-gdk` **with `VCPKG_ROOT` unset** + `cmake --build build/installed-gdk --config Debug` — configure clean (Microsoft.GameInput fetched from nuget.org on first run, cache reused thereafter), full debug build of all 3 addons succeeds. Zero vcpkg ports restored (no `build/installed-gdk/vcpkg_installed/` directory).
- `cmake --preset default -DGDK_DEPENDENCY_SOURCE=auto` — rejected with `Invalid GDK_DEPENDENCY_SOURCE='auto'. Allowed values: vcpkg, installed.`

No `.gd` touched, no native API surface changed; `tools/run_all_tests.ps1` and the parse gate are not required for this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
