### PR TITLE
pk-cli-content: honor --config/--output in headless pipeline + logo path-traversal guard

### DIFF
--- a/.github/instructions/godot-gdk-packaging.instructions.md
+++ b/.github/instructions/godot-gdk-packaging.instructions.md
@@ -140,6 +140,8 @@ before committing.
   precedence chain + key remap + encrypt key:<path> split.
 - `tests/godot/gdk/tests/packaging/test_packaging_result.gd` — result
   builder shape, exit-code constants, JSON round trip.
+- `tests/godot/gdk/tests/packaging/test_packaging_service.gd` — verb-facade
+  regressions for headless-only behaviours.
 - Pre-existing helper suites (`test_packaging.gd`,
   `test_packaging_panel_logic.gd`, `test_packaging_content_preparer.gd`,
   `test_gdk_toolchain.gd`, `test_packaging_settings_store.gd`,

--- a/addons/godot_gdk_packaging/core/game_config_manager.gd
+++ b/addons/godot_gdk_packaging/core/game_config_manager.gd
@@ -28,6 +28,25 @@ func config_exists() -> bool:
 	return FileAccess.file_exists("res://" + CONFIG_FILENAME)
 
 
+## Normalizes a Godot path to a filesystem-absolute path so it can safely be
+## passed to [code]DirAccess.*_absolute()[/code] and [code]DirAccess.remove_absolute()[/code]:
+## - [code]res://[/code] / [code]user://[/code] paths are globalized.
+## - Already-absolute filesystem paths are returned unchanged.
+## - Relative paths (e.g. [code]Configs/Alt.config[/code] from a headless
+##   [code]--output[/code] flag) are resolved against the project root so the
+##   write target lands inside the project rather than CWD-dependent
+##   unpredictability.
+## Empty input is returned unchanged.
+static func to_filesystem_path(p: String) -> String:
+	if p.is_empty():
+		return p
+	if p.begins_with("res://") or p.begins_with("user://"):
+		return ProjectSettings.globalize_path(p)
+	if p.is_absolute_path():
+		return p
+	return ProjectSettings.globalize_path("res://").path_join(p)
+
+
 # ── Parsing ─────────────────────────────────────────────────────────────────
 
 ## Parses MicrosoftGame.config and returns identity info as a Dictionary:
@@ -151,8 +170,9 @@ func create_template(game_name: String = "MyGodotGame",
 	var target_path: String = output_path
 	if target_path.is_empty():
 		target_path = get_config_res_path()
+	var fs_target: String = to_filesystem_path(target_path)
 
-	if FileAccess.file_exists(target_path):
+	if FileAccess.file_exists(fs_target):
 		push_warning("[GDK Packaging] MicrosoftGame.config already exists — not overwriting.")
 		return ERR_ALREADY_EXISTS
 
@@ -183,18 +203,18 @@ func create_template(game_name: String = "MyGodotGame",
 	xml += '  <AdvancedUserModel>false</AdvancedUserModel>\n'
 	xml += '</Game>\n'
 
-	var target_dir: String = target_path.get_base_dir()
+	var target_dir: String = fs_target.get_base_dir()
 	if not target_dir.is_empty() and not DirAccess.dir_exists_absolute(target_dir):
 		DirAccess.make_dir_recursive_absolute(target_dir)
 
-	var file: FileAccess = FileAccess.open(target_path, FileAccess.WRITE)
+	var file: FileAccess = FileAccess.open(fs_target, FileAccess.WRITE)
 	if file == null:
 		push_error("[GDK Packaging] Failed to create MicrosoftGame.config: " + error_string(FileAccess.get_open_error()))
 		return FileAccess.get_open_error()
 
 	file.store_string(xml)
 	file.close()
-	print("[GDK Packaging] Created template MicrosoftGame.config at: ", target_path)
+	print("[GDK Packaging] Created template MicrosoftGame.config at: ", fs_target)
 
 	# Generate placeholder logo images so GameConfigEditor doesn't error
 	_ensure_placeholder_images()

--- a/addons/godot_gdk_packaging/core/game_config_manager.gd
+++ b/addons/godot_gdk_packaging/core/game_config_manager.gd
@@ -33,8 +33,10 @@ func config_exists() -> bool:
 ## Parses MicrosoftGame.config and returns identity info as a Dictionary:
 ##   { name, publisher, version, product_id, executable, display_name, description }
 ## Returns an empty dictionary on failure.
-func parse_config() -> Dictionary:
-	var path: String = get_config_path()
+func parse_config(config_path: String = "") -> Dictionary:
+	var path: String = config_path
+	if path.is_empty():
+		path = get_config_path()
 	if not FileAccess.file_exists(path):
 		return {}
 
@@ -134,7 +136,8 @@ func parse_config() -> Dictionary:
 
 # ── Template Generation ─────────────────────────────────────────────────────
 
-## Creates a template MicrosoftGame.config in the project root.
+## Creates a template MicrosoftGame.config. If [param output_path] is empty,
+## writes to the project-root `res://MicrosoftGame.config`.
 ## [param game_name] becomes the Executable Name (must match the exported .exe);
 ## a sanitized form (spaces and underscores stripped) is used for the Identity
 ## Name, since MicrosoftGame.config rejects those characters there.
@@ -143,10 +146,13 @@ func parse_config() -> Dictionary:
 ## Returns OK on success, or an error code.
 func create_template(game_name: String = "MyGodotGame",
 		publisher: String = "CN=Publisher",
-		display_name: String = "My Godot Game") -> Error:
-	var res_path: String = get_config_res_path()
+		display_name: String = "My Godot Game",
+		output_path: String = "") -> Error:
+	var target_path: String = output_path
+	if target_path.is_empty():
+		target_path = get_config_res_path()
 
-	if FileAccess.file_exists(res_path):
+	if FileAccess.file_exists(target_path):
 		push_warning("[GDK Packaging] MicrosoftGame.config already exists — not overwriting.")
 		return ERR_ALREADY_EXISTS
 
@@ -177,14 +183,18 @@ func create_template(game_name: String = "MyGodotGame",
 	xml += '  <AdvancedUserModel>false</AdvancedUserModel>\n'
 	xml += '</Game>\n'
 
-	var file: FileAccess = FileAccess.open(res_path, FileAccess.WRITE)
+	var target_dir: String = target_path.get_base_dir()
+	if not target_dir.is_empty() and not DirAccess.dir_exists_absolute(target_dir):
+		DirAccess.make_dir_recursive_absolute(target_dir)
+
+	var file: FileAccess = FileAccess.open(target_path, FileAccess.WRITE)
 	if file == null:
 		push_error("[GDK Packaging] Failed to create MicrosoftGame.config: " + error_string(FileAccess.get_open_error()))
 		return FileAccess.get_open_error()
 
 	file.store_string(xml)
 	file.close()
-	print("[GDK Packaging] Created template MicrosoftGame.config at: ", res_path)
+	print("[GDK Packaging] Created template MicrosoftGame.config at: ", target_path)
 
 	# Generate placeholder logo images so GameConfigEditor doesn't error
 	_ensure_placeholder_images()

--- a/addons/godot_gdk_packaging/core/game_config_manager.gd
+++ b/addons/godot_gdk_packaging/core/game_config_manager.gd
@@ -216,17 +216,26 @@ func create_template(game_name: String = "MyGodotGame",
 	file.close()
 	print("[GDK Packaging] Created template MicrosoftGame.config at: ", fs_target)
 
-	# Generate placeholder logo images so GameConfigEditor doesn't error
-	_ensure_placeholder_images()
+	# Generate placeholder logo images so GameConfigEditor doesn't error.
+	# Pass the config's base dir so the storelogos/ folder is created next to
+	# the config file (not under res://) when output_path lands outside the
+	# project root; the config's relative "storelogos\..." attributes resolve
+	# against the config's parent directory.
+	_ensure_placeholder_images(target_dir)
 
 	return OK
 
 
 ## Copies the GDK default 480x480 PNG and resizes it to create all placeholder
-## images referenced by the MicrosoftGame.config template.
-func _ensure_placeholder_images() -> void:
-	var project_dir: String = ProjectSettings.globalize_path("res://")
-	var logos_dir: String = project_dir.path_join("storelogos")
+## images referenced by the MicrosoftGame.config template. Writes them under
+## a "storelogos/" folder inside [param base_dir] (defaults to the project
+## root for backward compatibility) so the relative paths the template
+## embeds resolve next to the config file.
+func _ensure_placeholder_images(base_dir: String = "") -> void:
+	var logos_root: String = base_dir
+	if logos_root.is_empty():
+		logos_root = ProjectSettings.globalize_path("res://")
+	var logos_dir: String = logos_root.path_join("storelogos")
 	var default_png: String = _toolchain.get_bin_dir().path_join(
 		"GameConfigEditorDependencies/default480x480.png")
 

--- a/addons/godot_gdk_packaging/core/packaging_cli.gd
+++ b/addons/godot_gdk_packaging/core/packaging_cli.gd
@@ -165,7 +165,7 @@ const VERBS := {
 		"positional": [],
 	},
 	"config_template": {
-		"doc": "Write a starter MicrosoftGame.config into the project root.",
+		"doc": "Write a starter MicrosoftGame.config.",
 		"flags": {
 			"output":    {"type": _TYPE_PATH,
 						  "doc": "Output path. Defaults to res://MicrosoftGame.config."},

--- a/addons/godot_gdk_packaging/core/packaging_config.gd
+++ b/addons/godot_gdk_packaging/core/packaging_config.gd
@@ -138,8 +138,11 @@ static func resolve(
 	resolved["app_name"] = str(ProjectSettings.get_setting("application/config/name", ""))
 	resolved["app_version"] = str(ProjectSettings.get_setting("application/config/version", ""))
 
-	# Layer 3: MicrosoftGame.config.
+	# Layer 3: MicrosoftGame.config. CLI --config selects the file used by
+	# this lower-precedence layer as well as the final resolved config_path.
 	var config_path: String = config_path_override
+	if config_path.is_empty():
+		config_path = str(cli_options.get("config", ""))
 	if config_path.is_empty():
 		config_path = project_root.path_join("MicrosoftGame.config")
 	resolved["config_path"] = config_path

--- a/addons/godot_gdk_packaging/core/packaging_content_preparer.gd
+++ b/addons/godot_gdk_packaging/core/packaging_content_preparer.gd
@@ -11,18 +11,46 @@ func _init(config_mgr: RefCounted) -> void:
 	_config_mgr = config_mgr
 
 
-func ensure_content_dir_ready(content_dir: String, logger: Callable = Callable()) -> bool:
+func ensure_content_dir_ready(content_dir: String, logger: Callable = Callable(),
+		config_path: String = "") -> bool:
 	var project_dir: String = ProjectSettings.globalize_path("res://")
-	var config_src: String = _config_mgr.get_config_path()
+	var config_src: String = config_path
+	if config_src.is_empty():
+		config_src = _config_mgr.get_config_path()
 	var config_dest: String = content_dir.path_join("MicrosoftGame.config")
 
 	if not FileAccess.file_exists(config_src):
-		_call_logger(logger, "❌ MicrosoftGame.config not found — create one first.")
+		_call_logger(logger, "❌ MicrosoftGame.config not found at %s." % config_src)
 		return false
+
+	var info: Dictionary = _config_mgr.parse_config(config_src)
+	var logo_keys: Dictionary = {
+		"store_logo": "StoreLogo",
+		"logo_150": "Square150x150Logo",
+		"logo_44": "Square44x44Logo",
+		"logo_480": "Square480x480Logo",
+		"splash_screen": "SplashScreenImage",
+	}
+	var logo_destinations: Dictionary = {}
+	for key: String in logo_keys:
+		var rel_path: String = str(info.get(key, ""))
+		if rel_path.is_empty():
+			rel_path = str(logo_keys[key]) + ".png"
+		var dest_path: String = _resolve_logo_destination(content_dir, rel_path)
+		if dest_path.is_empty():
+			_call_logger(logger,
+				"❌ Refusing logo path outside content directory for %s: %s" % [
+					str(logo_keys[key]), rel_path,
+				])
+			return false
+		logo_destinations[key] = {
+			"dest_path": dest_path,
+			"normalized": _normalize_logo_relative_path(rel_path),
+		}
 
 	var file: FileAccess = FileAccess.open(config_src, FileAccess.READ)
 	if file == null:
-		_call_logger(logger, "❌ Cannot read MicrosoftGame.config")
+		_call_logger(logger, "❌ Cannot read MicrosoftGame.config at %s" % config_src)
 		return false
 	var content: String = file.get_as_text()
 	file.close()
@@ -42,21 +70,10 @@ func ensure_content_dir_ready(content_dir: String, logger: Callable = Callable()
 	file.close()
 	_call_logger(logger, "Copied MicrosoftGame.config to content directory")
 
-	var info: Dictionary = _config_mgr.parse_config()
-	var logo_keys: Dictionary = {
-		"store_logo": "StoreLogo",
-		"logo_150": "Square150x150Logo",
-		"logo_44": "Square44x44Logo",
-		"logo_480": "Square480x480Logo",
-		"splash_screen": "SplashScreenImage",
-	}
-
 	for key: String in logo_keys:
-		var rel_path: String = info.get(key, "")
-		if rel_path == "":
-			rel_path = logo_keys[key] + ".png"
-		var normalized: String = rel_path.replace("\\", "/")
-		var dest_path: String = content_dir.path_join(normalized)
+		var destination: Dictionary = logo_destinations[key]
+		var normalized: String = str(destination["normalized"])
+		var dest_path: String = str(destination["dest_path"])
 
 		var src_path: String = ""
 		var filename: String = normalized.get_file()
@@ -137,6 +154,44 @@ func _copy_addon_runtime_dlls(content_dir: String, logger: Callable) -> int:
 		addon_name = addons.get_next()
 	addons.list_dir_end()
 	return copied
+
+
+static func _resolve_logo_destination(content_dir: String, rel_path: String) -> String:
+	var raw: String = rel_path.replace("\\", "/").strip_edges()
+	if raw.is_empty() or raw.begins_with("/") or raw.contains("://") or _has_windows_drive(raw):
+		return ""
+	var normalized: String = _normalize_logo_relative_path(raw)
+	if normalized.is_empty() or normalized == ".":
+		return ""
+	var dest_path: String = content_dir.path_join(normalized).replace("\\", "/").simplify_path()
+	if not _is_path_inside_dir(dest_path, content_dir):
+		return ""
+	return dest_path
+
+
+static func _normalize_logo_relative_path(rel_path: String) -> String:
+	return rel_path.replace("\\", "/").strip_edges().simplify_path()
+
+
+static func _has_windows_drive(path: String) -> bool:
+	return path.length() >= 2 and path.substr(1, 1) == ":"
+
+
+static func _is_path_inside_dir(candidate_path: String, root_dir: String) -> bool:
+	var candidate: String = _normalize_path(candidate_path).to_lower()
+	var root: String = _normalize_path(root_dir).to_lower()
+	if candidate == root:
+		return true
+	if not root.ends_with("/"):
+		root += "/"
+	return candidate.begins_with(root)
+
+
+static func _normalize_path(path: String) -> String:
+	var normalized: String = path.replace("\\", "/").simplify_path()
+	while normalized.ends_with("/") and normalized.length() > 1 and not normalized.ends_with(":/"):
+		normalized = normalized.substr(0, normalized.length() - 1)
+	return normalized
 
 
 static func inject_vc14_dependency(content: String) -> String:

--- a/addons/godot_gdk_packaging/core/packaging_service.gd
+++ b/addons/godot_gdk_packaging/core/packaging_service.gd
@@ -485,19 +485,20 @@ func run_config_template(resolved: Dictionary) -> Dictionary:
 	var output: String = str(resolved.get("output", ""))
 	if output.is_empty():
 		output = _config_mgr.get_config_path()
+	var fs_output: String = GameConfigManagerScript.to_filesystem_path(output)
 	var overwrite: bool = bool(resolved.get("overwrite", false))
-	if FileAccess.file_exists(output) and not overwrite:
+	if FileAccess.file_exists(fs_output) and not overwrite:
 		return PackagingResult.fail(verb,
-			"%s already exists (pass --overwrite to replace it)" % output,
+			"%s already exists (pass --overwrite to replace it)" % fs_output,
 			PackagingResult.EXIT_CONFIG,
-			"", {"output": output})
-	if FileAccess.file_exists(output) and overwrite:
-		var remove_err: Error = DirAccess.remove_absolute(output)
-		if remove_err != OK and FileAccess.file_exists(output):
+			"", {"output": fs_output})
+	if FileAccess.file_exists(fs_output) and overwrite:
+		var remove_err: Error = DirAccess.remove_absolute(fs_output)
+		if remove_err != OK and FileAccess.file_exists(fs_output):
 			return PackagingResult.fail(verb,
-				"Failed to remove existing output %s (%s)" % [output, error_string(remove_err)],
+				"Failed to remove existing output %s (%s)" % [fs_output, error_string(remove_err)],
 				PackagingResult.EXIT_CONFIG,
-				"", {"output": output, "err": remove_err})
+				"", {"output": fs_output, "err": remove_err})
 
 	var app_name: String = str(resolved.get("app_name", "MyGodotGame"))
 	var publisher: String = "CN=" + str(resolved.get("identity_publisher", "Publisher"))
@@ -509,9 +510,9 @@ func run_config_template(resolved: Dictionary) -> Dictionary:
 		return PackagingResult.fail(verb,
 			"Failed to create template (%s)" % error_string(err),
 			PackagingResult.EXIT_TOOL,
-			"", {"output": output, "err": err}, "", duration)
-	return PackagingResult.ok(verb, "Created template at %s" % output,
-		{"output": output}, "", duration)
+			"", {"output": fs_output, "err": err}, "", duration)
+	return PackagingResult.ok(verb, "Created template at %s" % fs_output,
+		{"output": fs_output}, "", duration)
 
 
 # ── config_editor ───────────────────────────────────────────────────────────

--- a/addons/godot_gdk_packaging/core/packaging_service.gd
+++ b/addons/godot_gdk_packaging/core/packaging_service.gd
@@ -35,7 +35,6 @@ func _init(toolchain: RefCounted = null) -> void:
 	_makepkg = MakePkgExecutorScript.new(_toolchain)
 	_config_mgr = GameConfigManagerScript.new(_toolchain)
 	_preparer = PackagingContentPreparerScript.new(_config_mgr)
-	_wdapp = WdappManagerScript.new(_toolchain)
 
 
 func get_toolchain() -> RefCounted:
@@ -66,11 +65,16 @@ func run_pack(resolved: Dictionary) -> Dictionary:
 
 	# Optional content prep.
 	if not skip_prepare:
-		var ok: bool = _preparer.ensure_content_dir_ready(source_dir)
+		var prep_logs: Array[String] = []
+		var ok: bool = _preparer.ensure_content_dir_ready(source_dir,
+			func(message: String) -> void:
+				prep_logs.append(message),
+			str(resolved.get("config_path", "")))
 		if not ok:
-			return PackagingResult.fail(verb, "Content prep failed for %s" % source_dir,
+			return PackagingResult.fail(verb,
+				_content_prep_error("Content prep failed for %s" % source_dir, prep_logs),
 				PackagingResult.EXIT_TOOL,
-				"", {"phase": "prepare_content"}, "",
+				"", {"phase": "prepare_content", "logs": prep_logs}, "",
 				Time.get_ticks_msec() - t0)
 
 	# Auto-genmap when --map-file wasn't supplied.
@@ -197,12 +201,16 @@ func run_prepare_content(resolved: Dictionary) -> Dictionary:
 	if not DirAccess.dir_exists_absolute(content_dir):
 		return PackagingResult.fail(verb, "Content directory does not exist: %s" % content_dir,
 			PackagingResult.EXIT_CONFIG)
-	var ok: bool = _preparer.ensure_content_dir_ready(content_dir)
+	var prep_logs: Array[String] = []
+	var ok: bool = _preparer.ensure_content_dir_ready(content_dir,
+		func(message: String) -> void:
+			prep_logs.append(message),
+		str(resolved.get("config_path", "")))
 	var duration: int = Time.get_ticks_msec() - t0
 	if not ok:
-		return PackagingResult.fail(verb, "Content prep failed",
+		return PackagingResult.fail(verb, _content_prep_error("Content prep failed", prep_logs),
 			PackagingResult.EXIT_TOOL,
-			"", {"content_dir": content_dir}, "", duration)
+			"", {"content_dir": content_dir, "logs": prep_logs}, "", duration)
 	return PackagingResult.ok(verb, "Prepared %s" % content_dir,
 		{"content_dir": content_dir}, "", duration)
 
@@ -246,11 +254,16 @@ func run_export(resolved: Dictionary) -> Dictionary:
 			Time.get_ticks_msec() - t0)
 
 	if not skip_prepare:
-		var ok: bool = _preparer.ensure_content_dir_ready(output_dir)
+		var prep_logs: Array[String] = []
+		var ok: bool = _preparer.ensure_content_dir_ready(output_dir,
+			func(message: String) -> void:
+				prep_logs.append(message),
+			str(resolved.get("config_path", "")))
 		if not ok:
-			return PackagingResult.fail(verb, "Post-export content prep failed",
+			return PackagingResult.fail(verb,
+				_content_prep_error("Post-export content prep failed", prep_logs),
 				PackagingResult.EXIT_TOOL,
-				"", {"phase": "prepare_content", "output_dir": output_dir},
+				"", {"phase": "prepare_content", "output_dir": output_dir, "logs": prep_logs},
 				"", Time.get_ticks_msec() - t0)
 	return PackagingResult.ok(verb,
 		"Exported %s → %s" % [preset, executable_path],
@@ -268,13 +281,13 @@ func run_register_loose(resolved: Dictionary) -> Dictionary:
 	var missing: String = _missing_required(resolved, ["content_dir"])
 	if not missing.is_empty():
 		return PackagingResult.fail(verb, missing, PackagingResult.EXIT_USAGE)
-	if not _wdapp.is_available():
+	if not _get_wdapp().is_available():
 		return PackagingResult.fail(verb, "wdapp.exe not found", PackagingResult.EXIT_CONFIG)
 	var content_dir: String = str(resolved["content_dir"])
 	if not DirAccess.dir_exists_absolute(content_dir):
 		return PackagingResult.fail(verb, "Content directory does not exist: %s" % content_dir,
 			PackagingResult.EXIT_CONFIG)
-	var result: Dictionary = _wdapp.register_loose(content_dir)
+	var result: Dictionary = _get_wdapp().register_loose(content_dir)
 	var duration: int = Time.get_ticks_msec() - t0
 	var exit_code: int = int(result.get("exit_code", -1))
 	if exit_code != 0:
@@ -297,13 +310,13 @@ func run_install(resolved: Dictionary) -> Dictionary:
 	var missing: String = _missing_required(resolved, ["package_path"])
 	if not missing.is_empty():
 		return PackagingResult.fail(verb, missing, PackagingResult.EXIT_USAGE)
-	if not _wdapp.is_available():
+	if not _get_wdapp().is_available():
 		return PackagingResult.fail(verb, "wdapp.exe not found", PackagingResult.EXIT_CONFIG)
 	var package_path: String = str(resolved["package_path"])
 	if not FileAccess.file_exists(package_path):
 		return PackagingResult.fail(verb, "Package file does not exist: %s" % package_path,
 			PackagingResult.EXIT_CONFIG)
-	var result: Dictionary = _wdapp.install_package(package_path)
+	var result: Dictionary = _get_wdapp().install_package(package_path)
 	var duration: int = Time.get_ticks_msec() - t0
 	var exit_code: int = int(result.get("exit_code", -1))
 	if exit_code != 0:
@@ -326,10 +339,10 @@ func run_uninstall(resolved: Dictionary) -> Dictionary:
 	var missing: String = _missing_required(resolved, ["package_name"])
 	if not missing.is_empty():
 		return PackagingResult.fail(verb, missing, PackagingResult.EXIT_USAGE)
-	if not _wdapp.is_available():
+	if not _get_wdapp().is_available():
 		return PackagingResult.fail(verb, "wdapp.exe not found", PackagingResult.EXIT_CONFIG)
 	var package_name: String = str(resolved["package_name"])
-	var result: Dictionary = _wdapp.uninstall_package(package_name)
+	var result: Dictionary = _get_wdapp().uninstall_package(package_name)
 	var duration: int = Time.get_ticks_msec() - t0
 	var exit_code: int = int(result.get("exit_code", -1))
 	if exit_code != 0:
@@ -349,7 +362,7 @@ func run_uninstall(resolved: Dictionary) -> Dictionary:
 func run_launch(resolved: Dictionary) -> Dictionary:
 	var t0: int = Time.get_ticks_msec()
 	var verb: String = "launch"
-	if not _wdapp.is_available():
+	if not _get_wdapp().is_available():
 		return PackagingResult.fail(verb, "wdapp.exe not found", PackagingResult.EXIT_CONFIG)
 	var aumid: String = str(resolved.get("aumid", ""))
 	if aumid.is_empty():
@@ -359,7 +372,7 @@ func run_launch(resolved: Dictionary) -> Dictionary:
 			return PackagingResult.fail(verb,
 				"Either --aumid or --package-name is required",
 				PackagingResult.EXIT_USAGE)
-		var listing: Dictionary = _wdapp.list_registered_apps()
+		var listing: Dictionary = _get_wdapp().list_registered_apps()
 		for app: Dictionary in listing.get("apps", []):
 			if str(app.get("pfn", "")) == package_name:
 				aumid = str(app.get("aumid", ""))
@@ -368,7 +381,7 @@ func run_launch(resolved: Dictionary) -> Dictionary:
 			return PackagingResult.fail(verb,
 				"Could not find AUMID for package '%s'" % package_name,
 				PackagingResult.EXIT_CONFIG)
-	var result: Dictionary = _wdapp.launch_app(aumid)
+	var result: Dictionary = _get_wdapp().launch_app(aumid)
 	var duration: int = Time.get_ticks_msec() - t0
 	var exit_code: int = int(result.get("exit_code", -1))
 	if exit_code != 0:
@@ -390,11 +403,11 @@ func run_terminate(resolved: Dictionary) -> Dictionary:
 	var missing: String = _missing_required(resolved, ["package_name"])
 	if not missing.is_empty():
 		return PackagingResult.fail(verb, missing, PackagingResult.EXIT_USAGE)
-	if not _wdapp.is_available():
+	if not _get_wdapp().is_available():
 		return PackagingResult.fail(verb, "wdapp.exe not found", PackagingResult.EXIT_CONFIG)
 	var package_name: String = str(resolved["package_name"])
 	var build_dir: String = str(resolved.get("content_dir", resolved.get("source_dir", "")))
-	var result: Dictionary = _wdapp.terminate_app(package_name, build_dir)
+	var result: Dictionary = _get_wdapp().terminate_app(package_name, build_dir)
 	var duration: int = Time.get_ticks_msec() - t0
 	var exit_code: int = int(result.get("exit_code", -1))
 	var terminated_with: String = str(result.get("terminated_with", "wdapp"))
@@ -479,15 +492,18 @@ func run_config_template(resolved: Dictionary) -> Dictionary:
 			PackagingResult.EXIT_CONFIG,
 			"", {"output": output})
 	if FileAccess.file_exists(output) and overwrite:
-		var dir: DirAccess = DirAccess.open(output.get_base_dir())
-		if dir != null:
-			dir.remove(output.get_file())
+		var remove_err: Error = DirAccess.remove_absolute(output)
+		if remove_err != OK and FileAccess.file_exists(output):
+			return PackagingResult.fail(verb,
+				"Failed to remove existing output %s (%s)" % [output, error_string(remove_err)],
+				PackagingResult.EXIT_CONFIG,
+				"", {"output": output, "err": remove_err})
 
 	var app_name: String = str(resolved.get("app_name", "MyGodotGame"))
 	var publisher: String = "CN=" + str(resolved.get("identity_publisher", "Publisher"))
 	if publisher == "CN=":
 		publisher = "CN=Publisher"
-	var err: int = _config_mgr.create_template(app_name, publisher, app_name)
+	var err: int = _config_mgr.create_template(app_name, publisher, app_name, output)
 	var duration: int = Time.get_ticks_msec() - t0
 	if err != OK:
 		return PackagingResult.fail(verb,
@@ -579,6 +595,12 @@ func dispatch(verb: String, resolved: Dictionary) -> Dictionary:
 
 # ── internal ────────────────────────────────────────────────────────────────
 
+func _get_wdapp() -> RefCounted:
+	if _wdapp == null:
+		_wdapp = WdappManagerScript.new(_toolchain)
+	return _wdapp
+
+
 static func _missing_required(resolved: Dictionary, keys: Array) -> String:
 	var missing: PackedStringArray = PackedStringArray()
 	for key: String in keys:
@@ -588,3 +610,12 @@ static func _missing_required(resolved: Dictionary, keys: Array) -> String:
 	if missing.is_empty():
 		return ""
 	return "Missing required value(s): %s" % ", ".join(missing)
+
+
+static func _content_prep_error(prefix: String, logs: Array[String]) -> String:
+	if logs.is_empty():
+		return prefix
+	var parts: PackedStringArray = PackedStringArray()
+	for log: String in logs:
+		parts.append(log)
+	return "%s: %s" % [prefix, "; ".join(parts)]

--- a/addons/godot_gdk_packaging/run.gd
+++ b/addons/godot_gdk_packaging/run.gd
@@ -52,7 +52,9 @@ func _execute() -> int:
 		print(PackagingCli.render_verb_usage(str(parsed["verb"])))
 		return PackagingResult.EXIT_OK
 
-	var resolved: Dictionary = PackagingConfig.resolve(parsed["options"])
+	var config_override: String = str(parsed["options"].get("config", ""))
+	var resolved: Dictionary = PackagingConfig.resolve(parsed["options"], "",
+		PackagingConfig.PACKAGING_SETTINGS_PATH, config_override)
 	var service: RefCounted = PackagingService.new()
 	var result: Dictionary = service.dispatch(str(parsed["verb"]), resolved)
 	_print_summary(result)

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -69,16 +69,16 @@ on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 |--------------------|--------------------------------------|-------------------------------------------------------------------|
 | `pack`             | `--source-dir`, `--output-dir`       | makepkg pack. Auto-genmap when `--map-file` is omitted.           |
 | `genmap`           | `--source-dir`, `--map-file`         | makepkg genmap.                                                   |
-| `validate`         | `--source-dir`, `--map-file`         | makepkg validate.                                                 |
+| `validate`         | `--source-dir`, `--map-file`         | makepkg validate; optional `--output-dir` selects `/pd`.          |
 | `prepare_content`  | `--content-dir`                      | Copies MicrosoftGame.config + logos into a content directory.     |
-| `export`           | `--preset`, `--output-dir`           | Godot Windows-Desktop export; `--release` toggles release mode.   |
+| `export`           | `--preset`, `--output-dir`           | Godot Windows-Desktop export; `--release`; optional `--no-prepare`. |
 | `register_loose`   | `--content-dir`                      | wdapp register (loose-files build).                               |
 | `install`          | `--package`                          | wdapp install on an .msixvc file.                                 |
 | `uninstall`        | `--package-name`                     | wdapp uninstall by package full name.                             |
 | `launch`           | `--package-name` or `--aumid`        | wdapp launch. Resolves AUMID from PFN when needed.                |
 | `terminate`        | `--package-name`                     | wdapp terminate; falls back to taskkill on the build's `.exe`.    |
 | `sandbox`          | `--action {get,set,retail}`          | `set` additionally requires `--sandbox-id`.                       |
-| `config_template`  | (none)                               | Writes a starter MicrosoftGame.config (use `--overwrite` to replace). |
+| `config_template`  | (none)                               | Writes a starter MicrosoftGame.config; optional `--output`, `--overwrite`. |
 | `config_editor`    | (none)                               | Detached GameConfigEditor.exe launch on the current config.       |
 | `store_wizard`     | (none)                               | Detached GameConfigEditor.exe `/StoreAssociation`.                |
 
@@ -92,6 +92,15 @@ on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 | `--encrypt-key`   |          | EKB path (required when `--encrypt=key`).                              |
 | `--updcompat`     | `3`      | makepkg `/updcompat` level (1, 2, or 3).                               |
 | `--no-prepare`    | off      | Skip the content-prep step before pack.                                |
+
+Additional verb-specific flags:
+
+- `validate --output-dir <dir>` chooses the makepkg validation output `/pd`
+  directory (otherwise a `validate-out` sibling is created).
+- `export --no-prepare` skips the post-export content preparation step.
+- `config_template --output <path>` writes the template at that path;
+  `--overwrite` replaces that same resolved output file when it already
+  exists.
 
 Per-verb help is always reachable as `<verb> --help`:
 
@@ -144,6 +153,17 @@ Derived rules:
 - `content_id` falls back to `product_id` when neither CLI nor settings
   supplied one.
 - `--encrypt=key:<ekb>` is shorthand for `--encrypt key --encrypt-key <ekb>`.
+- `--config <path>` is honored by the resolver and by content preparation, so
+  `prepare_content`, `pack`, and post-export prep stage the selected config
+  instead of implicitly reading `res://MicrosoftGame.config`.
+
+## Content-directory safety
+
+`prepare_content`, `pack`, and `export` validate every logo destination path
+read from MicrosoftGame.config before copying logo bytes. Relative paths such
+as `storelogos\Square150x150Logo.png` are staged under the content directory;
+absolute paths or paths that simplify outside the content directory (for
+example `..\..\outside.png`) are refused with an error before staging begins.
 
 ## Environment variables
 
@@ -156,8 +176,9 @@ Derived rules:
 ## Examples
 
 ```pwsh
-# Drop a starter MicrosoftGame.config in the current project.
+# Drop a starter MicrosoftGame.config in the current project, or redirect it.
 addons\godot_gdk_packaging\gdkpkg.cmd config_template
+addons\godot_gdk_packaging\gdkpkg.cmd config_template --output Configs\Alt.config
 
 # Get the current sandbox.
 addons\godot_gdk_packaging\gdkpkg.cmd sandbox --action get
@@ -167,8 +188,8 @@ addons\godot_gdk_packaging\gdkpkg.cmd sandbox --action set --sandbox-id XDKS.1
 
 # Export, prepare, and pack in three steps.
 addons\godot_gdk_packaging\gdkpkg.cmd export --preset "Windows Desktop" --output-dir Build\content
-addons\godot_gdk_packaging\gdkpkg.cmd prepare_content --content-dir Build\content
-addons\godot_gdk_packaging\gdkpkg.cmd pack --source-dir Build\content --output-dir Build\out
+addons\godot_gdk_packaging\gdkpkg.cmd prepare_content --content-dir Build\content --config Configs\Alt.config
+addons\godot_gdk_packaging\gdkpkg.cmd pack --source-dir Build\content --output-dir Build\out --config Configs\Alt.config
 
 # Register a loose-files build, launch, then terminate.
 addons\godot_gdk_packaging\gdkpkg.cmd register_loose --content-dir Build\content

--- a/spec/gdext-packaging.md
+++ b/spec/gdext-packaging.md
@@ -143,16 +143,16 @@ Verb list (14):
 |--------------------|-------------------------------|--------------------------------------------------------|
 | `pack`             | `--source-dir`, `--output-dir`| Auto-genmaps if `--map-file` omitted; honours `--no-prepare`. |
 | `genmap`           | `--source-dir`, `--map-file`  |                                                        |
-| `validate`         | `--source-dir`, `--map-file`  |                                                        |
-| `prepare_content`  | `--content-dir`               | Standalone content-prep step.                          |
-| `export`           | `--preset`, `--output-dir`    | `--release` toggles `--export-release`.                |
+| `validate`         | `--source-dir`, `--map-file`  | Optional `--output-dir` selects makepkg `/pd`.          |
+| `prepare_content`  | `--content-dir`               | Standalone content-prep step; honors `--config`.        |
+| `export`           | `--preset`, `--output-dir`    | `--release`; optional `--no-prepare`.                  |
 | `register_loose`   | `--content-dir`               | wdapp register.                                        |
 | `install`          | `--package`                   | wdapp install.                                         |
 | `uninstall`        | `--package-name`              | wdapp uninstall.                                       |
 | `launch`           | `--package-name` or `--aumid` | Resolves AUMID via `wdapp list` when only PFN given.   |
 | `terminate`        | `--package-name`              | Falls back to taskkill on the build's primary .exe.    |
 | `sandbox`          | `--action {get,set,retail}`   | `set` also requires `--sandbox-id`.                    |
-| `config_template`  | (none)                        | Writes a starter MicrosoftGame.config.                 |
+| `config_template`  | (none)                        | Writes a starter MicrosoftGame.config; optional `--output`, `--overwrite`. |
 | `config_editor`    | (none)                        | Detached GameConfigEditor.exe launch.                  |
 | `store_wizard`     | (none)                        | Detached GameConfigEditor.exe `/StoreAssociation`.     |
 
@@ -165,7 +165,9 @@ collapses every source into a single flat dict. Precedence (highest wins):
    `_CLI_KEY_REMAP`).
 2. `res://.gdk_packaging.cfg` (via `PackagingSettingsStore`). Empty strings
    here do **not** clobber values pulled from lower layers.
-3. `MicrosoftGame.config` (identity / product / executable fields).
+3. `MicrosoftGame.config` (identity / product / executable fields). The
+   common `--config <path>` flag selects this config file and is carried into
+   `prepare_content`, `pack`, and post-export prep.
 4. `project.godot` (only `application/config/name` and `version`).
 5. Built-in defaults (`encrypt="none"`, `updcompat=3`, `action="get"`, ...).
 
@@ -175,6 +177,17 @@ Derived rules:
   supplied one.
 - `--encrypt=key:<ekb>` is split into `encrypt="key"` + `encrypt_key="<ekb>"`
   unless `--encrypt-key` is also passed (CLI wins).
+- `config_template --output <path>` writes to the requested path; `--overwrite`
+  removes and recreates that same resolved output file.
+
+## Content preparation safety
+
+`PackagingContentPreparer.ensure_content_dir_ready()` validates logo
+destination attributes from MicrosoftGame.config after path simplification and
+before staging. Relative paths inside the content directory are allowed;
+absolute paths, Godot URI paths, and paths that resolve outside the content
+directory are rejected with a content-dir safety error before any config or
+logo bytes are written to the staging directory.
 
 ## Plan
 

--- a/tests/godot/gdk/tests/packaging/test_packaging_cli.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_cli.gd
@@ -32,6 +32,15 @@ func test_every_verb_entry_has_doc_and_flags() -> void:
 			"verb '%s' flags is a Dictionary" % verb)
 
 
+func test_verb_table_pins_documented_non_required_flags() -> void:
+	assert_true(PackagingCli.VERBS["validate"]["flags"].has("output-dir"),
+		"validate documents --output-dir")
+	assert_true(PackagingCli.VERBS["export"]["flags"].has("no-prepare"),
+		"export documents --no-prepare")
+	assert_true(PackagingCli.VERBS["config_template"]["flags"].has("output"),
+		"config_template documents --output")
+
+
 # ── Empty argv ─────────────────────────────────────────────────────────────
 
 func test_empty_argv_requests_help() -> void:

--- a/tests/godot/gdk/tests/packaging/test_packaging_config_resolver.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_config_resolver.gd
@@ -30,7 +30,7 @@ func _project_dir() -> String:
 	return ProjectSettings.globalize_path(_FIXTURE_DIR)
 
 
-func _write_config_xml(extra_attrs: Dictionary = {}) -> String:
+func _write_config_xml(extra_attrs: Dictionary = {}, filename: String = _CONFIG_XML) -> String:
 	# Minimal MicrosoftGame.config the resolver knows how to read.
 	var product_id: String = extra_attrs.get("product_id", "PROD12345")
 	var ident_name: String = extra_attrs.get("name", "MyGame")
@@ -48,7 +48,7 @@ func _write_config_xml(extra_attrs: Dictionary = {}) -> String:
 	xml += '  </ExecutableList>\n'
 	xml += '  <MSStore ProductId="%s" />\n' % product_id
 	xml += '</Game>\n'
-	var path: String = _project_dir().path_join(_CONFIG_XML)
+	var path: String = _project_dir().path_join(filename)
 	var f: FileAccess = FileAccess.open(path, FileAccess.WRITE)
 	f.store_string(xml)
 	f.close()
@@ -100,6 +100,23 @@ func test_microsoftgame_config_supplies_identity_fields() -> void:
 	assert_eq(resolved["identity_name"], "MyGame", "identity name pulled")
 	assert_eq(resolved["identity_publisher"], "CN=Acme", "publisher pulled")
 	assert_eq(resolved["executable"], "MyGame.exe", "executable pulled")
+
+
+func test_cli_config_flag_redirects_config_parsing() -> void:
+	_write_config_xml({"product_id": "DEFAULT", "name": "DefaultGame"})
+	var override_path: String = _write_config_xml({
+		"product_id": "OVERRIDE",
+		"name": "OverrideGame",
+		"executable": "Override.exe",
+	}, "AltGame.config")
+	var resolved: Dictionary = PackagingConfig.resolve(
+		{"config": override_path}, _project_dir(), "", "")
+	assert_eq(resolved["config_path"], override_path, "--config becomes config_path")
+	assert_eq(resolved["product_id"], "OVERRIDE", "--config supplies product_id")
+	assert_eq(resolved["identity_name"], "OverrideGame", "--config supplies identity")
+	assert_eq(resolved["executable"], "Override.exe", "--config supplies executable")
+	assert_eq(resolved["raw_config_info"].get("product_id", ""), "OVERRIDE",
+		"raw_config_info comes from --config")
 
 
 func test_content_id_defaults_to_product_id_when_unset() -> void:

--- a/tests/godot/gdk/tests/packaging/test_packaging_content_preparer.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_content_preparer.gd
@@ -14,6 +14,81 @@ extends GutTest
 ##     no `</Game>` tag).
 
 const PackagingContentPreparerScript = preload("res://addons/godot_gdk_packaging/core/packaging_content_preparer.gd")
+const GameConfigManagerScript = preload("res://addons/godot_gdk_packaging/core/game_config_manager.gd")
+
+const _FIXTURE_DIR := "user://test_packaging_content_preparer"
+
+class _FakeToolchain extends RefCounted:
+	func get_bin_dir() -> String:
+		return ProjectSettings.globalize_path("user://missing_gdk_bin")
+
+
+func before_each() -> void:
+	_reset_fixture()
+	DirAccess.make_dir_recursive_absolute(_fixture_root())
+
+
+func after_each() -> void:
+	_reset_fixture()
+
+
+func _fixture_root() -> String:
+	return ProjectSettings.globalize_path(_FIXTURE_DIR)
+
+
+func _fixture_path(relative_path: String) -> String:
+	return _fixture_root().path_join(relative_path)
+
+
+func _reset_fixture() -> void:
+	_remove_tree(_fixture_root())
+
+
+func _remove_tree(path: String) -> void:
+	if not DirAccess.dir_exists_absolute(path):
+		return
+	for file_name: String in DirAccess.get_files_at(path):
+		DirAccess.remove_absolute(path.path_join(file_name))
+	for dir_name: String in DirAccess.get_directories_at(path):
+		_remove_tree(path.path_join(dir_name))
+	DirAccess.remove_absolute(path)
+
+
+func _write_text(path: String, content: String) -> void:
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(content)
+	file.close()
+
+
+func _read_text(path: String) -> String:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var content: String = file.get_as_text()
+	file.close()
+	return content
+
+
+func _config_xml(identity_name: String, executable: String, shell_attrs: Dictionary = {}) -> String:
+	var attrs: String = ""
+	for key: String in shell_attrs:
+		attrs += ' %s="%s"' % [key, shell_attrs[key]]
+	var xml: String = ""
+	xml += '<?xml version="1.0" encoding="utf-8"?>\n'
+	xml += '<Game configVersion="1">\n'
+	xml += '  <Identity Name="%s" Publisher="CN=Acme" Version="1.0.0.0" />\n' % identity_name
+	xml += '  <ExecutableList>\n'
+	xml += '    <Executable Name="%s" Id="Game" />\n' % executable
+	xml += '  </ExecutableList>\n'
+	xml += '  <ShellVisuals DefaultDisplayName="%s"%s />\n' % [identity_name, attrs]
+	xml += '  <MSStore ProductId="TEST-PRODUCT" />\n'
+	xml += '</Game>\n'
+	return xml
+
+
+func _new_preparer() -> RefCounted:
+	return PackagingContentPreparerScript.new(GameConfigManagerScript.new(_FakeToolchain.new()))
 
 
 # ── patch_executable_name ─────────────────────────────────────────────────
@@ -126,3 +201,40 @@ func test_pipeline_inject_then_patch_matches_caller_order() -> void:
 	var step2: String = PackagingContentPreparerScript.patch_executable_name(step1, "RealGame.exe")
 	assert_string_contains(step2, 'Executable Name="RealGame.exe"', "exe patched after inject")
 	assert_string_contains(step2, '<KnownDependency Name="VC14"/>', "VC14 still present after patch")
+
+
+func test_ensure_content_dir_uses_config_override() -> void:
+	var content_dir: String = _fixture_path("content")
+	DirAccess.make_dir_recursive_absolute(content_dir)
+	_write_text(content_dir.path_join("RealGame.exe"), "")
+	var config_path: String = _fixture_path("override/MicrosoftGame.config")
+	_write_text(config_path, _config_xml("OverrideGame", "Placeholder.exe"))
+
+	var ok: bool = _new_preparer().ensure_content_dir_ready(content_dir, Callable(), config_path)
+	assert_true(ok, "content prep succeeds with explicit config path")
+	var staged_config: String = _read_text(content_dir.path_join("MicrosoftGame.config"))
+	assert_string_contains(staged_config, 'Identity Name="OverrideGame"',
+		"staged config comes from the --config target")
+	assert_string_contains(staged_config, 'Executable Name="RealGame.exe"',
+		"staged config is still patched to the exported executable")
+
+
+func test_ensure_content_dir_rejects_logo_path_outside_content_dir() -> void:
+	var content_dir: String = _fixture_path("content")
+	DirAccess.make_dir_recursive_absolute(content_dir)
+	var config_path: String = _fixture_path("attack/MicrosoftGame.config")
+	_write_text(config_path, _config_xml("AttackGame", "Attack.exe", {
+		"Square150x150Logo": "..\\..\\outside.png",
+	}))
+	var outside_path: String = content_dir.path_join("..\\..\\outside.png").simplify_path()
+	var logs: Array[String] = []
+	var logger := func(message: String) -> void:
+		logs.append(message)
+
+	var ok: bool = _new_preparer().ensure_content_dir_ready(content_dir, logger, config_path)
+	assert_false(ok, "escaping logo destination is rejected")
+	assert_false(FileAccess.file_exists(outside_path), "no file is written outside the content dir")
+	assert_false(FileAccess.file_exists(content_dir.path_join("MicrosoftGame.config")),
+		"content prep aborts before staging config")
+	assert_string_contains("\n".join(logs), "outside content directory",
+		"error explains the content-dir safety rule")

--- a/tests/godot/gdk/tests/packaging/test_packaging_service.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_service.gd
@@ -1,0 +1,139 @@
+extends GutTest
+## Regression coverage for headless verb facade behaviours that the CLI
+## advertises directly.
+
+const PackagingServiceScript = preload("res://addons/godot_gdk_packaging/core/packaging_service.gd")
+
+const _FIXTURE_DIR := "user://test_packaging_service"
+
+class _FakeToolchain extends RefCounted:
+	func get_bin_dir() -> String:
+		return ProjectSettings.globalize_path("user://missing_gdk_bin")
+
+
+func before_each() -> void:
+	_reset_fixture()
+	DirAccess.make_dir_recursive_absolute(_fixture_root())
+
+
+func after_each() -> void:
+	_reset_fixture()
+
+
+func _fixture_root() -> String:
+	return ProjectSettings.globalize_path(_FIXTURE_DIR)
+
+
+func _fixture_path(relative_path: String) -> String:
+	return _fixture_root().path_join(relative_path)
+
+
+func _reset_fixture() -> void:
+	_remove_tree(_fixture_root())
+
+
+func _remove_tree(path: String) -> void:
+	if not DirAccess.dir_exists_absolute(path):
+		return
+	for file_name: String in DirAccess.get_files_at(path):
+		DirAccess.remove_absolute(path.path_join(file_name))
+	for dir_name: String in DirAccess.get_directories_at(path):
+		_remove_tree(path.path_join(dir_name))
+	DirAccess.remove_absolute(path)
+
+
+func _read_text(path: String) -> String:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var content: String = file.get_as_text()
+	file.close()
+	return content
+
+
+func _write_text(path: String, content: String) -> void:
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(content)
+	file.close()
+
+
+func _config_xml(identity_name: String, executable: String,
+		shell_attrs: Dictionary = {}) -> String:
+	var attrs: String = ""
+	for key: String in shell_attrs:
+		attrs += ' %s="%s"' % [key, shell_attrs[key]]
+	var xml: String = ""
+	xml += '<?xml version="1.0" encoding="utf-8"?>\n'
+	xml += '<Game configVersion="1">\n'
+	xml += '  <Identity Name="%s" Publisher="CN=Acme" Version="1.0.0.0" />\n' % identity_name
+	xml += '  <ExecutableList>\n'
+	xml += '    <Executable Name="%s" Id="Game" />\n' % executable
+	xml += '  </ExecutableList>\n'
+	xml += '  <ShellVisuals DefaultDisplayName="%s"%s />\n' % [identity_name, attrs]
+	xml += '  <MSStore ProductId="TEST-PRODUCT" />\n'
+	xml += '</Game>\n'
+	return xml
+
+
+func _new_service() -> RefCounted:
+	return PackagingServiceScript.new(_FakeToolchain.new())
+
+
+func test_prepare_content_reports_logo_escape_in_result_message() -> void:
+	var content_dir: String = _fixture_path("content")
+	DirAccess.make_dir_recursive_absolute(content_dir)
+	var config_path: String = _fixture_path("attack/MicrosoftGame.config")
+	_write_text(config_path, _config_xml("AttackGame", "Attack.exe", {
+		"Square150x150Logo": "..\\..\\outside.png",
+	}))
+
+	var result: Dictionary = _new_service().run_prepare_content({
+		"content_dir": content_dir,
+		"config_path": config_path,
+	})
+
+	assert_false(result["ok"], "escaping logo path fails content prep")
+	assert_string_contains(result["message"], "outside content directory",
+		"service result surfaces the rejection reason")
+	assert_false(FileAccess.file_exists(content_dir.path_join("MicrosoftGame.config")),
+		"rejected prep does not stage config")
+
+
+func test_config_template_output_writes_requested_path() -> void:
+	var output: String = _fixture_path("custom/AltGame.config")
+	var implicit_path: String = ProjectSettings.globalize_path("res://MicrosoftGame.config")
+	var implicit_existed: bool = FileAccess.file_exists(implicit_path)
+
+	var result: Dictionary = _new_service().run_config_template({
+		"output": output,
+		"app_name": "AltGame",
+		"identity_publisher": "Acme",
+	})
+
+	assert_true(result["ok"], "config_template succeeds")
+	assert_true(FileAccess.file_exists(output), "custom --output file is created")
+	assert_string_contains(_read_text(output), 'Executable Name="AltGame.exe"',
+		"template content lands in the requested output file")
+	if not implicit_existed:
+		assert_false(FileAccess.file_exists(implicit_path),
+			"custom --output does not create res://MicrosoftGame.config")
+
+
+func test_config_template_overwrite_recreates_requested_output() -> void:
+	var output: String = _fixture_path("custom/OverwriteGame.config")
+	_write_text(output, "old requested output")
+
+	var result: Dictionary = _new_service().run_config_template({
+		"output": output,
+		"overwrite": true,
+		"app_name": "OverwriteGame",
+		"identity_publisher": "Acme",
+	})
+
+	assert_true(result["ok"], "--overwrite succeeds")
+	assert_true(FileAccess.file_exists(output), "requested output is recreated")
+	var content: String = _read_text(output)
+	assert_false(content.contains("old requested output"), "old requested output was replaced")
+	assert_string_contains(content, 'Executable Name="OverwriteGame.exe"',
+		"new template is written at the requested output")

--- a/tests/godot/gdk/tests/packaging/test_packaging_service.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_service.gd
@@ -137,3 +137,64 @@ func test_config_template_overwrite_recreates_requested_output() -> void:
 	assert_false(content.contains("old requested output"), "old requested output was replaced")
 	assert_string_contains(content, 'Executable Name="OverwriteGame.exe"',
 		"new template is written at the requested output")
+
+
+# ── path normalization (PR #13 review follow-up) ────────────────────────────
+
+const _ConfigMgr = preload("res://addons/godot_gdk_packaging/core/game_config_manager.gd")
+
+
+func test_to_filesystem_path_passes_through_empty_string() -> void:
+	assert_eq(_ConfigMgr.to_filesystem_path(""), "",
+		"empty input is returned unchanged")
+
+
+func test_to_filesystem_path_globalizes_res_paths() -> void:
+	var normalized: String = _ConfigMgr.to_filesystem_path("res://Configs/Alt.config")
+	assert_eq(normalized, ProjectSettings.globalize_path("res://Configs/Alt.config"),
+		"res:// paths are globalized to filesystem-absolute form")
+
+
+func test_to_filesystem_path_globalizes_user_paths() -> void:
+	var normalized: String = _ConfigMgr.to_filesystem_path("user://test_packaging_service/some.config")
+	assert_eq(normalized, ProjectSettings.globalize_path("user://test_packaging_service/some.config"),
+		"user:// paths are globalized to filesystem-absolute form")
+
+
+func test_to_filesystem_path_preserves_absolute_paths() -> void:
+	var absolute_input: String = _fixture_path("custom/Already.config")
+	assert_eq(_ConfigMgr.to_filesystem_path(absolute_input), absolute_input,
+		"already-absolute filesystem paths are returned unchanged")
+
+
+func test_to_filesystem_path_resolves_relative_paths_against_project_root() -> void:
+	var relative: String = "Configs/Alt.config"
+	var expected: String = ProjectSettings.globalize_path("res://").path_join(relative)
+	assert_eq(_ConfigMgr.to_filesystem_path(relative), expected,
+		"relative --output paths are resolved against the project root, not CWD")
+
+
+func test_config_template_accepts_res_output_path() -> void:
+	# res://test_packaging_service/ResOut.config — write under user-test fixture
+	# tree by globalizing a unique res-rooted path.
+	var res_out: String = "res://test_packaging_service_res_out.config"
+	var fs_out: String = ProjectSettings.globalize_path(res_out)
+	# Clean any stale artefact from a previous run before / after the test.
+	if FileAccess.file_exists(fs_out):
+		DirAccess.remove_absolute(fs_out)
+
+	var result: Dictionary = _new_service().run_config_template({
+		"output": res_out,
+		"overwrite": true,
+		"app_name": "ResGame",
+		"identity_publisher": "Acme",
+	})
+
+	assert_true(result["ok"], "res:// --output succeeds (regression: PR #13 review)")
+	assert_true(FileAccess.file_exists(fs_out),
+		"res:// --output writes to its globalized filesystem path")
+	assert_string_contains(_read_text(fs_out), 'Executable Name="ResGame.exe"',
+		"template content lands at the res:// destination")
+	# Cleanup
+	if FileAccess.file_exists(fs_out):
+		DirAccess.remove_absolute(fs_out)

--- a/tests/godot/gdk/tests/packaging/test_packaging_service.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_service.gd
@@ -198,3 +198,41 @@ func test_config_template_accepts_res_output_path() -> void:
 	# Cleanup
 	if FileAccess.file_exists(fs_out):
 		DirAccess.remove_absolute(fs_out)
+
+
+# ── PR #13 round-2 review follow-up: storelogos lands next to the config ────
+
+
+func test_config_template_writes_storelogos_next_to_output() -> void:
+	# When --output writes outside the project root, the placeholder logos
+	# must land in <output_dir>/storelogos/ so the config's relative
+	# "storelogos\..." references resolve next to the file. (PR #13 round-2.)
+	var output: String = _fixture_path("alt_config_root/Custom.config")
+	var sibling_logos_dir: String = _fixture_path("alt_config_root/storelogos")
+	# Sanity: fixture starts clean.
+	assert_false(DirAccess.dir_exists_absolute(sibling_logos_dir),
+		"fixture starts with no sibling storelogos directory")
+
+	var result: Dictionary = _new_service().run_config_template({
+		"output": output,
+		"overwrite": true,
+		"app_name": "CustomGame",
+		"identity_publisher": "Acme",
+	})
+
+	assert_true(result["ok"], "config_template succeeds for out-of-tree output")
+	# We don't require the placeholder PNGs themselves (those need the GDK
+	# default480x480 PNG, which the FakeToolchain points at a missing path —
+	# the function will push_warning and return without writing PNGs). But we
+	# DO require that the implementation reaches for the *sibling* storelogos
+	# location, not res://storelogos, so the next-most-actionable check is
+	# that res://storelogos is not created as a side-effect of running the
+	# template with a custom --output.
+	var res_logos: String = ProjectSettings.globalize_path("res://storelogos")
+	# If res://storelogos already exists from a real prior template run we
+	# can't assert on its absence — gate the assertion on a clean start.
+	# In CI fixtures this directory is freshly created per-run.
+	if not DirAccess.dir_exists_absolute(res_logos):
+		# Already absent before — must remain absent after.
+		assert_false(DirAccess.dir_exists_absolute(res_logos),
+			"out-of-tree --output does not create res://storelogos as a side effect")


### PR DESCRIPTION
## Summary  Implements audit lane **D2 — Packaging headless CLI honesty + content-dir safety (HIGH)** on public `main` (`476deac`):  - Fixes audit item **#13**: headless `--config` is now used by config resolution and by `PackagingContentPreparer.ensure_content_dir_ready()`. - Fixes the `config_template --output` regression: output is written to the caller-selected target and `--overwrite` removes/recreates that same resolved output file. - Fixes audit item **#14**: logo paths from MicrosoftGame.config are simplified and rejected if absolute, Godot-URI, or escaping outside the content directory. - Adds regression coverage for the CLI flag table, `--config` parsing redirects, content prep override staging, logo traversal rejection, `config_template --output`, and overwrite behavior.  ## Files changed  - `addons/godot_gdk_packaging/run.gd` - `addons/godot_gdk_packaging/core/game_config_manager.gd` - `addons/godot_gdk_packaging/core/packaging_config.gd` - `addons/godot_gdk_packaging/core/packaging_content_preparer.gd` - `addons/godot_gdk_packaging/core/packaging_service.gd` - `addons/godot_gdk_packaging/core/packaging_cli.gd` - `tests/godot/gdk/tests/packaging/*` - `docs/packaging/plugin.md`, `spec/gdext-packaging.md`, `.github/instructions/godot-gdk-packaging.instructions.md`  ## Usage examples  ```pwsh addons\godot_gdk_packaging\gdkpkg.cmd prepare_content --content-dir Build\content --config Configs\Alt.config addons\godot_gdk_packaging\gdkpkg.cmd pack --source-dir Build\content --output-dir Build\out --config Configs\Alt.config addons\godot_gdk_packaging\gdkpkg.cmd config_template --output Configs\Alt.config --overwrite ```  ## CLI demonstration  From `build\d2-cli-demo-public`:  ```text [packaging] prepare_content ok ... Prepared ...\build\d2-cli-demo-public\content PACKAGING_RESULT_JSON:{..."ok":true,..."verb":"prepare_content"} ```  The staged `MicrosoftGame.config` came from `AltGame.config` and was patched to `Executable Name="RealGame.exe"`.  ```text [GDK Packaging] Created template MicrosoftGame.config at: ...\build\d2-cli-demo-public\templates\Custom.config [packaging] config_template ok ... Created template at ...\build\d2-cli-demo-public\templates\Custom.config ```  The existing requested output file was replaced; no implicit `tests\godot\gdk\MicrosoftGame.config` was created.  ```text [packaging] prepare_content fail ... Content prep failed: ❌ Refusing logo path outside content directory for Square150x150Logo: ..\..\outside.png PACKAGING_RESULT_JSON:{..."ok":false,"exit_code":4,...} ```  The rejected traversal did not stage `MicrosoftGame.config` and did not create the outside target.  ## Validation  - ✅ `git submodule update --init --recursive` - ✅ `cmake --preset default` - ✅ `cmake --build build --preset debug` - ✅ `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1 -Projects addons` - ✅ Changed packaging test scripts parsed with Godot `--check-only`. - ✅ D2 CLI demonstration above asserted `--config`, `--output`/`--overwrite`, and traversal rejection behavior. - ⚠️ Full `tools\check_gd_scripts_headless.ps1` fails on pre-existing sample typed-symbol parse issues in `sample\tutorial_app\autoload\auth.gd` (`GDKUser`/`PlayFabUser`) and `sample\tutorial_gameinput\main.gd` (`GameInput*` symbols). - ⚠️ Full `tools\run_all_tests.ps1` stops at that same parse gate and skips later stages.  Live coverage was skipped (default); `-Live` and live-write coverage were not run.