### PR TITLE
gi-stuck-actions: release held actions across all stop paths

### DIFF
--- a/addons/godot_gameinput/doc_classes/GameInput.xml
+++ b/addons/godot_gameinput/doc_classes/GameInput.xml
@@ -63,7 +63,7 @@
 			<param index="3" name="left_trigger" type="float" default="0.0" />
 			<param index="4" name="right_trigger" type="float" default="0.0" />
 			<description>
-				Sets the rumble motor levels on [param device]. Each value is clamped to [code][0.0, 1.0][/code]. Returns [code]true[/code] when the rumble request was sent, or [code]false[/code] when the device is null, disconnected, has no rumble motors, or the runtime is not initialized. Trigger motors are only meaningful on impulse-trigger gamepads; pass [code]0.0[/code] on devices without them.
+				Sets the rumble motor levels on [param device]. Each value is clamped to [code][0.0, 1.0][/code]. Returns [code]true[/code] when the rumble request was sent, or [code]false[/code] when the device is null, disconnected, has no rumble motors, the runtime is not initialized, or the native [code]SetRumbleState[/code] call reports failure on SDKs that expose an HRESULT. Trigger motors are only meaningful on impulse-trigger gamepads; pass [code]0.0[/code] on devices without them.
 			</description>
 		</method>
 		<method name="stop_haptics">

--- a/addons/godot_gameinput/doc_classes/GameInputActionMap.xml
+++ b/addons/godot_gameinput/doc_classes/GameInputActionMap.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[GameInputActionMap] is a [Resource] that owns an ordered, typed array of [GameInputBinding]. Edit it in the inspector or build it in code, save and load via [code]ResourceSaver[/code] / [code]ResourceLoader[/code], and assign it to [member GameInputMapper.action_map] to drive Godot actions from GameInput.
-		Mutations through [method add_binding] and [method clear] emit [code]changed[/code] (inherited from [Resource]), so a [GameInputMapper] referencing the action map can react to live edits in the editor.
+		Mutations through [method set_bindings], [method add_binding], [method clear], and property edits on contained [GameInputBinding] resources emit [code]changed[/code] (inherited from [Resource]), so a [GameInputMapper] referencing the action map can release any currently held actions and refresh its caches before the next frame.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -19,7 +19,7 @@
 			<return type="void" />
 			<param index="0" name="bindings" type="Array" />
 			<description>
-				Replaces the entire binding list. The argument should be a typed [code]Array[GameInputBinding][/code]; non-binding entries are silently kept by Godot's typed-array machinery but ignored at runtime. See [member bindings].
+				Replaces the entire binding list and emits [code]changed[/code]. The argument should be a typed [code]Array[GameInputBinding][/code]; non-binding entries are silently kept by Godot's typed-array machinery but ignored at runtime. See [member bindings].
 			</description>
 		</method>
 		<method name="get_binding_count" qualifiers="const">

--- a/addons/godot_gameinput/doc_classes/GameInputMapper.xml
+++ b/addons/godot_gameinput/doc_classes/GameInputMapper.xml
@@ -5,9 +5,9 @@
 	</brief_description>
 	<description>
 		[GameInputMapper] is a [Node] that resolves a target [GameInputDevice] (either by id via [member target_device_id] or as the primary device of [member target_kind_mask]) every [code]_process[/code] frame, fetches its [GameInputReading], and walks [member action_map] calling [code]Input.action_press(action, strength)[/code] or [code]Input.action_release(action)[/code] on each press / release edge so the rest of your game can keep using the standard [code]Input.is_action_pressed("jump")[/code] APIs without knowing GameInput exists. On every press / release transition the mapper additionally pushes an [InputEventAction] through [code]Input.parse_input_event[/code] so event-driven listeners — Viewport GUI focus traversal for [code]ui_*[/code] actions, [code]_gui_input[/code] handlers, [code]_input[/code] / [code]_unhandled_input[/code] — actually see the action fire, since [code]Input.action_press[/code] alone updates polled state but does not deliver an [InputEvent].
-		To avoid double-firing when Godot's built-in joypad backend is already wired to deliver the same action via an [InputEventJoypadButton] / [InputEventJoypadMotion] in the project's [code]InputMap[/code] (e.g., the default [code]ui_accept[/code] mapping that includes joypad button A), the mapper checks each binding once against the action's [code]InputMap[/code] events and skips its own synthetic [InputEventAction] when a matching native joypad event is found. The polled state via [code]Input.action_press[/code] is still refreshed every frame either way. The check is per-binding, cached, and invalidated whenever [member action_map] is reassigned; runtime [code]InputMap[/code] edits made after the cache fills will tolerate one frame of staleness.
+		To avoid double-firing when Godot's built-in joypad backend is already wired to deliver the same action via an [InputEventJoypadButton] / [InputEventJoypadMotion] in the project's [code]InputMap[/code] (e.g., the default [code]ui_accept[/code] mapping that includes joypad button A), the mapper checks each binding once against the action's [code]InputMap[/code] events and skips its own synthetic [InputEventAction] when a matching native joypad event is found. The polled state via [code]Input.action_press[/code] is still refreshed every frame either way. The check is per-binding, cached, invalidated whenever [member action_map] or a binding on that map changes, and refreshed once per frame so runtime [code]InputMap[/code] edits made after the cache fills tolerate at most one frame of staleness.
 		The mapper calls [method GameInput.poll] defensively at the start of each frame; that call is per-frame idempotent so multiple [GameInputMapper] instances in the same scene do not refresh device state more than once per frame.
-		Action names listed in [member GameInputBinding.action] must already exist in the project's [code]InputMap[/code]. Missing actions emit a single [code]push_warning[/code] per [GameInputMapper] instance per action (debounced via an internal set) and the binding is then ignored. On [code]NOTIFICATION_EXIT_TREE[/code], any actions the mapper currently holds pressed are released so freed actions never get stuck.
+		Action names listed in [member GameInputBinding.action] must already exist in the project's [code]InputMap[/code]. Missing actions emit a single [code]push_warning[/code] per [GameInputMapper] instance per action (debounced via an internal set) and the binding is then ignored. Whenever the mapper stops driving a held binding — exiting the tree, swapping or mutating the active map, retargeting the mapper, losing the target device, or failing to obtain a fresh reading — it releases every action it previously held so Godot's polled action state cannot get stuck pressed.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -21,7 +21,7 @@
 			<return type="void" />
 			<param index="0" name="map" type="GameInputActionMap" />
 			<description>
