### PR TITLE
pf-string-lifetime: own async UTF-8 request buffers

### DIFF
--- a/addons/godot_playfab/src/playfab_gamesaves.cpp
+++ b/addons/godot_playfab/src/playfab_gamesaves.cpp
@@ -6,6 +6,8 @@
 
 #include <playfab/gamesave/PFGameSaveFiles.h>
 
+#include "playfab_owned_utf8.h"
+
 #include "playfab.h"
 #include "playfab_pending_signal.h"
 #include "playfab_result.h"
@@ -197,6 +199,7 @@ class GameSaveSimpleAsyncContext final : public PlayFabSignalXAsyncContext {
     String m_cancel_message;
     String m_failure_action;
     String m_failure_code;
+    playfab_internal::OwnedUtf8String m_request_utf8;
 
 public:
     GameSaveSimpleAsyncContext(
@@ -207,20 +210,26 @@ public:
             const Variant &p_success_data,
             const String &p_cancel_message,
             const String &p_failure_action,
-            const String &p_failure_code) :
+            const String &p_failure_code,
+            const char *p_request_utf8 = nullptr) :
             PlayFabSignalXAsyncContext(p_runtime, p_pending_signal),
             m_local_user_handle(p_local_user_handle),
             m_result_fn(p_result_fn),
             m_success_data(p_success_data),
             m_cancel_message(p_cancel_message),
             m_failure_action(p_failure_action),
-            m_failure_code(p_failure_code) {}
+            m_failure_code(p_failure_code),
+            m_request_utf8(p_request_utf8) {}
 
     ~GameSaveSimpleAsyncContext() override {
         if (m_local_user_handle != nullptr) {
             PFLocalUserCloseHandle(m_local_user_handle);
             m_local_user_handle = nullptr;
         }
+    }
+
+    const char *get_request_utf8() const {
+        return m_request_utf8.c_str();
     }
 
 protected:
