### PR TITLE
pf-lobby-cleanup: harden lobby/match/party shutdown

### DIFF
--- a/addons/godot_playfab/doc_classes/PlayFabMultiplayer.xml
+++ b/addons/godot_playfab/doc_classes/PlayFabMultiplayer.xml
@@ -4,7 +4,7 @@
 		PlayFab Multiplayer lobby and matchmaking service.
 	</brief_description>
 	<description>
-		Accessed through [code]PlayFab.multiplayer[/code]. All user-owned calls require a signed-in [PlayFabUser] and use that user's native entity handle. Matchmaking completion reports arranged-lobby connection strings but never auto-joins them.
+		Accessed through [code]PlayFab.multiplayer[/code]. All user-owned calls require a signed-in [PlayFabUser] and use that user's native entity handle. Matchmaking completion reports arranged-lobby connection strings but never auto-joins them. Failed lobby create/join completions detach their temporary [PlayFabLobby] wrapper and do not appear in [method get_lobbies]. If finishing lobby or matchmaking state changes fails, [signal multiplayer_error] is emitted and the service resets to an uninitialized state; call [method initialize_async] again before issuing more Multiplayer calls.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -16,7 +16,7 @@
 		<method name="join_arranged_lobby_async"><return type="Signal" /><param index="0" name="user" type="PlayFabUser" /><param index="1" name="connection_string" type="String" /><param index="2" name="config" type="PlayFabLobbyJoinConfig" default="null" /><description>Explicitly joins an arranged lobby using a connection string from a matched ticket.</description></method>
 		<method name="find_lobbies_async"><return type="Signal" /><param index="0" name="user" type="PlayFabUser" /><param index="1" name="search" type="PlayFabLobbySearchConfig" default="null" /><description>Searches lobbies for [param user].</description></method>
 		<method name="create_match_ticket_async"><return type="Signal" /><param index="0" name="user" type="PlayFabUser" /><param index="1" name="config" type="PlayFabMatchmakingTicketConfig" /><description>Creates a matchmaking ticket.</description></method>
-		<method name="get_lobbies" qualifiers="const"><return type="Array" /><description>Returns tracked, connected lobbies.</description></method>
+		<method name="get_lobbies" qualifiers="const"><return type="Array" /><description>Returns tracked, connected lobbies. Failed create/join attempts are removed before their failure signal completes.</description></method>
 		<method name="get_lobby" qualifiers="const"><return type="PlayFabLobby" /><param index="0" name="lobby_id" type="String" /><description>Returns a tracked lobby by id.</description></method>
 		<method name="get_match_tickets" qualifiers="const"><return type="Array" /><description>Returns tracked tickets.</description></method>
 	</methods>
@@ -24,7 +24,7 @@
 	<signals>
 		<signal name="state_changed"><param index="0" name="change" type="PlayFabMultiplayerStateChange" /><description>Aggregate lobby and matchmaking state signal.</description></signal>
 		<signal name="invite_received"><param index="0" name="invite" type="PlayFabLobbyInvite" /><description>Emitted when a lobby invite arrives.</description></signal>
-		<signal name="multiplayer_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Multiplayer dispatch errors.</description></signal>
+		<signal name="multiplayer_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Multiplayer dispatch errors. A [code]lobby_state_finish_failed[/code] or [code]matchmaking_state_finish_failed[/code] result means the native dispatcher was reset and [method initialize_async] must succeed before further Multiplayer use.</description></signal>
 	</signals>
 	<constants></constants>
 </class>

--- a/addons/godot_playfab/doc_classes/PlayFabParty.xml
+++ b/addons/godot_playfab/doc_classes/PlayFabParty.xml
@@ -4,7 +4,7 @@
 		PlayFab Party network and chat service.
 	</brief_description>
 	<description>