-				Assigns a new action map. Resets the internal "previously pressed" state and the missing-action warning set so the new map gets a clean slate.
+				Assigns a new action map. Any actions held by the previous map are released before the internal previous-pressed state, native-event cache, and missing-action warning set are reset so the new map gets a clean slate.
 			</description>
 		</method>
 		<method name="get_target_kind_mask" qualifiers="const">
@@ -34,7 +34,7 @@
 			<return type="void" />
 			<param index="0" name="mask" type="int" />
 			<description>
-				Sets the kind mask used to pick a primary device. See [member target_kind_mask].
+				Sets the kind mask used to pick a primary device. If the mapper was holding any actions for the previous target scope, they are released before the mask changes. See [member target_kind_mask].
 			</description>
 		</method>
 		<method name="get_target_device_id" qualifiers="const">
@@ -47,7 +47,7 @@
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Sets a specific [GameInputDevice] id to drive. Pass [code]-1[/code] to revert to "primary device of [member target_kind_mask]". See [member target_device_id].
+				Sets a specific [GameInputDevice] id to drive. If the mapper was holding any actions for the previous device, they are released before the id changes. Pass [code]-1[/code] to revert to "primary device of [member target_kind_mask]". See [member target_device_id].
 			</description>
 		</method>
 		<method name="get_active_binding_count" qualifiers="const">

--- a/addons/godot_gameinput/src/gameinput_action_map.cpp
+++ b/addons/godot_gameinput/src/gameinput_action_map.cpp
@@ -24,8 +24,44 @@ void GameInputActionMap::_bind_methods() {
                  "set_bindings", "get_bindings");
 }
 
+void GameInputActionMap::_connect_binding_changed(const Ref<GameInputBinding> &binding) {
+    if (binding.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputActionMap::_on_binding_changed);
+    if (!binding->is_connected("changed", callback)) {
+        binding->connect("changed", callback);
+    }
+}
+
+void GameInputActionMap::_disconnect_binding_changed(const Ref<GameInputBinding> &binding) {
+    if (binding.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputActionMap::_on_binding_changed);
+    if (binding->is_connected("changed", callback)) {
+        binding->disconnect("changed", callback);
+    }
+}
+
+void GameInputActionMap::_disconnect_all_binding_changed() {
+    for (int i = 0; i < (int)m_bindings.size(); ++i) {
+        Ref<GameInputBinding> binding = m_bindings[i];
+        _disconnect_binding_changed(binding);
+    }
+}
+
+void GameInputActionMap::_on_binding_changed() {
+    emit_changed();
+}
+
 void GameInputActionMap::set_bindings(const TypedArray<GameInputBinding> &p_bindings) {
+    _disconnect_all_binding_changed();
     m_bindings = p_bindings;
+    for (int i = 0; i < (int)m_bindings.size(); ++i) {
+        Ref<GameInputBinding> binding = m_bindings[i];
+        _connect_binding_changed(binding);
+    }
     emit_changed();
 }
 
