### PR TITLE
pf-runtime-lifecycle: treat XGameRuntime init/uninit as process-lifetime

### DIFF
--- a/addons/godot_playfab/doc_classes/PlayFab.xml
+++ b/addons/godot_playfab/doc_classes/PlayFab.xml
@@ -4,20 +4,20 @@
 		Root singleton for PlayFab services integration.
 	</brief_description>
 	<description>
-		PlayFab is the engine singleton that owns the PlayFab runtime, shared async dispatch, user sign-in, Game Saves, leaderboards, Multiplayer lobby/matchmaking, and client-safe PlayFab service surfaces. Configure [code]playfab/runtime/title_id[/code] in Project Settings before calling [method initialize]. By default the addon pumps completions automatically each process frame through [code]playfab/runtime/embed_dispatch[/code]; call [method dispatch] manually when that setting is disabled.
+		PlayFab is the engine singleton that owns the PlayFab runtime, shared async dispatch, user sign-in, Game Saves, leaderboards, Multiplayer lobby/matchmaking, and client-safe PlayFab service surfaces. Configure [code]playfab/runtime/title_id[/code] in Project Settings before calling [method initialize]. By default the addon pumps completions automatically each process frame through [code]playfab/runtime/embed_dispatch[/code]; call [method dispatch] manually when that setting is disabled. [method initialize] and [method shutdown] can be cycled to re-arm PlayFab Core, Services, Game Save Files, and the task queue; the underlying XGameRuntime reference is process-lifetime state released once when the extension singleton is torn down.
 	</description>
 	<tutorials></tutorials>
 	<methods>
 		<method name="initialize">
 			<return type="PlayFabResult" />
 			<description>
-				Initializes the PlayFab runtime using [code]playfab/runtime/title_id[/code] and [code]playfab/runtime/endpoint[/code] from Project Settings. Returns a [PlayFabResult] describing success or failure.
+				Initializes PlayFab Core, Services, Game Save Files, and the shared task queue using [code]playfab/runtime/title_id[/code] and [code]playfab/runtime/endpoint[/code] from Project Settings. Returns a [PlayFabResult] describing success or failure. The first successful XGameRuntime initialization also acquires this addon's process-lifetime XGameRuntime reference.
 			</description>
 		</method>
 		<method name="shutdown">
 			<return type="void" />
 			<description>
-				Shuts down the PlayFab runtime and clears cached user state.
+				Shuts down PlayFab Core, Services, Game Save Files, the shared task queue, and cached user state. This is safe to call before another [method initialize]; it does not release the process-lifetime XGameRuntime reference.
 			</description>
 		</method>
 		<method name="is_available" qualifiers="const">