@@ -453,6 +462,7 @@ Signal PlayFabGameSaves::set_save_description_async(const Ref<PlayFabUser> &p_us
 
     Ref<PlayFabPendingSignal> pending_signal = runtime->make_pending_signal();
 
+    const CharString description_utf8 = p_short_save_description.utf8();
     auto *context = new GameSaveSimpleAsyncContext(
             runtime,
             pending_signal,
@@ -461,13 +471,13 @@ Signal PlayFabGameSaves::set_save_description_async(const Ref<PlayFabUser> &p_us
             success_data,
             "Setting the Game Saves description was cancelled.",
             "Failed to set the Game Saves description.",
-            "gamesave_set_description_failed");
+            "gamesave_set_description_failed",
+            description_utf8.get_data());
     context->bind_cancel_handler();
 
-    const CharString description_utf8 = p_short_save_description.utf8();
     HRESULT hr = PFGameSaveFilesSetSaveDescriptionAsync(
             local_user_handle,
-            description_utf8.get_data(),
+            context->get_request_utf8(),
             context->get_async_block());
     if (FAILED(hr)) {
         pending_signal->clear_cancel_handler();

--- a/addons/godot_playfab/src/playfab_owned_utf8.h
+++ b/addons/godot_playfab/src/playfab_owned_utf8.h
@@ -1,0 +1,37 @@
+#ifndef GODOT_PLAYFAB_OWNED_UTF8_H
+#define GODOT_PLAYFAB_OWNED_UTF8_H
+
+#include <string>
+
+namespace playfab_internal {
+
+class OwnedUtf8String final {
+    std::string m_value;
+
+public:
+    OwnedUtf8String() = default;
+
+    explicit OwnedUtf8String(const char *p_value) {
+        set(p_value);
+    }
+
+    void set(const char *p_value) {
+        m_value = p_value != nullptr ? p_value : "";
+    }
+
+    const char *c_str() const noexcept {
+        return m_value.c_str();
+    }
+
+    const char *c_str_or_null() const noexcept {
+        return m_value.empty() ? nullptr : m_value.c_str();
+    }
+
+    const std::string &str() const noexcept {
+        return m_value;
+    }
+};
+
+} // namespace playfab_internal
+
+#endif // GODOT_PLAYFAB_OWNED_UTF8_H

--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -1735,19 +1735,20 @@ Signal PlayFabParty::create_and_join_network_async(const Ref<PlayFabUser> &p_use
     net_config.maxEndpointsPerDeviceCount = 1;
     net_config.directPeerConnectivityOptions = static_cast<Party::PartyDirectPeerConnectivityOptions>(config->get_direct_peer_connectivity());
 
-    Party::PartyInvitationConfiguration invite_config = {};
-    const CharString invite_id_utf8 = config->get_invitation_id().utf8();
-    invite_config.identifier = invite_id_utf8.length() > 0 ? invite_id_utf8.get_data() : nullptr;
-    invite_config.revocability = Party::PartyInvitationRevocability::Anyone;
-    invite_config.entityIdCount = 0;
-    invite_config.entityIds = nullptr;
-
     PendingOperation *operation = _create_pending(PENDING_CREATE_NETWORK);
     operation->user = p_user;
     operation->config = config;
     operation->host = true;
     operation->native_user = local_user;
     operation->invitation_id = config->get_invitation_id();
+    const CharString invite_id_utf8 = operation->invitation_id.utf8();
+    operation->create_invitation_id_utf8.set(invite_id_utf8.get_data());
+
+    Party::PartyInvitationConfiguration invite_config = {};
+    invite_config.identifier = operation->create_invitation_id_utf8.c_str_or_null();
+    invite_config.revocability = Party::PartyInvitationRevocability::Anyone;
+    invite_config.entityIdCount = 0;
+    invite_config.entityIds = nullptr;
     operation->network.instantiate();
     operation->network->set_owner(this);
     operation->network->set_state_value(NETWORK_STATE_CREATING);
@@ -1773,6 +1774,7 @@ Signal PlayFabParty::create_and_join_network_async(const Ref<PlayFabUser> &p_use
     }
 
     operation->invitation_id = String::utf8(applied_invitation_id);
+    operation->auth_invitation_id_utf8.set(applied_invitation_id);
     operation->network->set_network_id(String::utf8(descriptor.networkIdentifier));
 
     Party::PartyNetwork *network_handle = nullptr;
@@ -1839,6 +1841,8 @@ Signal PlayFabParty::join_network_async(const Ref<PlayFabUser> &p_user, const St
     operation->descriptor = p_descriptor;
     operation->native_user = local_user;
     operation->invitation_id = config->get_invitation_id();
+    const CharString invitation_id_utf8 = operation->invitation_id.utf8();
+    operation->auth_invitation_id_utf8.set(invitation_id_utf8.get_data());
     operation->network.instantiate();
     operation->network->set_owner(this);
     operation->network->set_state_value(NETWORK_STATE_CONNECTING);
@@ -2041,7 +2045,7 @@ void PlayFabParty::_process_connect_to_network_completed(const Party::PartyState
 
     PartyError err = change->network->AuthenticateLocalUser(
             operation->native_user,
-            operation->invitation_id.utf8().get_data(),
+            operation->auth_invitation_id_utf8.c_str(),
             operation);
     if (PARTY_FAILED(err)) {
         Ref<PlayFabResult> result = _party_error_result(err, PARTY_NETWORK_CONNECT_FAILED, "PartyNetwork::AuthenticateLocalUser");

--- a/addons/godot_playfab/src/playfab_party.h
+++ b/addons/godot_playfab/src/playfab_party.h
@@ -22,6 +22,8 @@
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/string.hpp>
 
+#include "playfab_owned_utf8.h"
+
 #include <XTaskQueue.h>
 #include <playfab/core/PFEntity.h>
 
@@ -546,6 +548,8 @@ public:
         Party::PartyLocalEndpoint *native_endpoint = nullptr;
         Party::PartyLocalChatControl *native_chat_control = nullptr;
         String invitation_id;
+        playfab_internal::OwnedUtf8String create_invitation_id_utf8;
+        playfab_internal::OwnedUtf8String auth_invitation_id_utf8;
         uint32_t handshake_nonce = 0;
     };
 

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -90,6 +90,7 @@ Rules:
 4. With `playfab/runtime/embed_dispatch = true`, the addon pumps completions automatically each process frame.
 5. When embed dispatch is disabled, callers must pump the queue manually with `PlayFab.dispatch()`.
 6. `PlayFab.dispatch()` also pumps PlayFab Multiplayer lobby and matchmaking state changes after `PlayFab.multiplayer.initialize_async()`.
+7. Native async-operation contexts own UTF-8 request strings passed to PlayFab or Party SDK calls until the SDK completion callback has settled; callers must not hand SDK async calls pointers into stack-local `CharString` buffers.
 
 ## User/session model
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -23,6 +23,7 @@ godot_addon_doctest_target(
     SOURCES
         "${CMAKE_CURRENT_SOURCE_DIR}/result_codes/test_gdk_result_codes.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/result_codes/test_playfab_result_codes.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/playfab/test_owned_utf8.cpp"
         "${_GDK_RC_SRC}/gdk_result_codes_internal.cpp"
         "${_PF_RC_SRC}/playfab_result_codes_internal.cpp"
     LINK_LIBS   godot::cpp

--- a/tests/cpp/playfab/test_owned_utf8.cpp
+++ b/tests/cpp/playfab/test_owned_utf8.cpp
@@ -1,0 +1,41 @@
+#include "../third_party/doctest/doctest.h"
+
+#include "playfab_owned_utf8.h"
+
+#include <cstring>
+#include <string>
+
+TEST_CASE("playfab_internal::OwnedUtf8String survives transient request buffers until completion") {
+    constexpr const char *expected = "save description \xE2\x98\x83 from a transient CharString-shaped buffer";
+
+    playfab_internal::OwnedUtf8String owned;
+    const char *owned_completion_ptr = nullptr;
+    {
+        std::string transient = expected;
+        owned.set(transient.c_str());
+        owned_completion_ptr = owned.c_str();
+        CHECK(std::strcmp(owned_completion_ptr, expected) == 0);
+    }
+
+    CHECK(owned.c_str() == owned_completion_ptr);
+    CHECK(std::strcmp(owned.c_str(), expected) == 0);
+}
+
+TEST_CASE("playfab_internal::OwnedUtf8String supports Party optional-null and auth string shapes") {
+    playfab_internal::OwnedUtf8String empty;
+    CHECK(std::strcmp(empty.c_str(), "") == 0);
+    CHECK(empty.c_str_or_null() == nullptr);
+
+    constexpr const char *invitation_id = "party-invite-lifetime-pin-123456789";
+    playfab_internal::OwnedUtf8String auth_string(invitation_id);
+    CHECK(auth_string.c_str_or_null() != nullptr);
+    CHECK(std::strcmp(auth_string.c_str(), invitation_id) == 0);
+
+    std::string overwrite_source = invitation_id;
+    auth_string.set(overwrite_source.c_str());
+    const char *completion_ptr = auth_string.c_str();
+    overwrite_source.assign(4096, 'x');
+
+    CHECK(auth_string.c_str() == completion_ptr);
+    CHECK(std::strcmp(auth_string.c_str(), invitation_id) == 0);
+}


### PR DESCRIPTION
**Audit lane A2 — PlayFab string-lifetime UAFs (mirror of internal PR #136)**

Heap-promote the PlayFab Game Saves description and Party invitation/auth strings into the async operation contexts that survive until SDK completion. Adds doctest coverage for the new `playfab_owned_utf8.h` helper and documents the async string ownership contract in `spec/gdext-playfab.md`.

## Audit source

Item #9 in `files/exhaustive-fleet-audit-report.md` (string-lifetime UAFs around `set_save_description_async` + Party auth string finding `[pf-overall-gpt finding 1]`).

## Validation

- `cmake --preset default` ✅
- `cmake --build build --preset debug` ✅
- C++ doctest: 10/10 ✅ (includes the new `test_owned_utf8.cpp` suite)
- Targeted PlayFab GUT run ✅

> **Pre-existing repo issue noted:** `tools\run_all_tests.ps1` orchestrator fails the parse gate on existing samples with typed-symbol issues. Unrelated to this lane — captured in a follow-up audit todo.

## Live coverage decision

Live tests skipped (default). No write tests added; no sandbox title id needed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