@@ -46,11 +82,13 @@ Ref<GameInputBinding> GameInputActionMap::get_binding(int index) const {
 
 void GameInputActionMap::add_binding(const Ref<GameInputBinding> &binding) {
     if (binding.is_null()) return;
+    _connect_binding_changed(binding);
     m_bindings.push_back(binding);
     emit_changed();
 }
 
 void GameInputActionMap::clear() {
+    _disconnect_all_binding_changed();
     m_bindings.clear();
     emit_changed();
 }

--- a/addons/godot_gameinput/src/gameinput_action_map.h
+++ b/addons/godot_gameinput/src/gameinput_action_map.h
@@ -17,6 +17,11 @@ class GameInputActionMap : public Resource {
 private:
     TypedArray<GameInputBinding> m_bindings;
 
+    void _connect_binding_changed(const Ref<GameInputBinding> &binding);
+    void _disconnect_binding_changed(const Ref<GameInputBinding> &binding);
+    void _disconnect_all_binding_changed();
+    void _on_binding_changed();
+
 protected:
     static void _bind_methods();
 

--- a/addons/godot_gameinput/src/gameinput_mapper.cpp
+++ b/addons/godot_gameinput/src/gameinput_mapper.cpp
@@ -170,13 +170,14 @@ void GameInputMapper::_release_held_action_for(int binding_index) {
         InputMap *imap = InputMap::get_singleton();
         if (input && action != StringName()) {
             input->action_release(action);
-            if (!imap || imap->has_action(action)) {
+            if (imap && imap->has_action(action)) {
                 Ref<InputEventAction> evt;
                 evt.instantiate();
                 evt->set_action(action);
                 evt->set_pressed(false);
                 input->parse_input_event(evt);
             }
+        }
         }
     }
 

--- a/addons/godot_gameinput/src/gameinput_mapper.cpp
+++ b/addons/godot_gameinput/src/gameinput_mapper.cpp
@@ -6,12 +6,14 @@
 #include "gameinput_device.h"
 #include "gameinput_reading.h"
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/input.hpp>
 #include <godot_cpp/classes/input_event.hpp>
 #include <godot_cpp/classes/input_event_action.hpp>
 #include <godot_cpp/classes/input_event_joypad_button.hpp>
 #include <godot_cpp/classes/input_event_joypad_motion.hpp>
 #include <godot_cpp/classes/input_map.hpp>
+#include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/variant/typed_array.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
@@ -21,6 +23,11 @@ namespace godot {
 
 GameInputMapper::GameInputMapper() {
     set_process(true);
+}
+
+GameInputMapper::~GameInputMapper() {
+    _release_held_actions();
+    _disconnect_action_map_changed(m_action_map);
 }
 
 void GameInputMapper::_bind_methods() {
@@ -36,6 +43,14 @@ void GameInputMapper::_bind_methods() {
                          &GameInputMapper::get_target_device_id);
     ClassDB::bind_method(D_METHOD("get_active_binding_count"),
                          &GameInputMapper::get_active_binding_count);
+#ifndef NDEBUG
+    ClassDB::bind_method(D_METHOD("_test_mark_binding_pressed", "binding_index"),
+                         &GameInputMapper::_test_mark_binding_pressed);
+    ClassDB::bind_method(D_METHOD("_test_prime_native_handles_cache", "binding_index", "native_handles"),
+                         &GameInputMapper::_test_prime_native_handles_cache);
+    ClassDB::bind_method(D_METHOD("_test_get_native_handles_cache_count"),
+                         &GameInputMapper::_test_get_native_handles_cache_count);
+#endif
 
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "action_map",
                               PROPERTY_HINT_RESOURCE_TYPE, "GameInputActionMap"),
@@ -55,33 +70,21 @@ void GameInputMapper::_notification(int p_what) {
     if (p_what == NOTIFICATION_PROCESS) {
         _process_bindings();
     } else if (p_what == NOTIFICATION_EXIT_TREE) {
-        // Release any actions we currently hold pressed.
-        Input *input = Input::get_singleton();
-        InputMap *imap = InputMap::get_singleton();
-        if (input && imap && m_action_map.is_valid()) {
-            for (KeyValue<int, bool> &kv : m_prev_pressed) {
-                if (!kv.value) continue;
-                Ref<GameInputBinding> b = m_action_map->get_binding(kv.key);
-                if (b.is_null()) continue;
-                StringName a = b->get_action();
-                if (a != StringName() && imap->has_action(a)) {
-                    input->action_release(a);
-                    Ref<InputEventAction> evt;
-                    evt.instantiate();
-                    evt->set_action(a);
-                    evt->set_pressed(false);
-                    input->parse_input_event(evt);
-                }
-            }
-        }
-        m_prev_pressed.clear();
+        _release_held_actions();
     }
 }
 
 void GameInputMapper::set_action_map(const Ref<GameInputActionMap> &map) {
+    if (m_action_map == map) {
+        return;
+    }
+
+    _release_held_actions();
+    _disconnect_action_map_changed(m_action_map);
     m_action_map = map;
-    m_prev_pressed.clear();
-    m_native_handles_cache.clear();
+    _connect_action_map_changed(m_action_map);
+    _forget_pressed_state();
+    _invalidate_native_handles_cache();
     m_warned_missing_actions.clear();
 }
 
@@ -89,10 +92,22 @@ Ref<GameInputActionMap> GameInputMapper::get_action_map() const {
     return m_action_map;
 }
 
-void GameInputMapper::set_target_kind_mask(int mask) { m_target_kind_mask = mask; }
+void GameInputMapper::set_target_kind_mask(int mask) {
+    if (m_target_kind_mask == mask) {
+        return;
+    }
+    _release_held_actions();
+    m_target_kind_mask = mask;
+}
 int GameInputMapper::get_target_kind_mask() const { return m_target_kind_mask; }
 
-void GameInputMapper::set_target_device_id(int64_t id) { m_target_device_id = id; }
+void GameInputMapper::set_target_device_id(int64_t id) {
+    if (m_target_device_id == id) {
+        return;
+    }
+    _release_held_actions();
+    m_target_device_id = id;
+}
 int64_t GameInputMapper::get_target_device_id() const { return m_target_device_id; }
 
 int GameInputMapper::get_active_binding_count() const {
@@ -101,6 +116,119 @@ int GameInputMapper::get_active_binding_count() const {
         if (kv.value) n++;
     }
     return n;
+}
+
+#ifndef NDEBUG
+void GameInputMapper::_test_mark_binding_pressed(int binding_index) {
+    if (m_action_map.is_null()) {
+        return;
+    }
+    Ref<GameInputBinding> binding = m_action_map->get_binding(binding_index);
+    if (binding.is_null()) {
+        return;
+    }
+    StringName action = binding->get_action();
+    if (action == StringName()) {
+        return;
+    }
+    Input *input = Input::get_singleton();
+    if (input) {
+        input->action_press(action, 1.0f);
+    }
+    m_prev_pressed[binding_index] = true;
+    m_prev_actions[binding_index] = action;
+}
+
+void GameInputMapper::_test_prime_native_handles_cache(int binding_index, bool native_handles) {
+    m_native_handles_cache[binding_index] = native_handles;
+}
+
+int GameInputMapper::_test_get_native_handles_cache_count() const {
+    return (int)m_native_handles_cache.size();
+}
+#endif
+
+void GameInputMapper::_release_held_action_for(int binding_index) {
+    bool was_pressed = false;
+    if (HashMap<int, bool>::Iterator it = m_prev_pressed.find(binding_index)) {
+        was_pressed = it->value;
+    }
+
+    if (was_pressed) {
+        StringName action;
+        if (HashMap<int, StringName>::Iterator ait = m_prev_actions.find(binding_index)) {
+            action = ait->value;
+        }
+        if (action == StringName() && m_action_map.is_valid()) {
+            Ref<GameInputBinding> binding = m_action_map->get_binding(binding_index);
+            if (binding.is_valid()) {
+                action = binding->get_action();
+            }
+        }
+
+        Input *input = Input::get_singleton();
+        InputMap *imap = InputMap::get_singleton();
+        if (input && action != StringName()) {
+            input->action_release(action);
+            if (!imap || imap->has_action(action)) {
+                Ref<InputEventAction> evt;
+                evt.instantiate();
+                evt->set_action(action);
+                evt->set_pressed(false);
+                input->parse_input_event(evt);
+            }
+        }
+    }
+
+    m_prev_pressed.erase(binding_index);
+    m_prev_actions.erase(binding_index);
+}
+
+void GameInputMapper::_release_held_actions() {
+    Vector<int> keys;
+    for (const KeyValue<int, bool> &kv : m_prev_pressed) {
+        keys.push_back(kv.key);
+    }
+    for (int i = 0; i < keys.size(); ++i) {
+        _release_held_action_for(keys[i]);
+    }
+}
+
+void GameInputMapper::_forget_pressed_state() {
+    m_prev_pressed.clear();
+    m_prev_actions.clear();
+}
+
+void GameInputMapper::_invalidate_native_handles_cache() {
+    m_native_handles_cache.clear();
+    m_native_handles_cache_frame = UINT64_MAX;
+}
+
+void GameInputMapper::_connect_action_map_changed(const Ref<GameInputActionMap> &map) {
+    if (map.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputMapper::_on_action_map_changed);
+    if (!map->is_connected("changed", callback)) {
+        map->connect("changed", callback);
+    }
+}
+
+void GameInputMapper::_disconnect_action_map_changed(const Ref<GameInputActionMap> &map) {
+    if (map.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputMapper::_on_action_map_changed);
+    if (map->is_connected("changed", callback)) {
+        map->disconnect("changed", callback);
+    }
+}
+
+void GameInputMapper::_on_action_map_changed() {
+    _release_held_actions();
+    _forget_pressed_state();
+    _invalidate_native_handles_cache();
+    m_warned_missing_actions.clear();
 }
 
 bool GameInputMapper::_is_pressed_for(int source, float &out_strength,
@@ -152,10 +280,23 @@ bool GameInputMapper::_is_pressed_for(int source, float &out_strength,
 }
 
 void GameInputMapper::_process_bindings() {
-    if (m_action_map.is_null()) return;
+    if (m_action_map.is_null()) {
+        _release_held_actions();
+        return;
+    }
+
+    Engine *engine = Engine::get_singleton();
+    uint64_t frame = engine ? engine->get_process_frames() : 0;
+    if (frame != m_native_handles_cache_frame) {
+        m_native_handles_cache.clear();
+        m_native_handles_cache_frame = frame;
+    }
 
     GameInput *gi = GameInput::get_singleton();
-    if (!gi || !gi->is_initialized()) return;
+    if (!gi || !gi->is_initialized()) {
+        _release_held_actions();
+        return;
+    }
 
     gi->poll(); // idempotent per frame
 
@@ -175,24 +316,64 @@ void GameInputMapper::_process_bindings() {
     }
 
     if (device.is_null() || !device->is_connected()) {
+        _release_held_actions();
         return;
     }
 
     Ref<GameInputReading> reading = gi->get_current_reading(device);
-    if (reading.is_null()) return;
+    if (reading.is_null()) {
+        _release_held_actions();
+        return;
+    }
 
     Input *input = Input::get_singleton();
     InputMap *imap = InputMap::get_singleton();
-    if (!input || !imap) return;
+    if (!input || !imap) {
+        _release_held_actions();
+        return;
+    }
 
     int n = m_action_map->get_binding_count();
+    Vector<int> stale_binding_indices;
+    for (const KeyValue<int, bool> &kv : m_prev_pressed) {
+        if (kv.key < 0 || kv.key >= n) {
+            stale_binding_indices.push_back(kv.key);
+        }
+    }
+    for (int i = 0; i < stale_binding_indices.size(); ++i) {
+        _release_held_action_for(stale_binding_indices[i]);
+    }
+
     for (int i = 0; i < n; ++i) {
         Ref<GameInputBinding> b = m_action_map->get_binding(i);
-        if (b.is_null()) continue;
+        if (b.is_null()) {
+            _release_held_action_for(i);
+            continue;
+        }
 
         StringName action = b->get_action();
-        if (action == StringName()) continue;
+        if (action == StringName()) {
+            _release_held_action_for(i);
+            continue;
+        }
+
+        bool was_pressed = false;
+        if (HashMap<int, bool>::Iterator it = m_prev_pressed.find(i)) {
+            was_pressed = it->value;
+        }
+        if (was_pressed) {
+            StringName prev_action;
+            if (HashMap<int, StringName>::Iterator ait = m_prev_actions.find(i)) {
+                prev_action = ait->value;
+            }
+            if (prev_action != StringName() && prev_action != action) {
+                _release_held_action_for(i);
+                was_pressed = false;
+            }
+        }
+
         if (!imap->has_action(action)) {
+            _release_held_action_for(i);
             if (!m_warned_missing_actions.has(action)) {
                 m_warned_missing_actions.insert(action);
                 UtilityFunctions::push_warning(
@@ -223,11 +404,6 @@ void GameInputMapper::_process_bindings() {
             float s = 0.0f;
             is_pressed = _is_pressed_for(b->get_source(), s, reading.ptr());
             strength = s;
-        }
-
-        bool was_pressed = false;
-        if (HashMap<int, bool>::Iterator it = m_prev_pressed.find(i)) {
-            was_pressed = it->value;
         }
 
         if (is_pressed) {
@@ -270,6 +446,11 @@ void GameInputMapper::_process_bindings() {
         }
 
         m_prev_pressed[i] = is_pressed;
+        if (is_pressed) {
+            m_prev_actions[i] = action;
+        } else {
+            m_prev_actions.erase(i);
+        }
     }
 }
 

--- a/addons/godot_gameinput/src/gameinput_mapper.h
+++ b/addons/godot_gameinput/src/gameinput_mapper.h
@@ -7,6 +7,8 @@
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/variant/string_name.hpp>
 
+#include <cstdint>
+
 namespace godot {
 
 class GameInputActionMap;
@@ -29,7 +31,8 @@ class GameInputActionMap;
 // InputMap once, caches the result per binding, and skips its own
 // InputEventAction emit when a matching native event exists. The polled
 // action_press path keeps running either way; only the synthetic event is
-// suppressed. The cache is invalidated whenever the action_map changes.
+// suppressed. The cache is invalidated whenever the action_map changes and
+// refreshed per frame so runtime InputMap edits are stale for at most one frame.
 //
 // Action names must already exist in Godot's InputMap for the standard
 // Input.is_action_pressed("jump") API to work; the Mapper warns once per
@@ -56,16 +59,16 @@ private:
     // Per-binding press state from the previous frame so we can emit
     // press/release on the right edges. Keyed by binding index in the map.
     HashMap<int, bool> m_prev_pressed;
+    HashMap<int, StringName> m_prev_actions;
 
     // Per-binding cache: does Godot's built-in joypad backend already drive
     // this binding's action via an equivalent InputEventJoypadButton /
     // InputEventJoypadMotion in the project's InputMap? When true, we skip
     // emitting our own InputEventAction for the same press to avoid every
     // ui_accept / ui_up / etc. firing twice. The polled state (action_press)
-    // still gets refreshed every frame either way. Cache is invalidated when
-    // the action map changes; rare runtime InputMap edits are tolerated as
-    // single-frame staleness.
+    // still gets refreshed every frame either way.
     HashMap<int, bool> m_native_handles_cache;
+    uint64_t m_native_handles_cache_frame = UINT64_MAX;
 
     // Action names we've already warned about being missing from InputMap.
     HashSet<StringName> m_warned_missing_actions;
@@ -75,6 +78,13 @@ private:
                          class GameInputReading *reading) const;
     bool _native_path_handles_binding(const Ref<class GameInputBinding> &binding,
                                       const StringName &action) const;
+    void _release_held_actions();
+    void _release_held_action_for(int binding_index);
+    void _forget_pressed_state();
+    void _invalidate_native_handles_cache();
+    void _connect_action_map_changed(const Ref<GameInputActionMap> &map);
+    void _disconnect_action_map_changed(const Ref<GameInputActionMap> &map);
+    void _on_action_map_changed();
 
     static int _source_to_joy_button(int source);
     static int _source_to_joy_axis(int source);
@@ -85,7 +95,7 @@ protected:
 
 public:
     GameInputMapper();
-    ~GameInputMapper() = default;
+    ~GameInputMapper();
 
     void set_action_map(const Ref<GameInputActionMap> &map);
     Ref<GameInputActionMap> get_action_map() const;
@@ -98,6 +108,11 @@ public:
 
     // For tests / inspection.
     int get_active_binding_count() const;
+#ifndef NDEBUG
+    void _test_mark_binding_pressed(int binding_index);
+    void _test_prime_native_handles_cache(int binding_index, bool native_handles);
+    int _test_get_native_handles_cache_count() const;
+#endif
 };
 
 } // namespace godot

--- a/addons/godot_gameinput/src/gameinput_singleton.cpp
+++ b/addons/godot_gameinput/src/gameinput_singleton.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <type_traits>
 
 namespace godot {
 
@@ -21,6 +22,33 @@ static inline const GameInputDeviceInfo *_get_device_info(IGameInputDevice *devi
     const GameInputDeviceInfo *info = nullptr;
     HRESULT hr = device->GetDeviceInfo(&info);
     return SUCCEEDED(hr) ? info : nullptr;
+}
+
+template <typename DeviceT>
+static inline HRESULT _set_rumble_state_checked_impl(DeviceT *device,
+                                                     const GameInputRumbleParams *params) {
+    using ReturnT = decltype(device->SetRumbleState(params));
+    if constexpr (std::is_same_v<ReturnT, void>) {
+        device->SetRumbleState(params);
+        return S_OK;
+    } else {
+        ReturnT result = device->SetRumbleState(params);
+        if constexpr (std::is_same_v<ReturnT, HRESULT>) {
+            return result;
+        } else if constexpr (std::is_same_v<ReturnT, bool>) {
+            return result ? S_OK : E_FAIL;
+        } else {
+            return (HRESULT)result;
+        }
+    }
+}
+
+static inline HRESULT _set_rumble_state_checked(IGameInputDevice *device,
+                                                const GameInputRumbleParams *params) {
+    if (!device || !params) {
+        return E_POINTER;
+    }
+    return _set_rumble_state_checked_impl(device, params);
 }
 
 GameInput *GameInput::singleton = nullptr;
@@ -122,7 +150,7 @@ void CALLBACK GameInput::_on_device_callback(
         GameInputDeviceStatus current_status,
         GameInputDeviceStatus previous_status) {
     auto *self = static_cast<GameInput *>(context);
-    if (!self || !device) {
+    if (!self || !device || !self->m_accepting_callbacks.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -141,8 +169,26 @@ void CALLBACK GameInput::_on_device_callback(
 
     {
         std::lock_guard<std::mutex> lock(self->m_event_mutex);
+        if (!self->m_accepting_callbacks.load(std::memory_order_acquire)) {
+            device->Release();
+            return;
+        }
         self->m_pending_events.push_back(ev);
     }
+}
+
+void GameInput::_release_pending_events_locked() {
+    for (uint32_t i = 0; i < m_pending_events.size(); ++i) {
+        if (m_pending_events[i].native_device) {
+            m_pending_events[i].native_device->Release();
+        }
+    }
+    m_pending_events.clear();
+}
+
+void GameInput::_clear_pending_events() {
+    std::lock_guard<std::mutex> lock(m_event_mutex);
+    _release_pending_events_locked();
 }
 
 void GameInput::_drain_pending_events() {
@@ -234,6 +280,7 @@ bool GameInput::initialize() {
     if (m_initialized) {
         return true;
     }
+    m_accepting_callbacks.store(false, std::memory_order_release);
     HRESULT hr = ::GameInputCreate(&m_game_input);
     if (FAILED(hr) || !m_game_input) {
         if (!m_warned_create_failed) {
@@ -246,6 +293,7 @@ bool GameInput::initialize() {
         return false;
     }
 
+    m_accepting_callbacks.store(true, std::memory_order_release);
     hr = m_game_input->RegisterDeviceCallback(
         nullptr,
         (GameInputKind)(GameInputKindGamepad | GameInputKindKeyboard | GameInputKindMouse),
@@ -255,10 +303,13 @@ bool GameInput::initialize() {
         &GameInput::_on_device_callback,
         &m_device_callback_token);
     if (FAILED(hr)) {
+        m_accepting_callbacks.store(false, std::memory_order_release);
         UtilityFunctions::push_warning(
             "GameInput: RegisterDeviceCallback failed (hr=", (int64_t)hr, ")");
+        _clear_pending_events();
         m_game_input->Release();
         m_game_input = nullptr;
+        m_device_callback_token = 0;
         return false;
     }
 
@@ -269,11 +320,16 @@ bool GameInput::initialize() {
 }
 
 void GameInput::shutdown() {
-    if (!m_initialized) return;
+    if (!m_initialized && !m_game_input) return;
+
+    m_accepting_callbacks.store(false, std::memory_order_release);
 
     if (m_game_input && m_device_callback_token) {
-        // GameInput v3 dropped the timeout parameter that v1 accepted here.
-        m_game_input->UnregisterCallback(m_device_callback_token);
+        bool unregistered = m_game_input->UnregisterCallback(m_device_callback_token);
+        if (!unregistered) {
+            UtilityFunctions::push_warning(
+                "GameInput: UnregisterCallback() failed; late callbacks will be ignored.");
+        }
         m_device_callback_token = 0;
     }
 
@@ -284,7 +340,7 @@ void GameInput::shutdown() {
             const GameInputDeviceInfo *info = _get_device_info(d);
             if (info && info->supportedRumbleMotors != GameInputRumbleNone) {
                 GameInputRumbleParams zero{};
-                d->SetRumbleState(&zero);
+                _set_rumble_state_checked(d, &zero);
             }
             d->Release();
         }
@@ -292,15 +348,7 @@ void GameInput::shutdown() {
     m_devices.clear();
 
     // Drain any leftover queued events to release their AddRef.
-    {
-        std::lock_guard<std::mutex> lock(m_event_mutex);
-        for (uint32_t i = 0; i < m_pending_events.size(); ++i) {
-            if (m_pending_events[i].native_device) {
-                m_pending_events[i].native_device->Release();
-            }
-        }
-        m_pending_events.clear();
-    }
+    _clear_pending_events();
 
     if (m_game_input) {
         m_game_input->Release();
@@ -409,7 +457,12 @@ bool GameInput::set_vibration(const Ref<GameInputDevice> &device, float low_freq
     params.highFrequency = std::max(0.0f, std::min(1.0f, high_freq));
     params.leftTrigger   = std::max(0.0f, std::min(1.0f, left_trigger));
     params.rightTrigger  = std::max(0.0f, std::min(1.0f, right_trigger));
-    native->SetRumbleState(&params);
+    HRESULT hr = _set_rumble_state_checked(native, &params);
+    if (FAILED(hr)) {
+        UtilityFunctions::push_warning(
+            "GameInput: SetRumbleState failed (hr=", (int64_t)hr, ")");
+        return false;
+    }
     return true;
 }
 

--- a/addons/godot_gameinput/src/gameinput_singleton.h
+++ b/addons/godot_gameinput/src/gameinput_singleton.h
@@ -65,6 +65,7 @@ private:
 
     IGameInput *m_game_input = nullptr;
     GameInputCallbackToken m_device_callback_token = 0;
+    std::atomic_bool m_accepting_callbacks{false};
     bool m_initialized = false;
     bool m_warned_uninitialized = false;
     bool m_warned_create_failed = false;
@@ -97,6 +98,8 @@ private:
     };
     Vector<DeviceEntry> m_devices;
 
+    void _release_pending_events_locked();
+    void _clear_pending_events();
     void _drain_pending_events();
     void _real_poll();
     int _find_index_by_id(int64_t id) const;

--- a/docs/gameinput/manual-tests.md
+++ b/docs/gameinput/manual-tests.md
@@ -76,6 +76,7 @@ With a vibration-capable controller connected:
 - [ ] **Rumble Pulse** scenario causes the controller to vibrate for ~0.4 s.
 - [ ] **Stop Rumble** ends any in-flight rumble immediately.
 - [ ] Event log records both events.
+- [ ] Disconnect or disable the target device and confirm `GameInput.set_vibration()` returns `false` (or logs the native HRESULT on SDKs that report one) instead of reporting success.
 
 ### Vibration — two controllers
 
@@ -99,6 +100,12 @@ node into a scene and assign a small `GameInputActionMap` with one binding.
 - [ ] When you create a custom `GameInputBinding` that targets an action
   **not** present in `InputMap`, the Mapper logs **one** warning per missing
   action (not per frame).
+- [ ] Hold a mapped action, then hot-swap the mapper's `action_map`, call
+  `set_bindings()` / `add_binding()` / `clear()` on the active map, and remove
+  the mapper from the tree. After each stop-driving path,
+  `Input.is_action_pressed(action)` returns `false`.
+- [ ] Hold a mapped action and unplug the target controller. The action is
+  released on the next frame and does not remain stuck in Godot's `InputMap`.
 
 ## Regression smoke
 

--- a/docs/gameinput/plugin.md
+++ b/docs/gameinput/plugin.md
@@ -91,9 +91,9 @@ func _process(_delta: float) -> void:
         return
     var reading := gi.get_current_reading(pad)
     if reading != null and reading.was_button_pressed(GameInputDevice.BUTTON_A):
-        gi.set_vibration(pad, 0.6, 0.3)
-        await get_tree().create_timer(0.15).timeout
-        gi.stop_haptics(pad)
+        if gi.set_vibration(pad, 0.6, 0.3):
+            await get_tree().create_timer(0.15).timeout
+            gi.stop_haptics(pad)
 ```
 
 ### Drive Godot actions with a `GameInputMapper`
@@ -121,18 +121,28 @@ In the editor:
 The Mapper calls `Input.action_press(action, strength)` /
 `Input.action_release(action)` each frame, so the rest of your code can stay
 on Godot's standard `Input.is_action_pressed("jump")` / `Input.get_axis()`
-APIs and gain GameInput device support transparently. On every
-press / release transition the Mapper also pushes an `InputEventAction`
-through `Input.parse_input_event` so event-driven consumers — UI focus
-traversal for `ui_*`, `_gui_input` listeners, `_input` /
-`_unhandled_input` handlers — actually see the action change. When Godot's
-built-in joypad backend is already wired to deliver the same action through
-a matching `InputEventJoypadButton` / `InputEventJoypadMotion` in your
-`InputMap` (the default project mapping for `ui_accept` etc.), the Mapper
-suppresses its own `InputEventAction` for that binding so menu actions fire
-exactly once per physical press instead of twice.
+APIs and gain GameInput device support transparently. If the mapper stops
+driving a held binding — the node exits the tree, you swap or mutate the
+active `GameInputActionMap`, the target device disappears, or the frame cannot
+produce a fresh reading — it releases the actions it previously held before
+clearing its per-binding cache. Runtime `InputMap` edits also refresh the
+native-event suppression cache by the next frame. On every press / release
+transition the Mapper also pushes an `InputEventAction` through
+`Input.parse_input_event` so event-driven consumers — UI focus traversal for
+`ui_*`, `_gui_input` listeners, `_input` / `_unhandled_input` handlers —
+actually see the action change. When Godot's built-in joypad backend is
+already wired to deliver the same action through a matching
+`InputEventJoypadButton` / `InputEventJoypadMotion` in your `InputMap` (the
+default project mapping for `ui_accept` etc.), the Mapper suppresses its own
+`InputEventAction` for that binding so menu actions fire exactly once per
+physical press instead of twice.
 
 ### Soft-fail behaviour
+
+`GameInput.set_vibration()` returns `false` when preflight fails (null or
+disconnected device, no rumble motors, uninitialized runtime) and also when an
+HRESULT-returning GameInput SDK reports a native `SetRumbleState` failure, so
+callers can skip timers or surface diagnostics.
 
 Every public method on `GameInput`, `GameInputDevice`, and `GameInputReading`
 returns a safe default and emits a single `push_warning` if called before

--- a/spec/gdext-gameinput.md
+++ b/spec/gdext-gameinput.md
@@ -34,7 +34,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Device discovery/lifecycle | Shipped | connected/disconnected device cache, hot-plug signals on the main thread |
 | Polling API | Shipped | `GameInput.poll()` is per-frame idempotent |
 | Reading callbacks | Deferred | event-driven readings — see [§ Deferred to v2](#deferred-to-v2) |
-| Vibration/rumble | Shipped | `SetRumbleState`-backed; `supportedRumbleMotors` checked first |
+| Vibration/rumble | Shipped | `SetRumbleState`-backed; `supportedRumbleMotors` checked first; native failures are surfaced as `false` when the SDK reports them |
 | Force feedback / advanced haptics | Deferred | optional follow-on after basic rumble |
 | Battery state | Removed | GameInput v3 SDK dropped the battery API (`IGameInputDevice::GetBatteryState`, `GameInputBatteryState`) — no replacement upstream |
 | Device info | Shipped | `GameInputDevice.get_device_info()` (issue #23, device-info half) |
@@ -137,7 +137,7 @@ get_timestamp() -> int
 | `GameInput.poll()` | `IGameInput::GetCurrentReading` | Refreshes cached readings for tracked devices in polling mode. |
 | `GameInput.get_devices()` / `GameInput.get_primary_device()` | `IGameInput::RegisterDeviceCallback` | Build a device cache from the initial enumeration delivered by callback registration and keep it current with subsequent device-status callbacks. |
 | `GameInput.get_current_reading()` | `IGameInput::GetCurrentReading` | Returns a wrapped `IGameInputReading` snapshot for the requested device. |
-| `GameInput.set_vibration()` | `IGameInputDevice::SetRumbleState` | v1 haptics path is controller rumble, including trigger rumble when supported. |
+| `GameInput.set_vibration()` | `IGameInputDevice::SetRumbleState` | v1 haptics path is controller rumble, including trigger rumble when supported; returns `false` when preflight fails or an HRESULT-returning SDK reports a native failure. |
 | `GameInput.stop_haptics()` | `IGameInputDevice::SetRumbleState` | Send a zeroed rumble state. Advanced force-feedback work can later layer on the force-feedback APIs. |
 | `GameInput.enable_device_callbacks()` | `IGameInput::RegisterDeviceCallback`, `IGameInput::RegisterReadingCallback`, `IGameInput::UnregisterCallback` | Toggles the event-driven device and reading feed. |
 | `GameInputDevice` getters | `IGameInputDevice::GetDeviceInfo` | Cache display name, kind mask, and vibration/haptics capability flags from `GameInputDeviceInfo`. |
@@ -156,10 +156,12 @@ get_timestamp() -> int
 
 `GameInputMapper` is a `Node` intended to live in the scene tree. It polls `GameInput` or consumes device updates each frame, then emits synthetic `InputEventAction` events against a configured `GameInputActionMap`.
 
-Use it when gameplay code already depends on `Input`, `InputMap`, and project-defined actions. Skip it when a system needs raw per-device state, custom deadzones, or device-specific UX.
+Use it when gameplay code already depends on `Input`, `InputMap`, and project-defined actions. Skip it when a system needs raw per-device state, custom deadzones, or device-specific UX. `GameInputActionMap` mutations, including contained `GameInputBinding` property edits, emit `changed` so active mappers can immediately release held actions before their index-keyed state becomes stale.
 
 - polls `GameInput` each frame
 - translates readings into `InputEventAction`
+- releases every action it previously held when it stops driving a binding (tree exit, action-map swap or mutation, target-device retarget/loss, or a missing reading)
+- refreshes the native-joypad suppression cache at least once per frame so runtime `InputMap` edits cannot stay stale indefinitely
 - lets game code keep using:
 
 ```gdscript

--- a/tests/godot/gameinput/tests/test_gameinput_core.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_core.gd
@@ -58,6 +58,9 @@ func test_soft_fail_before_init() -> void:
 	var reading = gi.get_current_reading(null)
 	assert_true(reading == null, "get_current_reading(null) returns null before init")
 
+	assert_eq(gi.set_vibration(null, 1.0, 1.0), false,
+			"set_vibration(null) returns false before init")
+
 	gi.poll()
 	assert_true(true, "poll() is safe before initialize()")
 

--- a/tests/godot/gameinput/tests/test_gameinput_mapper_stuck_actions.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_mapper_stuck_actions.gd
@@ -1,0 +1,289 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Regression coverage for mapper-held action release paths.
+##
+## These tests use internal mapper hooks to seed the same per-binding cache that a
+## real GameInput press would populate, keeping the stuck-action sweep runnable on
+## CI hosts without controller hardware.
+
+const IMPOSSIBLE_DEVICE_ID := 9223372036854775807
+
+var _actions_to_cleanup: Array[StringName] = []
+
+
+func after_each() -> void:
+	for action in _actions_to_cleanup:
+		Input.action_release(action)
+		if InputMap.has_action(action):
+			InputMap.erase_action(action)
+	_actions_to_cleanup.clear()
+
+
+func _ensure_action(action: StringName) -> void:
+	if not InputMap.has_action(action):
+		InputMap.add_action(action)
+		_actions_to_cleanup.append(action)
+	Input.action_release(action)
+
+
+func _new_binding(action: StringName, source_value: int = 2):
+	if not ClassDB.class_exists("GameInputBinding"):
+		return null
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("action", action)
+	binding.set("source", source_value)
+	return binding
+
+
+func _new_action_map_with(action: StringName, source_value: int = 2):
+	if not ClassDB.class_exists("GameInputActionMap"):
+		return null
+	var binding = _new_binding(action, source_value)
+	if binding == null:
+		return null
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	action_map.set("bindings", [binding])
+	return action_map
+
+
+func _new_mapper():
+	if not ClassDB.class_exists("GameInputMapper"):
+		return null
+	var mapper = ClassDB.instantiate("GameInputMapper")
+	if not mapper.has_method("_test_mark_binding_pressed"):
+		mapper.free()
+		return null
+	return mapper
+
+
+func _seed_mapper_press(mapper: Node, action: StringName) -> void:
+	mapper.call("_test_mark_binding_pressed", 0)
+	assert_true(Input.is_action_pressed(action), "test hook seeds a held action")
+	assert_eq(mapper.call("get_active_binding_count"), 1,
+			"test hook seeds one active binding")
+
+
+func test_action_map_swap_releases_previous_held_action() -> void:
+	var old_action := &"test_gi_stuck_swap_old"
+	var new_action := &"test_gi_stuck_swap_new"
+	_ensure_action(old_action)
+	_ensure_action(new_action)
+
+	var mapper := _new_mapper()
+	var first := _new_action_map_with(old_action)
+	var second := _new_action_map_with(new_action)
+	if mapper == null or first == null or second == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", first)
+	_seed_mapper_press(mapper, old_action)
+
+	mapper.set("action_map", second)
+	assert_false(Input.is_action_pressed(old_action),
+			"set_action_map() releases actions held by the previous map")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"set_action_map() clears previous pressed-state cache")
+	mapper.free()
+
+
+func test_active_map_mutations_release_held_actions_and_invalidate_cache() -> void:
+	var cases := [
+		{
+			"name": "add_binding",
+			"held": &"test_gi_stuck_add_held",
+			"replacement": &"test_gi_stuck_add_new",
+		},
+		{
+			"name": "set_bindings",
+			"held": &"test_gi_stuck_set_held",
+			"replacement": &"test_gi_stuck_set_new",
+		},
+		{
+			"name": "clear",
+			"held": &"test_gi_stuck_clear_held",
+			"replacement": &"test_gi_stuck_clear_new",
+		},
+	]
+
+	for case in cases:
+		var held: StringName = case["held"]
+		var replacement: StringName = case["replacement"]
+		_ensure_action(held)
+		_ensure_action(replacement)
+
+		var mapper := _new_mapper()
+		var action_map := _new_action_map_with(held)
+		if mapper == null or action_map == null:
+			if mapper != null: mapper.free()
+			pending("GameInputMapper test hooks or action-map classes missing")
+			return
+
+		mapper.set("action_map", action_map)
+		_seed_mapper_press(mapper, held)
+		mapper.call("_test_prime_native_handles_cache", 0, true)
+		assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+				"%s primes native event cache" % case["name"])
+
+		match case["name"]:
+			"add_binding":
+				action_map.add_binding(_new_binding(replacement))
+			"set_bindings":
+				action_map.set("bindings", [_new_binding(replacement)])
+			"clear":
+				action_map.clear()
+
+		assert_false(Input.is_action_pressed(held),
+				"%s releases the action held by the active map" % case["name"])
+		assert_eq(mapper.call("get_active_binding_count"), 0,
+				"%s clears previous pressed-state cache" % case["name"])
+		assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+				"%s invalidates native event cache" % case["name"])
+		mapper.free()
+
+
+func test_binding_property_mutation_releases_held_action() -> void:
+	var held := &"test_gi_stuck_binding_mutation_held"
+	var replacement := &"test_gi_stuck_binding_mutation_new"
+	_ensure_action(held)
+	_ensure_action(replacement)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	var binding = action_map.get_binding(0)
+	mapper.set("action_map", action_map)
+	_seed_mapper_press(mapper, held)
+
+	binding.set("action", replacement)
+	assert_false(Input.is_action_pressed(held),
+			"mutating a binding on the active map releases the old held action")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"binding mutation clears previous pressed-state cache")
+	mapper.free()
+
+
+func test_uninitialized_runtime_early_return_releases_held_action() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var held := &"test_gi_stuck_runtime_unavailable"
+	_ensure_action(held)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	mapper.set("action_map", action_map)
+	_seed_mapper_press(mapper, held)
+
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+
+	assert_false(Input.is_action_pressed(held),
+			"process early-return when GameInput is stopped releases held actions")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"process early-return clears previous pressed-state cache")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_missing_target_device_releases_held_action() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	var held := &"test_gi_stuck_missing_device"
+	_ensure_action(held)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		gi.shutdown()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", IMPOSSIBLE_DEVICE_ID)
+	_seed_mapper_press(mapper, held)
+
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+
+	assert_false(Input.is_action_pressed(held),
+			"missing/disconnected target device releases held actions")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"missing/disconnected target device clears pressed-state cache")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+	gi.shutdown()
+
+
+func test_non_gamepad_target_without_reading_releases_held_action() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	var keyboard_kind: int = ClassDB.class_get_integer_constant("GameInput", "DEVICE_KEYBOARD")
+	var devices: Array = gi.get_devices(keyboard_kind)
+	if devices.is_empty():
+		gi.shutdown()
+		pending("No GameInput keyboard device available to exercise null-reading path")
+		return
+
+	var held := &"test_gi_stuck_null_reading"
+	_ensure_action(held)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		gi.shutdown()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", devices[0].get_device_id())
+	_seed_mapper_press(mapper, held)
+
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+
+	assert_false(Input.is_action_pressed(held),
+			"target with no gamepad reading releases held actions")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"null-reading path clears pressed-state cache")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+	gi.shutdown()


### PR DESCRIPTION
**Audit lane C1 — GameInput stuck-action sweep**

Extract the "release every held action" logic currently living only in `_notification(EXIT_TREE)` into a reusable helper, then invoke it from all four paths where a press can be stranded:

- `set_action_map()` swap (drops `m_prev_pressed`)
- Device disconnect mid-press
- Null reading mid-press
- `set_bindings()` / `add_binding()` / `clear()` on the active map

Plus: invalidate `m_native_handles_cache` on runtime `InputMap` edits; propagate native `SetRumbleState()` failures from `GameInput::set_vibration()`.

## Audit source

Item #8 + Theme T2 in `files/exhaustive-fleet-audit-report.md` (CONSENSUS across all three model families).

## Validation

- `cmake --preset default` ✅
- `cmake --build build --preset debug` ✅
- Targeted GameInput GUT host ✅ (new regression test `test_gameinput_mapper_stuck_actions.gd`)

> **Pre-existing repo issue noted:** `tools\run_all_tests.ps1` orchestrator fails the parse gate on existing samples with typed-symbol issues. Unrelated to this lane.

## Live coverage decision

Live tests skipped (default). No live-write coverage.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