-		Accessed through [code]PlayFab.party[/code]. Owns PlayFab Party initialization, network host/join flows, descriptor serialization, and chat-control integration. The title-facing transport object is [PlayFabPartyPeer], assigned to [code]multiplayer.multiplayer_peer[/code] for RPC traffic and exposing peer-id helpers for text chat, mute, and permissions. PlayFab Multiplayer lobbies and matchmaking are handled separately by [PlayFabMultiplayer].
+		Accessed through [code]PlayFab.party[/code]. Owns PlayFab Party initialization, network host/join flows, descriptor serialization, and chat-control integration. The title-facing transport object is [PlayFabPartyPeer], assigned to [code]multiplayer.multiplayer_peer[/code] for RPC traffic and exposing peer-id helpers for text chat, mute, and permissions. PlayFab Multiplayer lobbies and matchmaking are handled separately by [PlayFabMultiplayer]. If [code]PartyManager::FinishProcessingStateChanges[/code] fails, [signal party_error] is emitted, active wrappers are detached, and the service resets to an uninitialized state; call [method initialize_async] before using Party again.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -19,7 +19,7 @@
 	</methods>
 	<members></members>
 	<signals>
-		<signal name="party_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Party dispatch errors.</description></signal>
+		<signal name="party_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Party dispatch errors. A [code]party_state_finish_failed[/code] result means Party was reset and must be initialized again before further use.</description></signal>
 	</signals>
 	<constants>
 		<constant name="DIRECT_PEER_CONNECTIVITY_NONE" value="0" enum="DirectPeerConnectivity">No direct peer connectivity; all traffic relays through PlayFab Party. This is the default and is always valid by itself.</constant>

--- a/addons/godot_playfab/src/playfab_multiplayer.cpp
+++ b/addons/godot_playfab/src/playfab_multiplayer.cpp
@@ -914,12 +914,77 @@ void PlayFabMultiplayer::_track_lobby(const Ref<PlayFabLobby> &p_lobby) {
     }
 }
 
+void PlayFabMultiplayer::_untrack_lobby(const Ref<PlayFabLobby> &p_lobby) {
+    if (!p_lobby.is_valid()) {
+        return;
+    }
+    m_lobbies.erase(std::remove(m_lobbies.begin(), m_lobbies.end(), p_lobby), m_lobbies.end());
+}
+
 void PlayFabMultiplayer::_track_ticket(const Ref<PlayFabMatchTicket> &p_ticket) {
     if (!p_ticket.is_valid() || !p_ticket->get_native_handle()) {
         return;
     }
     if (_find_ticket(p_ticket->get_native_handle()).is_null()) {
         m_tickets.push_back(p_ticket);
+    }
+}
+
+void PlayFabMultiplayer::_terminate_multiplayer_queue() {
+    if (m_multiplayer_queue == nullptr) {
+        return;
+    }
+
+    const HRESULT terminate_hr = XTaskQueueTerminate(m_multiplayer_queue, true, nullptr, nullptr);
+    if (FAILED(terminate_hr)) {
+        WARN_PRINT(vformat("PlayFabMultiplayer: XTaskQueueTerminate(wait=true) failed during shutdown/reset: %s", PlayFabResult::format_hresult(terminate_hr)));
+    }
+    XTaskQueueCloseHandle(m_multiplayer_queue);
+    m_multiplayer_queue = nullptr;
+}
+
+void PlayFabMultiplayer::_reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result) {
+    Ref<PlayFabResult> result = p_result;
+    if (result.is_null()) {
+        result = PlayFabResult::error_result(E_FAIL, "state_changes_finish_failed", "PlayFab Multiplayer failed to finish state change processing.");
+    }
+
+    m_initialized = false;
+    ++m_dispatch_generation;
+
+    if (m_handle != nullptr) {
+        PFMultiplayerUninitialize(m_handle);
+        m_handle = nullptr;
+    }
+    _terminate_multiplayer_queue();
+
+    for (const Ref<PlayFabLobby> &lobby : m_lobbies) {
+        if (lobby.is_valid()) {
+            lobby->mark_disconnected();
+        }
+    }
+    m_lobbies.clear();
+
+    for (const Ref<PlayFabMatchTicket> &ticket : m_tickets) {
+        if (ticket.is_valid()) {
+            ticket->mark_destroyed();
+        }
+    }
+    m_tickets.clear();
+
+    std::vector<PendingOperation *> pending_operations;
+    pending_operations.swap(m_pending_operations);
+
+    ERR_PRINT(vformat(
+            "PlayFabMultiplayer: FinishStateChanges failed with %s; Multiplayer was reset. Call PlayFab.multiplayer.initialize_async() before using it again.",
+            PlayFabResult::format_hresult(static_cast<HRESULT>(result->get_hresult()))));
+    emit_signal("multiplayer_error", result);
+
+    for (PendingOperation *operation : pending_operations) {
+        if (operation != nullptr && operation->pending_signal.is_valid()) {
+            operation->pending_signal->complete(result);
+        }
+        delete operation;
     }
 }
 