--- a/addons/godot_playfab/src/playfab_runtime.cpp
+++ b/addons/godot_playfab/src/playfab_runtime.cpp
@@ -33,6 +33,14 @@ PlayFabRuntime::PlayFabRuntime() {
 
 PlayFabRuntime::~PlayFabRuntime() {
     shutdown();
+
+    // XGameRuntime is process-lifetime state. Keep initialize()/shutdown()
+    // re-armable and release this addon's runtime reference only when the
+    // extension singleton is torn down.
+    if (m_xgame_runtime_initialized) {
+        XGameRuntimeUninitialize();
+        m_xgame_runtime_initialized = false;
+    }
 }
 
 Ref<PlayFabResult> PlayFabRuntime::initialize() {
@@ -63,25 +71,24 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
         endpoint = "https://" + title_id + ".playfabapi.com";
     }
 
-    bool xgame_runtime_initialized = false;
     bool playfab_core_initialized = false;
     bool playfab_services_initialized = false;
     bool game_save_files_initialized = false;
 
-    HRESULT hr = XGameRuntimeInitialize();
-    if (FAILED(hr)) {
-        Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize the Gaming Runtime.", "runtime_initialize_failed");
-        return result;
+    if (!m_xgame_runtime_initialized) {
+        HRESULT runtime_hr = XGameRuntimeInitialize();
+        if (FAILED(runtime_hr)) {
+            Ref<PlayFabResult> result = PlayFabResult::hresult_error(runtime_hr, "Failed to initialize the Gaming Runtime.", "runtime_initialize_failed");
+            return result;
+        }
+        m_xgame_runtime_initialized = true;
     }
-    xgame_runtime_initialized = true;
 
-    hr = XTaskQueueCreate(
+    HRESULT hr = XTaskQueueCreate(
             XTaskQueueDispatchMode::ThreadPool,
             XTaskQueueDispatchMode::Manual,
             &m_task_queue);
     if (FAILED(hr)) {
-        XGameRuntimeUninitialize();
-
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to create the shared XTaskQueue.", "task_queue_create_failed");
         return result;
     }
@@ -90,7 +97,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
     if (FAILED(hr)) {
         XTaskQueueCloseHandle(m_task_queue);
         m_task_queue = nullptr;
-        XGameRuntimeUninitialize();
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize PlayFab Core.", "playfab_core_initialize_failed");
         return result;
@@ -104,7 +110,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
 
         XTaskQueueCloseHandle(m_task_queue);
         m_task_queue = nullptr;
-        XGameRuntimeUninitialize();
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize PlayFab Services.", "playfab_services_initialize_failed");
         return result;
@@ -129,7 +134,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
 
         XTaskQueueCloseHandle(m_task_queue);
         m_task_queue = nullptr;
-        XGameRuntimeUninitialize();
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize PlayFab Game Save Files.", "playfab_gamesave_initialize_failed");
         return result;
@@ -163,9 +167,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
         m_task_queue = nullptr;
         m_title_id = "";
         m_endpoint = "";
-        if (xgame_runtime_initialized) {
-            XGameRuntimeUninitialize();
-        }
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to create the PlayFab service configuration.", "service_config_create_failed");
         return result;
@@ -229,7 +230,9 @@ void PlayFabRuntime::shutdown() {
     }
     m_active_pending_signals.clear();
 
-    XGameRuntimeUninitialize();
+    // XGameRuntimeUninitialize intentionally does not run here. It is paired
+    // with the first successful XGameRuntimeInitialize and released once from
+    // ~PlayFabRuntime() during extension teardown.
 
     m_initialized = false;
     m_shutting_down = false;

--- a/addons/godot_playfab/src/playfab_runtime.h
+++ b/addons/godot_playfab/src/playfab_runtime.h
@@ -26,6 +26,7 @@ class PlayFabResult;
 class PlayFabRuntime {
     bool m_initialized = false;
     bool m_shutting_down = false;
+    bool m_xgame_runtime_initialized = false;
     bool m_game_save_files_initialized = false;
     XTaskQueueHandle m_task_queue = nullptr;
     PFServiceConfigHandle m_service_config_handle = nullptr;

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -9,7 +9,7 @@ This is the landing page for the `godot_playfab` docs set.
 ### Implemented now
 
 - root singleton registration through `PlayFab`
-- shared PlayFab runtime lifecycle through `XGameRuntimeInitialize`, `PFInitialize`, and `PFServicesInitialize`
+- shared PlayFab runtime lifecycle with a process-lifetime `XGameRuntimeInitialize` reference and re-armable `PFInitialize` / `PFServicesInitialize` cycles
 - shared Game Saves runtime lifecycle through `PFGameSaveFilesInitialize` and `PFGameSaveFilesUninitializeAsync`
 - default auto-dispatch through `playfab/runtime/embed_dispatch`
 - project-settings-backed PlayFab config through `playfab/runtime/title_id` and `playfab/runtime/endpoint`
@@ -55,6 +55,8 @@ The PlayFab runtime reads these settings from Project Settings:
 - `playfab/runtime/embed_dispatch` — defaults to `true`; disable only when you want to pump completions manually with `PlayFab.dispatch()`
 
 The `GodotPlayFab` editor plugin installs the `PlayFabBootstrap` autoload at `res://addons/godot_playfab/runtime/playfab_bootstrap.gd` when enabled, mirroring the `GDKBootstrap` pattern. Disabling the plugin removes the autoload again.
+
+`PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled when returning to a title screen or changing test fixtures: shutdown tears down PlayFab Core, Services, Game Save Files, the shared task queue, and cached users, then a later initialize recreates them. The underlying GDK `XGameRuntimeInitialize` reference is process-lifetime state, so the first successful runtime initialization acquires it and extension teardown releases it once. This mirrors `godot_gdk` and lets both addons coexist safely; each addon owns exactly one matching GDK runtime reference.
 
 ## Public GDScript surface
 

--- a/docs/playfab/prerequisites.md
+++ b/docs/playfab/prerequisites.md
@@ -51,6 +51,11 @@ runtime/initialize_on_startup=true
 `playfab/runtime/endpoint` may be left blank. When blank, the addon
 derives `https://<titleid>.playfabapi.com` from the Title ID.
 
+`PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled in tools and
+runtime flows. The PlayFab Core/Services/Game Save state and task queue are
+recreated on each initialize, while the GDK `XGameRuntimeInitialize` reference
+is held for the process lifetime and released once when the extension unloads.
+
 > **`PlayFab.initialize()` failing with `title_id_required`** indicates
 > the setting is empty at runtime. See
 > [Troubleshooting → `PlayFab.initialize()` fails with `title_id_required`](../troubleshooting.md#playfabinitialize-fails-with-title_id_required).

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -21,7 +21,7 @@ Lobby/matchmaking and Party design work are tracked separately in `spec\gdext-pl
 
 | Domain | Included | Notes |
 | --- | --- | --- |
-| Runtime init/shutdown | Yes | `XGameRuntimeInitialize`, PlayFab init, shared queue |
+| Runtime init/shutdown | Yes | Process-lifetime `XGameRuntimeInitialize` reference, re-armable PlayFab init/shutdown, shared queue |
 | Manual sign-in | Yes | `GDKUser` object and custom-ID entry points |
 | Cached user sessions | Yes | `PlayFabUser` keyed by local Xbox user id or custom id |
 | Game Saves | Yes | add/sync, upload, folder/quota/cloud-state queries |
@@ -77,6 +77,10 @@ The runtime reads these Project Settings keys:
 - `playfab/runtime/embed_dispatch`
 
 The endpoint setting is optional. When blank, the runtime derives the default endpoint from the title id.
+
+## Runtime lifecycle
+
+`PlayFab.initialize()` acquires this addon's GDK `XGameRuntimeInitialize` reference the first time the runtime initializes successfully and keeps it for the process lifetime. `PlayFab.shutdown()` tears down PlayFab-owned state (`PFGameSaveFiles`, service config, `PFServices`, `PFInitialize`, pending signals, cached users, and the shared task queue) but deliberately does not call `XGameRuntimeUninitialize`; the matching GDK runtime release happens once during extension teardown. This mirrors the `godot_gdk` singleton/runtime pattern and allows titles or tests to cycle `initialize() -> shutdown() -> initialize()` without racing the process-wide Gaming Runtime, even when both addons are loaded.
 
 ## Async model
 
@@ -181,7 +185,7 @@ Match tickets report `match_id` and `arranged_lobby_connection_string` through `
 
 - `tests\godot\playfab\tests\` is the PlayFab contract suite.
 - It should keep the root singleton, settings registration, deterministic
-  validation errors, API service contracts, Multiplayer class contracts, custom-ID sign-in, and optional live smoke flows aligned
+  validation errors, runtime lifecycle re-arm behavior, API service contracts, Multiplayer class contracts, custom-ID sign-in, and optional live smoke flows aligned
   with the shipped addon behavior.
 - `tools\configure_playfab_test_title.ps1` prepares the current sandbox title (`10D176` by default) for live coverage by ensuring the custom-ID account, Multiplayer worker accounts, a two-player matchmaking queue with a `run_id` equality rule, leaderboard/statistic definitions, and API-service fixtures used by the tests exist. It reads the developer secret from `PLAYFAB_DEVELOPER_SECRET_KEY` and never forwards the secret to Godot child processes.
 - `tools\run_all_tests.ps1 -Live -Hosts tests\godot\playfab -PlayFabTitleId "10D176" -PlayFabCustomId "godot-gdk-ext-live-smoke" -PlayFabMatchmakingQueue "godot_gdk_ext_live_smoke_queue"` also runs the opt-in PlayFab Multiplayer multi-client lobby orchestration plus matchmaking create/cancel, two-player match completion, explicit arranged-lobby join, and arranged-lobby cleanup coverage.

--- a/tests/godot/playfab/tests/test_core.gd
+++ b/tests/godot/playfab/tests/test_core.gd
@@ -34,6 +34,7 @@ const PLAYFAB_ROOT_METHODS := [
 ]
 
 const PLAYFAB_ROOT_SIGNALS := ["initialized", "shutdown_completed"]
+const REARM_TEST_TITLE_ID := "00000"
 
 const REGISTERED_CLASSES := [
 	"PlayFab",
@@ -83,6 +84,18 @@ const REGISTERED_CLASSES := [
 	"PlayFabTitleData",
 	"PlayFabResult",
 ]
+
+
+func _restore_playfab_runtime_settings(original_title_id, original_endpoint) -> void:
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, original_title_id)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, original_endpoint)
+
+
+func _disconnect_playfab_lifecycle_handlers(playfab, initialized_handler: Callable, shutdown_handler: Callable) -> void:
+	if playfab.initialized.is_connected(initialized_handler):
+		playfab.initialized.disconnect(initialized_handler)
+	if playfab.shutdown_completed.is_connected(shutdown_handler):
+		playfab.shutdown_completed.disconnect(shutdown_handler)
 
 
 func test_singleton_availability() -> void:
@@ -211,3 +224,54 @@ func test_initialize_rejects_blank_title_id() -> void:
 
 	if playfab.initialized.is_connected(initialized_handler):
 		playfab.initialized.disconnect(initialized_handler)
+
+
+func test_initialize_shutdown_rearms_runtime_lifecycle() -> void:
+	if pending_unless_playfab_available():
+		return
+	var playfab = get_playfab()
+
+	reset_playfab_runtime()
+
+	var original_title_id = ProjectSettings.get_setting(PLAYFAB_TITLE_ID_SETTING, "")
+	var original_endpoint = ProjectSettings.get_setting(PLAYFAB_ENDPOINT_SETTING, "")
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, REARM_TEST_TITLE_ID)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, "")
+
+	var initialized_events: Array = []
+	var shutdown_events: Array = []
+	var initialized_handler := func() -> void:
+		initialized_events.append(true)
+	var shutdown_handler := func() -> void:
+		shutdown_events.append(true)
+
+	playfab.initialized.connect(initialized_handler)
+	playfab.shutdown_completed.connect(shutdown_handler)
+
+	var lifecycle_failed := false
+	for cycle_index in range(3):
+		var init_result = playfab.initialize()
+		if init_result == null:
+			assert_not_null(init_result, "PlayFab.initialize() returns a result on cycle %d" % (cycle_index + 1))
+			lifecycle_failed = true
+			break
+		if not init_result.is_ok():
+			assert_playfab_result_ok(init_result, "PlayFab.initialize() re-arms after shutdown on cycle %d" % (cycle_index + 1))
+			lifecycle_failed = true
+			break
+
+		assert_true(playfab.is_initialized(), "PlayFab is initialized on cycle %d" % (cycle_index + 1))
+		if cycle_index < 2:
+			playfab.shutdown()
+			assert_false(playfab.is_initialized(), "PlayFab shuts down cleanly on cycle %d" % (cycle_index + 1))
+
+	if not lifecycle_failed:
+		assert_eq(initialized_events.size(), 3, "PlayFab.initialized emits for each re-arm initialize")
+		assert_eq(shutdown_events.size(), 2, "PlayFab.shutdown_completed emits for the two explicit shutdowns before the third initialize")
+		assert_true(playfab.is_initialized(), "PlayFab remains initialized after the third re-arm initialize")
+
+	if playfab.is_initialized():
+		playfab.shutdown()
+	_restore_playfab_runtime_settings(original_title_id, original_endpoint)
+	reset_playfab_runtime()
+	_disconnect_playfab_lifecycle_handlers(playfab, initialized_handler, shutdown_handler)


### PR DESCRIPTION
**Audit lane A4 — PlayFabRuntime XGameRuntime lifecycle**

Stop cycling `XGameRuntimeInitialize` / `XGameRuntimeUninitialize` per `PlayFab.initialize()` / `shutdown()` — they are process-lifetime calls that must not be paired with addon initialize/shutdown.

Move the uninit to extension teardown to mirror the `godot_gdk` pattern (already applied in internal #130).

Adds an `initialize -> shutdown -> initialize` re-arm regression test.

## Audit source

Item #6 in `files/exhaustive-fleet-audit-report.md` (PlayFab runtime lifecycle).

## Validation

- `cmake --preset default` ✅
- `cmake --build build --preset debug` ✅

> **Pre-existing repo issue noted:** `tools\run_all_tests.ps1` orchestrator parse-gate failures on samples are unrelated to this lane.

## Live coverage decision

Live tests skipped (default).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