@@ -958,6 +1023,7 @@ Signal PlayFabMultiplayer::initialize_async(const Ref<PlayFabMultiplayerConfig> 
 
     m_initialized = true;
     m_shutting_down = false;
+    ++m_dispatch_generation;
     pending_signal->complete_deferred(PlayFabResult::ok_result());
     return pending_signal->get_completed_signal();
 }
@@ -1035,12 +1101,7 @@ void PlayFabMultiplayer::shutdown() {
         m_handle = nullptr;
     }
 
-    if (m_multiplayer_queue != nullptr) {
-        HRESULT terminate_hr = XTaskQueueTerminate(m_multiplayer_queue, false, nullptr, nullptr);
-        (void)terminate_hr;
-        XTaskQueueCloseHandle(m_multiplayer_queue);
-        m_multiplayer_queue = nullptr;
-    }
+    _terminate_multiplayer_queue();
 
     for (const Ref<PlayFabLobby> &lobby : m_lobbies) {
         if (lobby.is_valid()) {
@@ -1053,6 +1114,7 @@ void PlayFabMultiplayer::shutdown() {
     m_initialized = false;
     m_processing_state_changes = false;
     m_shutting_down = false;
+    ++m_dispatch_generation;
 }
 
 int PlayFabMultiplayer::dispatch() {
@@ -1067,9 +1129,12 @@ int PlayFabMultiplayer::dispatch() {
         }
     }
 
+    const uint64_t dispatch_generation = m_dispatch_generation;
     m_processing_state_changes = true;
     dispatched += _dispatch_lobby_state_changes();
-    dispatched += _dispatch_matchmaking_state_changes();
+    if (m_dispatch_generation == dispatch_generation && m_initialized && m_handle != nullptr) {
+        dispatched += _dispatch_matchmaking_state_changes();
+    }
     m_processing_state_changes = false;
     return dispatched;
 }
@@ -1676,53 +1741,68 @@ int PlayFabMultiplayer::_dispatch_lobby_state_changes() {
         switch (state_change->stateChangeType) {
             case PFLobbyStateChangeType::CreateAndJoinLobbyCompleted: {
                 const auto *change = static_cast<const PFLobbyCreateAndJoinLobbyCompletedStateChange *>(state_change);
+                const bool succeeded = SUCCEEDED(change->result);
                 PendingOperation *operation = static_cast<PendingOperation *>(change->asyncContext);
                 Ref<PlayFabLobby> lobby = operation != nullptr ? operation->lobby : _find_lobby(change->lobby);
-                if (lobby.is_valid() && lobby->get_native_handle() == nullptr) {
+                if (lobby.is_valid() && lobby->get_native_handle() == nullptr && change->lobby != nullptr) {
                     lobby->adopt_handle(change->lobby, operation != nullptr ? operation->user : Ref<PlayFabUser>());
                     _track_lobby(lobby);
                 }
-                if (lobby.is_valid()) {
+                if (lobby.is_valid() && succeeded) {
                     lobby->refresh_snapshot();
                 }
-                Ref<PlayFabResult> result = SUCCEEDED(change->result) ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby creation failed.", "lobby_create_failed");
+                Ref<PlayFabResult> result = succeeded ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby creation failed.", "lobby_create_failed");
+                if (!succeeded && lobby.is_valid()) {
+                    _untrack_lobby(lobby);
+                    lobby->mark_disconnected();
+                }
                 _complete_pending_operation(operation, result);
                 _emit_lobby_change(PlayFabLobby::PROPERTIES_UPDATED, lobby, result);
             } break;
             case PFLobbyStateChangeType::JoinLobbyCompleted: {
                 const auto *change = static_cast<const PFLobbyJoinLobbyCompletedStateChange *>(state_change);
+                const bool succeeded = SUCCEEDED(change->result);
                 PendingOperation *operation = static_cast<PendingOperation *>(change->asyncContext);
                 Ref<PlayFabLobby> lobby = operation != nullptr ? operation->lobby : _find_lobby(change->lobby);
-                if (lobby.is_valid() && lobby->get_native_handle() == nullptr) {
+                if (lobby.is_valid() && lobby->get_native_handle() == nullptr && change->lobby != nullptr) {
                     lobby->adopt_handle(change->lobby, operation != nullptr ? operation->user : Ref<PlayFabUser>());
                     _track_lobby(lobby);
                 }
-                if (lobby.is_valid()) {
+                if (lobby.is_valid() && succeeded) {
                     lobby->refresh_snapshot();
                 }
-                Ref<PlayFabResult> result = SUCCEEDED(change->result) ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby join failed.", "lobby_join_failed");
+                Ref<PlayFabResult> result = succeeded ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby join failed.", "lobby_join_failed");
                 Ref<PlayFabLobbyMember> joined_member;
-                if (lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
+                if (succeeded && lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
                     joined_member = lobby->find_member(operation->user->get_entity_key());
+                }
+                if (!succeeded && lobby.is_valid()) {
+                    _untrack_lobby(lobby);
+                    lobby->mark_disconnected();
                 }
                 _complete_pending_operation(operation, result);
                 _emit_lobby_change(PlayFabLobby::MEMBER_ADDED, lobby, result, joined_member);
             } break;
             case PFLobbyStateChangeType::JoinArrangedLobbyCompleted: {
                 const auto *change = static_cast<const PFLobbyJoinArrangedLobbyCompletedStateChange *>(state_change);
+                const bool succeeded = SUCCEEDED(change->result);
                 PendingOperation *operation = static_cast<PendingOperation *>(change->asyncContext);
                 Ref<PlayFabLobby> lobby = operation != nullptr ? operation->lobby : _find_lobby(change->lobby);
-                if (lobby.is_valid() && lobby->get_native_handle() == nullptr) {
+                if (lobby.is_valid() && lobby->get_native_handle() == nullptr && change->lobby != nullptr) {
                     lobby->adopt_handle(change->lobby, operation != nullptr ? operation->user : Ref<PlayFabUser>());
                     _track_lobby(lobby);
                 }
-                if (lobby.is_valid()) {
+                if (lobby.is_valid() && succeeded) {
                     lobby->refresh_snapshot();
                 }
-                Ref<PlayFabResult> result = SUCCEEDED(change->result) ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab arranged lobby join failed.", "arranged_lobby_join_failed");
+                Ref<PlayFabResult> result = succeeded ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab arranged lobby join failed.", "arranged_lobby_join_failed");
                 Ref<PlayFabLobbyMember> joined_member;
-                if (lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
+                if (succeeded && lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
                     joined_member = lobby->find_member(operation->user->get_entity_key());
+                }
+                if (!succeeded && lobby.is_valid()) {
+                    _untrack_lobby(lobby);
+                    lobby->mark_disconnected();
                 }
                 _complete_pending_operation(operation, result);
                 _emit_lobby_change(PlayFabLobby::MEMBER_ADDED, lobby, result, joined_member);
@@ -1887,9 +1967,7 @@ int PlayFabMultiplayer::_dispatch_lobby_state_changes() {
     HRESULT finish_hr = PFMultiplayerFinishProcessingLobbyStateChanges(m_handle, state_change_count, state_changes);
     if (FAILED(finish_hr)) {
         Ref<PlayFabResult> result = multiplayer_hresult_error(finish_hr, "Failed to finish PlayFab lobby state changes.", "lobby_state_finish_failed");
-        if (_get_runtime() != nullptr) {
-        }
-        emit_signal("multiplayer_error", result);
+        _reset_after_state_change_finish_failure(result);
     }
     return static_cast<int>(state_change_count);
 }
@@ -1966,9 +2044,8 @@ int PlayFabMultiplayer::_dispatch_matchmaking_state_changes() {
     HRESULT finish_hr = PFMultiplayerFinishProcessingMatchmakingStateChanges(m_handle, state_change_count, state_changes);
     if (FAILED(finish_hr)) {
         Ref<PlayFabResult> result = multiplayer_hresult_error(finish_hr, "Failed to finish PlayFab matchmaking state changes.", "matchmaking_state_finish_failed");
-        if (_get_runtime() != nullptr) {
-        }
-        emit_signal("multiplayer_error", result);
+        _reset_after_state_change_finish_failure(result);
+        return static_cast<int>(state_change_count);
     }
 
     for (const Ref<PlayFabMatchTicket> &ticket : terminal_tickets) {

--- a/addons/godot_playfab/src/playfab_multiplayer.h
+++ b/addons/godot_playfab/src/playfab_multiplayer.h
@@ -6,6 +6,7 @@
 #endif
 #include <windows.h>
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -431,6 +432,7 @@ private:
     bool m_initialized = false;
     bool m_processing_state_changes = false;
     bool m_shutting_down = false;
+    uint64_t m_dispatch_generation = 0;
     std::vector<Ref<PlayFabLobby>> m_lobbies;
     std::vector<Ref<PlayFabMatchTicket>> m_tickets;
     std::vector<PendingOperation *> m_pending_operations;
@@ -445,7 +447,10 @@ private:
     Ref<PlayFabLobby> _find_lobby(PFLobbyHandle p_lobby_handle) const;
     Ref<PlayFabMatchTicket> _find_ticket(PFMatchmakingTicketHandle p_ticket_handle) const;
     void _track_lobby(const Ref<PlayFabLobby> &p_lobby);
+    void _untrack_lobby(const Ref<PlayFabLobby> &p_lobby);
     void _track_ticket(const Ref<PlayFabMatchTicket> &p_ticket);
+    void _terminate_multiplayer_queue();
+    void _reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result);
     int _dispatch_lobby_state_changes();
     int _dispatch_matchmaking_state_changes();
     void _emit_lobby_change(

--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -34,6 +34,7 @@ constexpr const char *PARTY_PEER_NOT_CONNECTED = "party_peer_not_connected";
 constexpr const char *PARTY_RESOURCE_NOT_READY = "party_resource_not_ready";
 constexpr const char *PARTY_CHAT_CONTROL_CREATE_FAILED = "party_chat_control_create_failed";
 constexpr const char *PARTY_CHAT_PERMISSION_FAILED = "party_chat_permission_failed";
+constexpr const char *PARTY_STATE_FINISH_FAILED = "party_state_finish_failed";
 
 // Reserved transport-control packet protocol marker. The first byte of every
 // envelope identifies the packet kind; gameplay packets are forwarded to
@@ -1608,6 +1609,49 @@ void PlayFabParty::_release_all_local_users() {
     m_local_users.clear();
 }
 
+void PlayFabParty::_reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result) {
+    Ref<PlayFabResult> result = p_result;
+    if (result.is_null()) {
+        result = PlayFabResult::error_result(E_FAIL, PARTY_STATE_FINISH_FAILED, "PartyManager::FinishProcessingStateChanges failed.");
+    }
+
+    if (m_initialized) {
+        Party::PartyManager::GetSingleton().Cleanup();
+        m_initialized = false;
+    }
+    m_local_users.clear();
+    m_orphan_chat_controls.clear();
+    if (m_chat.is_valid()) {
+        m_chat->clear();
+    }
+
+    std::vector<Ref<PlayFabPartyNetwork>> networks;
+    networks.swap(m_networks);
+    for (const Ref<PlayFabPartyNetwork> &network : networks) {
+        if (!network.is_valid()) {
+            continue;
+        }
+        network->set_state_value(NETWORK_STATE_FAILED);
+        network->detach_native();
+        _emit_network_state(network, NETWORK_CHANGE_ERROR, 0, result, "PlayFab Party state processing failed; PlayFab.party was reset.");
+        network->set_owner(nullptr);
+    }
+
+    std::vector<PendingOperation *> pending_operations;
+    pending_operations.swap(m_pending_operations);
+    for (PendingOperation *operation : pending_operations) {
+        if (operation != nullptr && operation->pending_signal.is_valid()) {
+            operation->pending_signal->complete(result);
+        }
+        delete operation;
+    }
+
+    ERR_PRINT("PlayFab.party: FinishProcessingStateChanges failed; Party was reset. Call PlayFab.party.initialize_async() before using it again.");
+    emit_signal("party_error", result);
+    m_processing_state_changes = false;
+    m_shutting_down = false;
+}
+
 PlayFabParty::PendingOperation *PlayFabParty::_create_pending(int32_t p_kind) {
     PendingOperation *operation = new PendingOperation;
     operation->kind = p_kind;
@@ -1925,7 +1969,12 @@ int PlayFabParty::_pump_state_changes() {
         ++processed;
     }
 
-    Party::PartyManager::GetSingleton().FinishProcessingStateChanges(change_count, changes);
+    err = Party::PartyManager::GetSingleton().FinishProcessingStateChanges(change_count, changes);
+    if (PARTY_FAILED(err)) {
+        Ref<PlayFabResult> result = _party_error_result(err, PARTY_STATE_FINISH_FAILED, "PartyManager::FinishProcessingStateChanges");
+        _reset_after_state_change_finish_failure(result);
+        return processed;
+    }
     m_processing_state_changes = false;
     return processed;
 }

--- a/addons/godot_playfab/src/playfab_party.h
+++ b/addons/godot_playfab/src/playfab_party.h
@@ -590,6 +590,7 @@ private:
     // batch). Callers should bail out when this returns true to avoid touching
     // the dead native network handle.
     bool _abort_join_op_if_network_dead(PendingOperation *p_operation);
+    void _reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result);
 
     int _pump_state_changes();
     void _process_state_change(const Party::PartyStateChange *p_change);

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -121,7 +121,7 @@ if title_data_result.ok:
 
 Game Saves still requires an Xbox-backed PlayFab session because the PlayFab Game Saves C API needs a local user handle. Use `PlayFab.users.sign_in_with_xuser_async(GDK.users.get_primary_user())` before calling `PlayFab.game_saves`; custom-ID users return `xbox_user_required` from Game Saves methods.
 
-Lobby and matchmaking calls use the signed-in user's native PlayFab entity handle. Match tickets do not auto-join arranged lobbies; title code decides whether to pass the reported connection string to `join_arranged_lobby_async`.
+Lobby and matchmaking calls use the signed-in user's native PlayFab entity handle. Match tickets do not auto-join arranged lobbies; title code decides whether to pass the reported connection string to `join_arranged_lobby_async`. Failed lobby create/join completions are removed from `PlayFab.multiplayer.get_lobbies()` before their failure result is surfaced. If the native Multiplayer or Party state-change finish call fails, the addon emits `multiplayer_error` or `party_error`, resets that service to an uninitialized state, and requires a fresh `initialize_async()` before more calls.
 
 ```gdscript
 var mp_result = await PlayFab.multiplayer.initialize_async()

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -170,6 +170,10 @@ The MLP `PlayFab.multiplayer` service supports PlayFab Multiplayer initializatio
 
 Match tickets report `match_id` and `arranged_lobby_connection_string` through `PlayFabMatchTicketStateChange`; title code decides whether to call `join_arranged_lobby_async(...)`. The addon does not automatically join arranged lobbies.
 
+Failed lobby create/join completions are terminal for their temporary wrapper: the wrapper is removed from `PlayFab.multiplayer.get_lobbies()` and marked disconnected before the failure result is surfaced. If `PFLobbyFinishStateChanges` or `PFMatchmakingFinishStateChanges` fails, the service emits `multiplayer_error`, tears down native Multiplayer state (including the task queue), marks wrappers detached, and returns to `is_initialized() == false`; titles must call `initialize_async()` before issuing more Multiplayer calls.
+
+`PlayFab.party` follows the same fail-closed recovery contract for `PartyManager::FinishProcessingStateChanges`: it emits `party_error`, detaches active network/chat wrappers, resets `PartyManager`, and requires `initialize_async()` before further Party calls.
+
 ## Samples
 
 - `sample\playfab_demo` (now removed) demonstrated settings-backed init plus manual PlayFab sign-in

--- a/tests/godot/playfab/tests/test_multiplayer_lobby_live.gd
+++ b/tests/godot/playfab/tests/test_multiplayer_lobby_live.gd
@@ -145,6 +145,63 @@ func test_lobby_shutdown_without_leave_does_not_emit_null_member() -> void:
 	# The lobby reference is now detached; no further teardown needed.
 
 
+func test_failed_lobby_join_does_not_leave_tracked_wrapper() -> void:
+	var session = await _begin_multiplayer_session()
+	var playfab_user = session.get("playfab_user")
+	if playfab_user == null:
+		return
+
+	var playfab: Object = session["playfab"]
+	var multiplayer: Object = session["multiplayer"]
+
+	var lobby_config = instantiate_class("PlayFabLobbyConfig")
+	if lobby_config == null:
+		_finish_session(playfab, null)
+		return
+	lobby_config.max_players = 2
+	lobby_config.access_policy = get_class_constant("PlayFabLobbyConfig", "ACCESS_POLICY_PRIVATE")
+
+	var create_result = await await_completion(multiplayer.create_lobby_async(playfab_user, lobby_config), _DEFAULT_OP_TIMEOUT_MSEC)
+	if create_result == null or not create_result.ok:
+		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % (create_result.message if create_result != null else "null result"))
+		_finish_session(playfab, null)
+		return
+
+	var lobby: Object = create_result.data
+	if lobby == null:
+		_finish_session(playfab, null)
+		return
+
+	var stale_connection_string := str(lobby.get_connection_string())
+	var leave_result = await await_completion(lobby.leave_async(), _DEFAULT_OP_TIMEOUT_MSEC)
+	if leave_result == null or not leave_result.ok:
+		pending("PlayFabLobby.leave_async failed before stale-join regression check: %s" % (leave_result.message if leave_result != null else "null result"))
+		_finish_session(playfab, null)
+		return
+	await advance_process_frames(_STATE_PUMP_FRAMES)
+
+	var before_count := multiplayer.get_lobbies().size()
+	var join_config = instantiate_class("PlayFabLobbyJoinConfig")
+	var join_result = await await_completion(multiplayer.join_lobby_async(playfab_user, stale_connection_string, join_config), _DEFAULT_OP_TIMEOUT_MSEC)
+	if join_result == null:
+		pending("PlayFab.multiplayer.join_lobby_async(stale_connection_string) timed out; cannot assert failure cleanup.")
+		_finish_session(playfab, null)
+		return
+	if join_result.ok:
+		var joined_lobby = join_result.data
+		if joined_lobby != null:
+			await await_completion(joined_lobby.leave_async(), _DEFAULT_OP_TIMEOUT_MSEC)
+		pending("PlayFab service accepted a stale lobby connection string; failure-cleanup path was not exercised.")
+		_finish_session(playfab, null)
+		return
+
+	await advance_process_frames(_STATE_PUMP_FRAMES)
+	assert_eq(multiplayer.get_lobbies().size(), before_count,
+			"failed join completion does not leave its PlayFabLobby wrapper tracked")
+
+	_finish_session(playfab, null)
+
+
 # ── Live setup helpers ────────────────────────────────────────────────────
 
 func _begin_multiplayer_session() -> Dictionary:


### PR DESCRIPTION
**Audit lane A3 — PlayFab lobby/match/party cleanup hardening**

Three related hardening fixes around PlayFab Multiplayer/Party shutdown:

- Mirror the matchmaking-ticket cleanup pattern on every `*Completed` failure branch so `m_lobbies` is not left with a stranded entry after a forced-failure create/join.
- Switch shutdown `XTaskQueueTerminate(wait=false)` to `wait=true` so the dispatch loop drains before the queue handle is closed.
- Add a recoverable-state branch around `Finish*StateChanges` failures so the dispatch loop is not left in an undefined state.

## Audit source

Items #10, F-08, F-09 in `files/exhaustive-fleet-audit-report.md`.

## Validation

- `cmake --preset default` ✅
- `cmake --build build --preset debug` ✅
- C++ doctest: 8/8 ✅
- Targeted PlayFab GUT: 53 tests, 1635 asserts ✅

> **Pre-existing repo issue noted:** `tools\run_all_tests.ps1` orchestrator parse-gate failures on samples are unrelated to this lane.

## Live coverage decision

Live tests skipped (default).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
