### PR TITLE
gi-tests: backfill coverage for cache, init-cycle, untested bind_methods, bootstrap, parameter branches

### DIFF
--- a/addons/godot_gameinput/doc_classes/GameInput.xml
+++ b/addons/godot_gameinput/doc_classes/GameInput.xml
@@ -63,7 +63,7 @@
 			<param index="3" name="left_trigger" type="float" default="0.0" />
 			<param index="4" name="right_trigger" type="float" default="0.0" />
 			<description>
-				Sets the rumble motor levels on [param device]. Each value is clamped to [code][0.0, 1.0][/code]. Returns [code]true[/code] when the rumble request was sent, or [code]false[/code] when the device is null, disconnected, has no rumble motors, or the runtime is not initialized. Trigger motors are only meaningful on impulse-trigger gamepads; pass [code]0.0[/code] on devices without them.
+				Sets the rumble motor levels on [param device]. Each value is clamped to [code][0.0, 1.0][/code]. Returns [code]true[/code] when the rumble request was sent, or [code]false[/code] when the device is null, disconnected, has no rumble motors, the runtime is not initialized, or the native [code]SetRumbleState[/code] call reports failure on SDKs that expose an HRESULT. Trigger motors are only meaningful on impulse-trigger gamepads; pass [code]0.0[/code] on devices without them.
 			</description>
 		</method>
 		<method name="stop_haptics">

--- a/addons/godot_gameinput/doc_classes/GameInputActionMap.xml
+++ b/addons/godot_gameinput/doc_classes/GameInputActionMap.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[GameInputActionMap] is a [Resource] that owns an ordered, typed array of [GameInputBinding]. Edit it in the inspector or build it in code, save and load via [code]ResourceSaver[/code] / [code]ResourceLoader[/code], and assign it to [member GameInputMapper.action_map] to drive Godot actions from GameInput.
-		Mutations through [method add_binding] and [method clear] emit [code]changed[/code] (inherited from [Resource]), so a [GameInputMapper] referencing the action map can react to live edits in the editor.
+		Mutations through [method set_bindings], [method add_binding], [method clear], and property edits on contained [GameInputBinding] resources emit [code]changed[/code] (inherited from [Resource]), so a [GameInputMapper] referencing the action map can release any currently held actions and refresh its caches before the next frame.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -19,7 +19,7 @@
 			<return type="void" />
 			<param index="0" name="bindings" type="Array" />
 			<description>
-				Replaces the entire binding list. The argument should be a typed [code]Array[GameInputBinding][/code]; non-binding entries are silently kept by Godot's typed-array machinery but ignored at runtime. See [member bindings].
+				Replaces the entire binding list and emits [code]changed[/code]. The argument should be a typed [code]Array[GameInputBinding][/code]; non-binding entries are silently kept by Godot's typed-array machinery but ignored at runtime. See [member bindings].
 			</description>
 		</method>
 		<method name="get_binding_count" qualifiers="const">

--- a/addons/godot_gameinput/doc_classes/GameInputMapper.xml
+++ b/addons/godot_gameinput/doc_classes/GameInputMapper.xml
@@ -5,9 +5,9 @@
 	</brief_description>
 	<description>
 		[GameInputMapper] is a [Node] that resolves a target [GameInputDevice] (either by id via [member target_device_id] or as the primary device of [member target_kind_mask]) every [code]_process[/code] frame, fetches its [GameInputReading], and walks [member action_map] calling [code]Input.action_press(action, strength)[/code] or [code]Input.action_release(action)[/code] on each press / release edge so the rest of your game can keep using the standard [code]Input.is_action_pressed("jump")[/code] APIs without knowing GameInput exists. On every press / release transition the mapper additionally pushes an [InputEventAction] through [code]Input.parse_input_event[/code] so event-driven listeners — Viewport GUI focus traversal for [code]ui_*[/code] actions, [code]_gui_input[/code] handlers, [code]_input[/code] / [code]_unhandled_input[/code] — actually see the action fire, since [code]Input.action_press[/code] alone updates polled state but does not deliver an [InputEvent].
-		To avoid double-firing when Godot's built-in joypad backend is already wired to deliver the same action via an [InputEventJoypadButton] / [InputEventJoypadMotion] in the project's [code]InputMap[/code] (e.g., the default [code]ui_accept[/code] mapping that includes joypad button A), the mapper checks each binding once against the action's [code]InputMap[/code] events and skips its own synthetic [InputEventAction] when a matching native joypad event is found. The polled state via [code]Input.action_press[/code] is still refreshed every frame either way. The check is per-binding, cached, and invalidated whenever [member action_map] is reassigned; runtime [code]InputMap[/code] edits made after the cache fills will tolerate one frame of staleness.
+		To avoid double-firing when Godot's built-in joypad backend is already wired to deliver the same action via an [InputEventJoypadButton] / [InputEventJoypadMotion] in the project's [code]InputMap[/code] (e.g., the default [code]ui_accept[/code] mapping that includes joypad button A), the mapper checks each binding once against the action's [code]InputMap[/code] events and skips its own synthetic [InputEventAction] when a matching native joypad event is found. The polled state via [code]Input.action_press[/code] is still refreshed every frame either way. The check is per-binding, cached, invalidated whenever [member action_map] or a binding on that map changes, and refreshed once per frame so runtime [code]InputMap[/code] edits made after the cache fills tolerate at most one frame of staleness.
 		The mapper calls [method GameInput.poll] defensively at the start of each frame; that call is per-frame idempotent so multiple [GameInputMapper] instances in the same scene do not refresh device state more than once per frame.
-		Action names listed in [member GameInputBinding.action] must already exist in the project's [code]InputMap[/code]. Missing actions emit a single [code]push_warning[/code] per [GameInputMapper] instance per action (debounced via an internal set) and the binding is then ignored. On [code]NOTIFICATION_EXIT_TREE[/code], any actions the mapper currently holds pressed are released so freed actions never get stuck.
+		Action names listed in [member GameInputBinding.action] must already exist in the project's [code]InputMap[/code]. Missing actions emit a single [code]push_warning[/code] per [GameInputMapper] instance per action (debounced via an internal set) and the binding is then ignored. Whenever the mapper stops driving a held binding — exiting the tree, swapping or mutating the active map, retargeting the mapper, losing the target device, or failing to obtain a fresh reading — it releases every action it previously held so Godot's polled action state cannot get stuck pressed.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -21,7 +21,7 @@
 			<return type="void" />
 			<param index="0" name="map" type="GameInputActionMap" />
 			<description>
-				Assigns a new action map. Resets the internal "previously pressed" state and the missing-action warning set so the new map gets a clean slate.
+				Assigns a new action map. Any actions held by the previous map are released before the internal previous-pressed state, native-event cache, and missing-action warning set are reset so the new map gets a clean slate.
 			</description>
 		</method>
 		<method name="get_target_kind_mask" qualifiers="const">
@@ -34,7 +34,7 @@
 			<return type="void" />
 			<param index="0" name="mask" type="int" />
 			<description>
-				Sets the kind mask used to pick a primary device. See [member target_kind_mask].
+				Sets the kind mask used to pick a primary device. If the mapper was holding any actions for the previous target scope, they are released before the mask changes. See [member target_kind_mask].
 			</description>
 		</method>
 		<method name="get_target_device_id" qualifiers="const">
@@ -47,7 +47,7 @@
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Sets a specific [GameInputDevice] id to drive. Pass [code]-1[/code] to revert to "primary device of [member target_kind_mask]". See [member target_device_id].
+				Sets a specific [GameInputDevice] id to drive. If the mapper was holding any actions for the previous device, they are released before the id changes. Pass [code]-1[/code] to revert to "primary device of [member target_kind_mask]". See [member target_device_id].
 			</description>
 		</method>
 		<method name="get_active_binding_count" qualifiers="const">

--- a/addons/godot_gameinput/src/gameinput_action_map.cpp
+++ b/addons/godot_gameinput/src/gameinput_action_map.cpp
@@ -24,8 +24,44 @@ void GameInputActionMap::_bind_methods() {
                  "set_bindings", "get_bindings");
 }
 
+void GameInputActionMap::_connect_binding_changed(const Ref<GameInputBinding> &binding) {
+    if (binding.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputActionMap::_on_binding_changed);
+    if (!binding->is_connected("changed", callback)) {
+        binding->connect("changed", callback);
+    }
+}
+
+void GameInputActionMap::_disconnect_binding_changed(const Ref<GameInputBinding> &binding) {
+    if (binding.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputActionMap::_on_binding_changed);
+    if (binding->is_connected("changed", callback)) {
+        binding->disconnect("changed", callback);
+    }
+}
+
+void GameInputActionMap::_disconnect_all_binding_changed() {
+    for (int i = 0; i < (int)m_bindings.size(); ++i) {
+        Ref<GameInputBinding> binding = m_bindings[i];
+        _disconnect_binding_changed(binding);
+    }
+}
+
+void GameInputActionMap::_on_binding_changed() {
+    emit_changed();
+}
+
 void GameInputActionMap::set_bindings(const TypedArray<GameInputBinding> &p_bindings) {
+    _disconnect_all_binding_changed();
     m_bindings = p_bindings;
+    for (int i = 0; i < (int)m_bindings.size(); ++i) {
+        Ref<GameInputBinding> binding = m_bindings[i];
+        _connect_binding_changed(binding);
+    }
     emit_changed();
 }
 
@@ -46,11 +82,13 @@ Ref<GameInputBinding> GameInputActionMap::get_binding(int index) const {
 
 void GameInputActionMap::add_binding(const Ref<GameInputBinding> &binding) {
     if (binding.is_null()) return;
+    _connect_binding_changed(binding);
     m_bindings.push_back(binding);
     emit_changed();
 }
 
 void GameInputActionMap::clear() {
+    _disconnect_all_binding_changed();
     m_bindings.clear();
     emit_changed();
 }

--- a/addons/godot_gameinput/src/gameinput_action_map.h
+++ b/addons/godot_gameinput/src/gameinput_action_map.h
@@ -17,6 +17,11 @@ class GameInputActionMap : public Resource {
 private:
     TypedArray<GameInputBinding> m_bindings;
 
+    void _connect_binding_changed(const Ref<GameInputBinding> &binding);
+    void _disconnect_binding_changed(const Ref<GameInputBinding> &binding);
+    void _disconnect_all_binding_changed();
+    void _on_binding_changed();
+
 protected:
     static void _bind_methods();
 

--- a/addons/godot_gameinput/src/gameinput_mapper.cpp
+++ b/addons/godot_gameinput/src/gameinput_mapper.cpp
@@ -6,12 +6,14 @@
 #include "gameinput_device.h"
 #include "gameinput_reading.h"
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/input.hpp>
 #include <godot_cpp/classes/input_event.hpp>
 #include <godot_cpp/classes/input_event_action.hpp>
 #include <godot_cpp/classes/input_event_joypad_button.hpp>
 #include <godot_cpp/classes/input_event_joypad_motion.hpp>
 #include <godot_cpp/classes/input_map.hpp>
+#include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/variant/typed_array.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
@@ -21,6 +23,11 @@ namespace godot {
 
 GameInputMapper::GameInputMapper() {
     set_process(true);
+}
+
+GameInputMapper::~GameInputMapper() {
+    _release_held_actions();
+    _disconnect_action_map_changed(m_action_map);
 }
 
 void GameInputMapper::_bind_methods() {
@@ -36,6 +43,14 @@ void GameInputMapper::_bind_methods() {
                          &GameInputMapper::get_target_device_id);
     ClassDB::bind_method(D_METHOD("get_active_binding_count"),
                          &GameInputMapper::get_active_binding_count);
+#ifndef NDEBUG
+    ClassDB::bind_method(D_METHOD("_test_mark_binding_pressed", "binding_index"),
+                         &GameInputMapper::_test_mark_binding_pressed);
+    ClassDB::bind_method(D_METHOD("_test_prime_native_handles_cache", "binding_index", "native_handles"),
+                         &GameInputMapper::_test_prime_native_handles_cache);
+    ClassDB::bind_method(D_METHOD("_test_get_native_handles_cache_count"),
+                         &GameInputMapper::_test_get_native_handles_cache_count);
+#endif
 
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "action_map",
                               PROPERTY_HINT_RESOURCE_TYPE, "GameInputActionMap"),
@@ -55,33 +70,21 @@ void GameInputMapper::_notification(int p_what) {
     if (p_what == NOTIFICATION_PROCESS) {
         _process_bindings();
     } else if (p_what == NOTIFICATION_EXIT_TREE) {
-        // Release any actions we currently hold pressed.
-        Input *input = Input::get_singleton();
-        InputMap *imap = InputMap::get_singleton();
-        if (input && imap && m_action_map.is_valid()) {
-            for (KeyValue<int, bool> &kv : m_prev_pressed) {
-                if (!kv.value) continue;
-                Ref<GameInputBinding> b = m_action_map->get_binding(kv.key);
-                if (b.is_null()) continue;
-                StringName a = b->get_action();
-                if (a != StringName() && imap->has_action(a)) {
-                    input->action_release(a);
-                    Ref<InputEventAction> evt;
-                    evt.instantiate();
-                    evt->set_action(a);
-                    evt->set_pressed(false);
-                    input->parse_input_event(evt);
-                }
-            }
-        }
-        m_prev_pressed.clear();
+        _release_held_actions();
     }
 }
 
 void GameInputMapper::set_action_map(const Ref<GameInputActionMap> &map) {
+    if (m_action_map == map) {
+        return;
+    }
+
+    _release_held_actions();
+    _disconnect_action_map_changed(m_action_map);
     m_action_map = map;
-    m_prev_pressed.clear();
-    m_native_handles_cache.clear();
+    _connect_action_map_changed(m_action_map);
+    _forget_pressed_state();
+    _invalidate_native_handles_cache();
     m_warned_missing_actions.clear();
 }
 
@@ -89,10 +92,22 @@ Ref<GameInputActionMap> GameInputMapper::get_action_map() const {
     return m_action_map;
 }
 
-void GameInputMapper::set_target_kind_mask(int mask) { m_target_kind_mask = mask; }
+void GameInputMapper::set_target_kind_mask(int mask) {
+    if (m_target_kind_mask == mask) {
+        return;
+    }
+    _release_held_actions();
+    m_target_kind_mask = mask;
+}
 int GameInputMapper::get_target_kind_mask() const { return m_target_kind_mask; }
 
-void GameInputMapper::set_target_device_id(int64_t id) { m_target_device_id = id; }
+void GameInputMapper::set_target_device_id(int64_t id) {
+    if (m_target_device_id == id) {
+        return;
+    }
+    _release_held_actions();
+    m_target_device_id = id;
+}
 int64_t GameInputMapper::get_target_device_id() const { return m_target_device_id; }
 
 int GameInputMapper::get_active_binding_count() const {
@@ -101,6 +116,120 @@ int GameInputMapper::get_active_binding_count() const {
         if (kv.value) n++;
     }
     return n;
+}
+
+#ifndef NDEBUG
+void GameInputMapper::_test_mark_binding_pressed(int binding_index) {
+    if (m_action_map.is_null()) {
+        return;
+    }
+    Ref<GameInputBinding> binding = m_action_map->get_binding(binding_index);
+    if (binding.is_null()) {
+        return;
+    }
+    StringName action = binding->get_action();
+    if (action == StringName()) {
+        return;
+    }
+    Input *input = Input::get_singleton();
+    if (input) {
+        input->action_press(action, 1.0f);
+    }
+    m_prev_pressed[binding_index] = true;
+    m_prev_actions[binding_index] = action;
+}
+
+void GameInputMapper::_test_prime_native_handles_cache(int binding_index, bool native_handles) {
+    m_native_handles_cache[binding_index] = native_handles;
+}
+
+int GameInputMapper::_test_get_native_handles_cache_count() const {
+    return (int)m_native_handles_cache.size();
+}
+#endif
+
+void GameInputMapper::_release_held_action_for(int binding_index) {
+    bool was_pressed = false;
+    if (HashMap<int, bool>::Iterator it = m_prev_pressed.find(binding_index)) {
+        was_pressed = it->value;
+    }
+
+    if (was_pressed) {
+        StringName action;
+        if (HashMap<int, StringName>::Iterator ait = m_prev_actions.find(binding_index)) {
+            action = ait->value;
+        }
+        if (action == StringName() && m_action_map.is_valid()) {
+            Ref<GameInputBinding> binding = m_action_map->get_binding(binding_index);
+            if (binding.is_valid()) {
+                action = binding->get_action();
+            }
+        }
+
+        Input *input = Input::get_singleton();
+        InputMap *imap = InputMap::get_singleton();
+        if (input && action != StringName()) {
+            input->action_release(action);
+            if (imap && imap->has_action(action)) {
+                Ref<InputEventAction> evt;
+                evt.instantiate();
+                evt->set_action(action);
+                evt->set_pressed(false);
+                input->parse_input_event(evt);
+            }
+        }
+        }
+    }
+
+    m_prev_pressed.erase(binding_index);
+    m_prev_actions.erase(binding_index);
+}
+
+void GameInputMapper::_release_held_actions() {
+    Vector<int> keys;
+    for (const KeyValue<int, bool> &kv : m_prev_pressed) {
+        keys.push_back(kv.key);
+    }
+    for (int i = 0; i < keys.size(); ++i) {
+        _release_held_action_for(keys[i]);
+    }
+}
+
+void GameInputMapper::_forget_pressed_state() {
+    m_prev_pressed.clear();
+    m_prev_actions.clear();
+}
+
+void GameInputMapper::_invalidate_native_handles_cache() {
+    m_native_handles_cache.clear();
+    m_native_handles_cache_frame = UINT64_MAX;
+}
+
+void GameInputMapper::_connect_action_map_changed(const Ref<GameInputActionMap> &map) {
+    if (map.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputMapper::_on_action_map_changed);
+    if (!map->is_connected("changed", callback)) {
+        map->connect("changed", callback);
+    }
+}
+
+void GameInputMapper::_disconnect_action_map_changed(const Ref<GameInputActionMap> &map) {
+    if (map.is_null()) {
+        return;
+    }
+    Callable callback = callable_mp(this, &GameInputMapper::_on_action_map_changed);
+    if (map->is_connected("changed", callback)) {
+        map->disconnect("changed", callback);
+    }
+}
+
+void GameInputMapper::_on_action_map_changed() {
+    _release_held_actions();
+    _forget_pressed_state();
+    _invalidate_native_handles_cache();
+    m_warned_missing_actions.clear();
 }
 
 bool GameInputMapper::_is_pressed_for(int source, float &out_strength,
@@ -152,10 +281,23 @@ bool GameInputMapper::_is_pressed_for(int source, float &out_strength,
 }
 
 void GameInputMapper::_process_bindings() {
-    if (m_action_map.is_null()) return;
+    if (m_action_map.is_null()) {
+        _release_held_actions();
+        return;
+    }
+
+    Engine *engine = Engine::get_singleton();
+    uint64_t frame = engine ? engine->get_process_frames() : 0;
+    if (frame != m_native_handles_cache_frame) {
+        m_native_handles_cache.clear();
+        m_native_handles_cache_frame = frame;
+    }
 
     GameInput *gi = GameInput::get_singleton();
-    if (!gi || !gi->is_initialized()) return;
+    if (!gi || !gi->is_initialized()) {
+        _release_held_actions();
+        return;
+    }
 
     gi->poll(); // idempotent per frame
 
@@ -175,24 +317,64 @@ void GameInputMapper::_process_bindings() {
     }
 
     if (device.is_null() || !device->is_connected()) {
+        _release_held_actions();
         return;
     }
 
     Ref<GameInputReading> reading = gi->get_current_reading(device);
-    if (reading.is_null()) return;
+    if (reading.is_null()) {
+        _release_held_actions();
+        return;
+    }
 
     Input *input = Input::get_singleton();
     InputMap *imap = InputMap::get_singleton();
-    if (!input || !imap) return;
+    if (!input || !imap) {
+        _release_held_actions();
+        return;
+    }
 
     int n = m_action_map->get_binding_count();
+    Vector<int> stale_binding_indices;
+    for (const KeyValue<int, bool> &kv : m_prev_pressed) {
+        if (kv.key < 0 || kv.key >= n) {
+            stale_binding_indices.push_back(kv.key);
+        }
+    }
+    for (int i = 0; i < stale_binding_indices.size(); ++i) {
+        _release_held_action_for(stale_binding_indices[i]);
+    }
+
     for (int i = 0; i < n; ++i) {
         Ref<GameInputBinding> b = m_action_map->get_binding(i);
-        if (b.is_null()) continue;
+        if (b.is_null()) {
+            _release_held_action_for(i);
+            continue;
+        }
 
         StringName action = b->get_action();
-        if (action == StringName()) continue;
+        if (action == StringName()) {
+            _release_held_action_for(i);
+            continue;
+        }
+
+        bool was_pressed = false;
+        if (HashMap<int, bool>::Iterator it = m_prev_pressed.find(i)) {
+            was_pressed = it->value;
+        }
+        if (was_pressed) {
+            StringName prev_action;
+            if (HashMap<int, StringName>::Iterator ait = m_prev_actions.find(i)) {
+                prev_action = ait->value;
+            }
+            if (prev_action != StringName() && prev_action != action) {
+                _release_held_action_for(i);
+                was_pressed = false;
+            }
+        }
+
         if (!imap->has_action(action)) {
+            _release_held_action_for(i);
             if (!m_warned_missing_actions.has(action)) {
                 m_warned_missing_actions.insert(action);
                 UtilityFunctions::push_warning(
@@ -223,11 +405,6 @@ void GameInputMapper::_process_bindings() {
             float s = 0.0f;
             is_pressed = _is_pressed_for(b->get_source(), s, reading.ptr());
             strength = s;
-        }
-
-        bool was_pressed = false;
-        if (HashMap<int, bool>::Iterator it = m_prev_pressed.find(i)) {
-            was_pressed = it->value;
         }
 
         if (is_pressed) {
@@ -270,6 +447,11 @@ void GameInputMapper::_process_bindings() {
         }
 
         m_prev_pressed[i] = is_pressed;
+        if (is_pressed) {
+            m_prev_actions[i] = action;
+        } else {
+            m_prev_actions.erase(i);
+        }
     }
 }
 

--- a/addons/godot_gameinput/src/gameinput_mapper.h
+++ b/addons/godot_gameinput/src/gameinput_mapper.h
@@ -7,6 +7,8 @@
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/variant/string_name.hpp>
 
+#include <cstdint>
+
 namespace godot {
 
 class GameInputActionMap;
@@ -29,7 +31,8 @@ class GameInputActionMap;
 // InputMap once, caches the result per binding, and skips its own
 // InputEventAction emit when a matching native event exists. The polled
 // action_press path keeps running either way; only the synthetic event is
-// suppressed. The cache is invalidated whenever the action_map changes.
+// suppressed. The cache is invalidated whenever the action_map changes and
+// refreshed per frame so runtime InputMap edits are stale for at most one frame.
 //
 // Action names must already exist in Godot's InputMap for the standard
 // Input.is_action_pressed("jump") API to work; the Mapper warns once per
@@ -56,16 +59,16 @@ private:
     // Per-binding press state from the previous frame so we can emit
     // press/release on the right edges. Keyed by binding index in the map.
     HashMap<int, bool> m_prev_pressed;
+    HashMap<int, StringName> m_prev_actions;
 
     // Per-binding cache: does Godot's built-in joypad backend already drive
     // this binding's action via an equivalent InputEventJoypadButton /
     // InputEventJoypadMotion in the project's InputMap? When true, we skip
     // emitting our own InputEventAction for the same press to avoid every
     // ui_accept / ui_up / etc. firing twice. The polled state (action_press)
-    // still gets refreshed every frame either way. Cache is invalidated when
-    // the action map changes; rare runtime InputMap edits are tolerated as
-    // single-frame staleness.
+    // still gets refreshed every frame either way.
     HashMap<int, bool> m_native_handles_cache;
+    uint64_t m_native_handles_cache_frame = UINT64_MAX;
 
     // Action names we've already warned about being missing from InputMap.
     HashSet<StringName> m_warned_missing_actions;
@@ -75,6 +78,13 @@ private:
                          class GameInputReading *reading) const;
     bool _native_path_handles_binding(const Ref<class GameInputBinding> &binding,
                                       const StringName &action) const;
+    void _release_held_actions();
+    void _release_held_action_for(int binding_index);
+    void _forget_pressed_state();
+    void _invalidate_native_handles_cache();
+    void _connect_action_map_changed(const Ref<GameInputActionMap> &map);
+    void _disconnect_action_map_changed(const Ref<GameInputActionMap> &map);
+    void _on_action_map_changed();
 
     static int _source_to_joy_button(int source);
     static int _source_to_joy_axis(int source);
@@ -85,7 +95,7 @@ protected:
 
 public:
     GameInputMapper();
-    ~GameInputMapper() = default;
+    ~GameInputMapper();
 
     void set_action_map(const Ref<GameInputActionMap> &map);
     Ref<GameInputActionMap> get_action_map() const;
@@ -98,6 +108,11 @@ public:
 
     // For tests / inspection.
     int get_active_binding_count() const;
+#ifndef NDEBUG
+    void _test_mark_binding_pressed(int binding_index);
+    void _test_prime_native_handles_cache(int binding_index, bool native_handles);
+    int _test_get_native_handles_cache_count() const;
+#endif
 };
 
 } // namespace godot

--- a/addons/godot_gameinput/src/gameinput_singleton.cpp
+++ b/addons/godot_gameinput/src/gameinput_singleton.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <type_traits>
 
 namespace godot {
 
@@ -21,6 +22,33 @@ static inline const GameInputDeviceInfo *_get_device_info(IGameInputDevice *devi
     const GameInputDeviceInfo *info = nullptr;
     HRESULT hr = device->GetDeviceInfo(&info);
     return SUCCEEDED(hr) ? info : nullptr;
+}
+
+template <typename DeviceT>
+static inline HRESULT _set_rumble_state_checked_impl(DeviceT *device,
+                                                     const GameInputRumbleParams *params) {
+    using ReturnT = decltype(device->SetRumbleState(params));
+    if constexpr (std::is_same_v<ReturnT, void>) {
+        device->SetRumbleState(params);
+        return S_OK;
+    } else {
+        ReturnT result = device->SetRumbleState(params);
+        if constexpr (std::is_same_v<ReturnT, HRESULT>) {
+            return result;
+        } else if constexpr (std::is_same_v<ReturnT, bool>) {
+            return result ? S_OK : E_FAIL;
+        } else {
+            return (HRESULT)result;
+        }
+    }
+}
+
+static inline HRESULT _set_rumble_state_checked(IGameInputDevice *device,
+                                                const GameInputRumbleParams *params) {
+    if (!device || !params) {
+        return E_POINTER;
+    }
+    return _set_rumble_state_checked_impl(device, params);
 }
 
 GameInput *GameInput::singleton = nullptr;
@@ -122,7 +150,7 @@ void CALLBACK GameInput::_on_device_callback(
         GameInputDeviceStatus current_status,
         GameInputDeviceStatus previous_status) {
     auto *self = static_cast<GameInput *>(context);
-    if (!self || !device) {
+    if (!self || !device || !self->m_accepting_callbacks.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -141,8 +169,26 @@ void CALLBACK GameInput::_on_device_callback(
 
     {
         std::lock_guard<std::mutex> lock(self->m_event_mutex);
+        if (!self->m_accepting_callbacks.load(std::memory_order_acquire)) {
+            device->Release();
+            return;
+        }
         self->m_pending_events.push_back(ev);
     }
+}
+
+void GameInput::_release_pending_events_locked() {
+    for (uint32_t i = 0; i < m_pending_events.size(); ++i) {
+        if (m_pending_events[i].native_device) {
+            m_pending_events[i].native_device->Release();
+        }
+    }
+    m_pending_events.clear();
+}
+
+void GameInput::_clear_pending_events() {
+    std::lock_guard<std::mutex> lock(m_event_mutex);
+    _release_pending_events_locked();
 }
 
 void GameInput::_drain_pending_events() {
@@ -234,6 +280,7 @@ bool GameInput::initialize() {
     if (m_initialized) {
         return true;
     }
+    m_accepting_callbacks.store(false, std::memory_order_release);
     HRESULT hr = ::GameInputCreate(&m_game_input);
     if (FAILED(hr) || !m_game_input) {
         if (!m_warned_create_failed) {
@@ -246,6 +293,7 @@ bool GameInput::initialize() {
         return false;
     }
 
+    m_accepting_callbacks.store(true, std::memory_order_release);
     hr = m_game_input->RegisterDeviceCallback(
         nullptr,
         (GameInputKind)(GameInputKindGamepad | GameInputKindKeyboard | GameInputKindMouse),
@@ -255,10 +303,13 @@ bool GameInput::initialize() {
         &GameInput::_on_device_callback,
         &m_device_callback_token);
     if (FAILED(hr)) {
+        m_accepting_callbacks.store(false, std::memory_order_release);
         UtilityFunctions::push_warning(
             "GameInput: RegisterDeviceCallback failed (hr=", (int64_t)hr, ")");
+        _clear_pending_events();
         m_game_input->Release();
         m_game_input = nullptr;
+        m_device_callback_token = 0;
         return false;
     }
 
@@ -269,11 +320,16 @@ bool GameInput::initialize() {
 }
 
 void GameInput::shutdown() {
-    if (!m_initialized) return;
+    if (!m_initialized && !m_game_input) return;
+
+    m_accepting_callbacks.store(false, std::memory_order_release);
 
     if (m_game_input && m_device_callback_token) {
-        // GameInput v3 dropped the timeout parameter that v1 accepted here.
-        m_game_input->UnregisterCallback(m_device_callback_token);
+        bool unregistered = m_game_input->UnregisterCallback(m_device_callback_token);
+        if (!unregistered) {
+            UtilityFunctions::push_warning(
+                "GameInput: UnregisterCallback() failed; late callbacks will be ignored.");
+        }
         m_device_callback_token = 0;
     }
 
@@ -284,7 +340,7 @@ void GameInput::shutdown() {
             const GameInputDeviceInfo *info = _get_device_info(d);
             if (info && info->supportedRumbleMotors != GameInputRumbleNone) {
                 GameInputRumbleParams zero{};
-                d->SetRumbleState(&zero);
+                _set_rumble_state_checked(d, &zero);
             }
             d->Release();
         }
@@ -292,15 +348,7 @@ void GameInput::shutdown() {
     m_devices.clear();
 
     // Drain any leftover queued events to release their AddRef.
-    {
-        std::lock_guard<std::mutex> lock(m_event_mutex);
-        for (uint32_t i = 0; i < m_pending_events.size(); ++i) {
-            if (m_pending_events[i].native_device) {
-                m_pending_events[i].native_device->Release();
-            }
-        }
-        m_pending_events.clear();
-    }
+    _clear_pending_events();
 
     if (m_game_input) {
         m_game_input->Release();
@@ -409,7 +457,12 @@ bool GameInput::set_vibration(const Ref<GameInputDevice> &device, float low_freq
     params.highFrequency = std::max(0.0f, std::min(1.0f, high_freq));
     params.leftTrigger   = std::max(0.0f, std::min(1.0f, left_trigger));
     params.rightTrigger  = std::max(0.0f, std::min(1.0f, right_trigger));
-    native->SetRumbleState(&params);
+    HRESULT hr = _set_rumble_state_checked(native, &params);
+    if (FAILED(hr)) {
+        UtilityFunctions::push_warning(
+            "GameInput: SetRumbleState failed (hr=", (int64_t)hr, ")");
+        return false;
+    }
     return true;
 }
 

--- a/addons/godot_gameinput/src/gameinput_singleton.h
+++ b/addons/godot_gameinput/src/gameinput_singleton.h
@@ -65,6 +65,7 @@ private:
 
     IGameInput *m_game_input = nullptr;
     GameInputCallbackToken m_device_callback_token = 0;
+    std::atomic_bool m_accepting_callbacks{false};
     bool m_initialized = false;
     bool m_warned_uninitialized = false;
     bool m_warned_create_failed = false;
@@ -97,6 +98,8 @@ private:
     };
     Vector<DeviceEntry> m_devices;
 
+    void _release_pending_events_locked();
+    void _clear_pending_events();
     void _drain_pending_events();
     void _real_poll();
     int _find_index_by_id(int64_t id) const;

--- a/addons/godot_playfab/doc_classes/PlayFab.xml
+++ b/addons/godot_playfab/doc_classes/PlayFab.xml
@@ -4,20 +4,20 @@
 		Root singleton for PlayFab services integration.
 	</brief_description>
 	<description>
-		PlayFab is the engine singleton that owns the PlayFab runtime, shared async dispatch, user sign-in, Game Saves, leaderboards, Multiplayer lobby/matchmaking, and client-safe PlayFab service surfaces. Configure [code]playfab/runtime/title_id[/code] in Project Settings before calling [method initialize]. By default the addon pumps completions automatically each process frame through [code]playfab/runtime/embed_dispatch[/code]; call [method dispatch] manually when that setting is disabled.
+		PlayFab is the engine singleton that owns the PlayFab runtime, shared async dispatch, user sign-in, Game Saves, leaderboards, Multiplayer lobby/matchmaking, and client-safe PlayFab service surfaces. Configure [code]playfab/runtime/title_id[/code] in Project Settings before calling [method initialize]. By default the addon pumps completions automatically each process frame through [code]playfab/runtime/embed_dispatch[/code]; call [method dispatch] manually when that setting is disabled. [method initialize] and [method shutdown] can be cycled to re-arm PlayFab Core, Services, Game Save Files, and the task queue; the underlying XGameRuntime reference is process-lifetime state released once when the extension singleton is torn down.
 	</description>
 	<tutorials></tutorials>
 	<methods>
 		<method name="initialize">
 			<return type="PlayFabResult" />
 			<description>
-				Initializes the PlayFab runtime using [code]playfab/runtime/title_id[/code] and [code]playfab/runtime/endpoint[/code] from Project Settings. Returns a [PlayFabResult] describing success or failure.
+				Initializes PlayFab Core, Services, Game Save Files, and the shared task queue using [code]playfab/runtime/title_id[/code] and [code]playfab/runtime/endpoint[/code] from Project Settings. Returns a [PlayFabResult] describing success or failure. The first successful XGameRuntime initialization also acquires this addon's process-lifetime XGameRuntime reference.
 			</description>
 		</method>
 		<method name="shutdown">
 			<return type="void" />
 			<description>
-				Shuts down the PlayFab runtime and clears cached user state.
+				Shuts down PlayFab Core, Services, Game Save Files, the shared task queue, and cached user state. This is safe to call before another [method initialize]; it does not release the process-lifetime XGameRuntime reference.
 			</description>
 		</method>
 		<method name="is_available" qualifiers="const">

--- a/addons/godot_playfab/doc_classes/PlayFabMultiplayer.xml
+++ b/addons/godot_playfab/doc_classes/PlayFabMultiplayer.xml
@@ -4,7 +4,7 @@
 		PlayFab Multiplayer lobby and matchmaking service.
 	</brief_description>
 	<description>
-		Accessed through [code]PlayFab.multiplayer[/code]. All user-owned calls require a signed-in [PlayFabUser] and use that user's native entity handle. Matchmaking completion reports arranged-lobby connection strings but never auto-joins them.
+		Accessed through [code]PlayFab.multiplayer[/code]. All user-owned calls require a signed-in [PlayFabUser] and use that user's native entity handle. Matchmaking completion reports arranged-lobby connection strings but never auto-joins them. Failed lobby create/join completions detach their temporary [PlayFabLobby] wrapper and do not appear in [method get_lobbies]. If finishing lobby or matchmaking state changes fails, [signal multiplayer_error] is emitted and the service resets to an uninitialized state; call [method initialize_async] again before issuing more Multiplayer calls.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -16,7 +16,7 @@
 		<method name="join_arranged_lobby_async"><return type="Signal" /><param index="0" name="user" type="PlayFabUser" /><param index="1" name="connection_string" type="String" /><param index="2" name="config" type="PlayFabLobbyJoinConfig" default="null" /><description>Explicitly joins an arranged lobby using a connection string from a matched ticket.</description></method>
 		<method name="find_lobbies_async"><return type="Signal" /><param index="0" name="user" type="PlayFabUser" /><param index="1" name="search" type="PlayFabLobbySearchConfig" default="null" /><description>Searches lobbies for [param user].</description></method>
 		<method name="create_match_ticket_async"><return type="Signal" /><param index="0" name="user" type="PlayFabUser" /><param index="1" name="config" type="PlayFabMatchmakingTicketConfig" /><description>Creates a matchmaking ticket.</description></method>
-		<method name="get_lobbies" qualifiers="const"><return type="Array" /><description>Returns tracked, connected lobbies.</description></method>
+		<method name="get_lobbies" qualifiers="const"><return type="Array" /><description>Returns tracked, connected lobbies. Failed create/join attempts are removed before their failure signal completes.</description></method>
 		<method name="get_lobby" qualifiers="const"><return type="PlayFabLobby" /><param index="0" name="lobby_id" type="String" /><description>Returns a tracked lobby by id.</description></method>
 		<method name="get_match_tickets" qualifiers="const"><return type="Array" /><description>Returns tracked tickets.</description></method>
 	</methods>
@@ -24,7 +24,7 @@
 	<signals>
 		<signal name="state_changed"><param index="0" name="change" type="PlayFabMultiplayerStateChange" /><description>Aggregate lobby and matchmaking state signal.</description></signal>
 		<signal name="invite_received"><param index="0" name="invite" type="PlayFabLobbyInvite" /><description>Emitted when a lobby invite arrives.</description></signal>
-		<signal name="multiplayer_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Multiplayer dispatch errors.</description></signal>
+		<signal name="multiplayer_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Multiplayer dispatch errors. A [code]lobby_state_finish_failed[/code] or [code]matchmaking_state_finish_failed[/code] result means the native dispatcher was reset and [method initialize_async] must succeed before further Multiplayer use.</description></signal>
 	</signals>
 	<constants></constants>
 </class>

--- a/addons/godot_playfab/doc_classes/PlayFabParty.xml
+++ b/addons/godot_playfab/doc_classes/PlayFabParty.xml
@@ -4,7 +4,7 @@
 		PlayFab Party network and chat service.
 	</brief_description>
 	<description>
-		Accessed through [code]PlayFab.party[/code]. Owns PlayFab Party initialization, network host/join flows, descriptor serialization, and chat-control integration. The title-facing transport object is [PlayFabPartyPeer], assigned to [code]multiplayer.multiplayer_peer[/code] for RPC traffic and exposing peer-id helpers for text chat, mute, and permissions. PlayFab Multiplayer lobbies and matchmaking are handled separately by [PlayFabMultiplayer].
+		Accessed through [code]PlayFab.party[/code]. Owns PlayFab Party initialization, network host/join flows, descriptor serialization, and chat-control integration. The title-facing transport object is [PlayFabPartyPeer], assigned to [code]multiplayer.multiplayer_peer[/code] for RPC traffic and exposing peer-id helpers for text chat, mute, and permissions. PlayFab Multiplayer lobbies and matchmaking are handled separately by [PlayFabMultiplayer]. If [code]PartyManager::FinishProcessingStateChanges[/code] fails, [signal party_error] is emitted, active wrappers are detached, and the service resets to an uninitialized state; call [method initialize_async] before using Party again.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -19,7 +19,7 @@
 	</methods>
 	<members></members>
 	<signals>
-		<signal name="party_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Party dispatch errors.</description></signal>
+		<signal name="party_error"><param index="0" name="result" type="PlayFabResult" /><description>Emitted for Party dispatch errors. A [code]party_state_finish_failed[/code] result means Party was reset and must be initialized again before further use.</description></signal>
 	</signals>
 	<constants>
 		<constant name="DIRECT_PEER_CONNECTIVITY_NONE" value="0" enum="DirectPeerConnectivity">No direct peer connectivity; all traffic relays through PlayFab Party. This is the default and is always valid by itself.</constant>

--- a/addons/godot_playfab/src/playfab_multiplayer.cpp
+++ b/addons/godot_playfab/src/playfab_multiplayer.cpp
@@ -914,12 +914,77 @@ void PlayFabMultiplayer::_track_lobby(const Ref<PlayFabLobby> &p_lobby) {
     }
 }
 
+void PlayFabMultiplayer::_untrack_lobby(const Ref<PlayFabLobby> &p_lobby) {
+    if (!p_lobby.is_valid()) {
+        return;
+    }
+    m_lobbies.erase(std::remove(m_lobbies.begin(), m_lobbies.end(), p_lobby), m_lobbies.end());
+}
+
 void PlayFabMultiplayer::_track_ticket(const Ref<PlayFabMatchTicket> &p_ticket) {
     if (!p_ticket.is_valid() || !p_ticket->get_native_handle()) {
         return;
     }
     if (_find_ticket(p_ticket->get_native_handle()).is_null()) {
         m_tickets.push_back(p_ticket);
+    }
+}
+
+void PlayFabMultiplayer::_terminate_multiplayer_queue() {
+    if (m_multiplayer_queue == nullptr) {
+        return;
+    }
+
+    const HRESULT terminate_hr = XTaskQueueTerminate(m_multiplayer_queue, true, nullptr, nullptr);
+    if (FAILED(terminate_hr)) {
+        WARN_PRINT(vformat("PlayFabMultiplayer: XTaskQueueTerminate(wait=true) failed during shutdown/reset: %s", PlayFabResult::format_hresult(terminate_hr)));
+    }
+    XTaskQueueCloseHandle(m_multiplayer_queue);
+    m_multiplayer_queue = nullptr;
+}
+
+void PlayFabMultiplayer::_reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result) {
+    Ref<PlayFabResult> result = p_result;
+    if (result.is_null()) {
+        result = PlayFabResult::error_result(E_FAIL, "state_changes_finish_failed", "PlayFab Multiplayer failed to finish state change processing.");
+    }
+
+    m_initialized = false;
+    ++m_dispatch_generation;
+
+    if (m_handle != nullptr) {
+        PFMultiplayerUninitialize(m_handle);
+        m_handle = nullptr;
+    }
+    _terminate_multiplayer_queue();
+
+    for (const Ref<PlayFabLobby> &lobby : m_lobbies) {
+        if (lobby.is_valid()) {
+            lobby->mark_disconnected();
+        }
+    }
+    m_lobbies.clear();
+
+    for (const Ref<PlayFabMatchTicket> &ticket : m_tickets) {
+        if (ticket.is_valid()) {
+            ticket->mark_destroyed();
+        }
+    }
+    m_tickets.clear();
+
+    std::vector<PendingOperation *> pending_operations;
+    pending_operations.swap(m_pending_operations);
+
+    ERR_PRINT(vformat(
+            "PlayFabMultiplayer: FinishStateChanges failed with %s; Multiplayer was reset. Call PlayFab.multiplayer.initialize_async() before using it again.",
+            PlayFabResult::format_hresult(static_cast<HRESULT>(result->get_hresult()))));
+    emit_signal("multiplayer_error", result);
+
+    for (PendingOperation *operation : pending_operations) {
+        if (operation != nullptr && operation->pending_signal.is_valid()) {
+            operation->pending_signal->complete(result);
+        }
+        delete operation;
     }
 }
 
@@ -958,6 +1023,7 @@ Signal PlayFabMultiplayer::initialize_async(const Ref<PlayFabMultiplayerConfig> 
 
     m_initialized = true;
     m_shutting_down = false;
+    ++m_dispatch_generation;
     pending_signal->complete_deferred(PlayFabResult::ok_result());
     return pending_signal->get_completed_signal();
 }
@@ -1035,12 +1101,7 @@ void PlayFabMultiplayer::shutdown() {
         m_handle = nullptr;
     }
 
-    if (m_multiplayer_queue != nullptr) {
-        HRESULT terminate_hr = XTaskQueueTerminate(m_multiplayer_queue, false, nullptr, nullptr);
-        (void)terminate_hr;
-        XTaskQueueCloseHandle(m_multiplayer_queue);
-        m_multiplayer_queue = nullptr;
-    }
+    _terminate_multiplayer_queue();
 
     for (const Ref<PlayFabLobby> &lobby : m_lobbies) {
         if (lobby.is_valid()) {
@@ -1053,6 +1114,7 @@ void PlayFabMultiplayer::shutdown() {
     m_initialized = false;
     m_processing_state_changes = false;
     m_shutting_down = false;
+    ++m_dispatch_generation;
 }
 
 int PlayFabMultiplayer::dispatch() {
@@ -1067,9 +1129,12 @@ int PlayFabMultiplayer::dispatch() {
         }
     }
 
+    const uint64_t dispatch_generation = m_dispatch_generation;
     m_processing_state_changes = true;
     dispatched += _dispatch_lobby_state_changes();
-    dispatched += _dispatch_matchmaking_state_changes();
+    if (m_dispatch_generation == dispatch_generation && m_initialized && m_handle != nullptr) {
+        dispatched += _dispatch_matchmaking_state_changes();
+    }
     m_processing_state_changes = false;
     return dispatched;
 }
@@ -1676,53 +1741,68 @@ int PlayFabMultiplayer::_dispatch_lobby_state_changes() {
         switch (state_change->stateChangeType) {
             case PFLobbyStateChangeType::CreateAndJoinLobbyCompleted: {
                 const auto *change = static_cast<const PFLobbyCreateAndJoinLobbyCompletedStateChange *>(state_change);
+                const bool succeeded = SUCCEEDED(change->result);
                 PendingOperation *operation = static_cast<PendingOperation *>(change->asyncContext);
                 Ref<PlayFabLobby> lobby = operation != nullptr ? operation->lobby : _find_lobby(change->lobby);
-                if (lobby.is_valid() && lobby->get_native_handle() == nullptr) {
+                if (lobby.is_valid() && lobby->get_native_handle() == nullptr && change->lobby != nullptr) {
                     lobby->adopt_handle(change->lobby, operation != nullptr ? operation->user : Ref<PlayFabUser>());
                     _track_lobby(lobby);
                 }
-                if (lobby.is_valid()) {
+                if (lobby.is_valid() && succeeded) {
                     lobby->refresh_snapshot();
                 }
-                Ref<PlayFabResult> result = SUCCEEDED(change->result) ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby creation failed.", "lobby_create_failed");
+                Ref<PlayFabResult> result = succeeded ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby creation failed.", "lobby_create_failed");
+                if (!succeeded && lobby.is_valid()) {
+                    _untrack_lobby(lobby);
+                    lobby->mark_disconnected();
+                }
                 _complete_pending_operation(operation, result);
                 _emit_lobby_change(PlayFabLobby::PROPERTIES_UPDATED, lobby, result);
             } break;
             case PFLobbyStateChangeType::JoinLobbyCompleted: {
                 const auto *change = static_cast<const PFLobbyJoinLobbyCompletedStateChange *>(state_change);
+                const bool succeeded = SUCCEEDED(change->result);
                 PendingOperation *operation = static_cast<PendingOperation *>(change->asyncContext);
                 Ref<PlayFabLobby> lobby = operation != nullptr ? operation->lobby : _find_lobby(change->lobby);
-                if (lobby.is_valid() && lobby->get_native_handle() == nullptr) {
+                if (lobby.is_valid() && lobby->get_native_handle() == nullptr && change->lobby != nullptr) {
                     lobby->adopt_handle(change->lobby, operation != nullptr ? operation->user : Ref<PlayFabUser>());
                     _track_lobby(lobby);
                 }
-                if (lobby.is_valid()) {
+                if (lobby.is_valid() && succeeded) {
                     lobby->refresh_snapshot();
                 }
-                Ref<PlayFabResult> result = SUCCEEDED(change->result) ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby join failed.", "lobby_join_failed");
+                Ref<PlayFabResult> result = succeeded ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab lobby join failed.", "lobby_join_failed");
                 Ref<PlayFabLobbyMember> joined_member;
-                if (lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
+                if (succeeded && lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
                     joined_member = lobby->find_member(operation->user->get_entity_key());
+                }
+                if (!succeeded && lobby.is_valid()) {
+                    _untrack_lobby(lobby);
+                    lobby->mark_disconnected();
                 }
                 _complete_pending_operation(operation, result);
                 _emit_lobby_change(PlayFabLobby::MEMBER_ADDED, lobby, result, joined_member);
             } break;
             case PFLobbyStateChangeType::JoinArrangedLobbyCompleted: {
                 const auto *change = static_cast<const PFLobbyJoinArrangedLobbyCompletedStateChange *>(state_change);
+                const bool succeeded = SUCCEEDED(change->result);
                 PendingOperation *operation = static_cast<PendingOperation *>(change->asyncContext);
                 Ref<PlayFabLobby> lobby = operation != nullptr ? operation->lobby : _find_lobby(change->lobby);
-                if (lobby.is_valid() && lobby->get_native_handle() == nullptr) {
+                if (lobby.is_valid() && lobby->get_native_handle() == nullptr && change->lobby != nullptr) {
                     lobby->adopt_handle(change->lobby, operation != nullptr ? operation->user : Ref<PlayFabUser>());
                     _track_lobby(lobby);
                 }
-                if (lobby.is_valid()) {
+                if (lobby.is_valid() && succeeded) {
                     lobby->refresh_snapshot();
                 }
-                Ref<PlayFabResult> result = SUCCEEDED(change->result) ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab arranged lobby join failed.", "arranged_lobby_join_failed");
+                Ref<PlayFabResult> result = succeeded ? PlayFabResult::ok_result(lobby) : multiplayer_hresult_error(change->result, "PlayFab arranged lobby join failed.", "arranged_lobby_join_failed");
                 Ref<PlayFabLobbyMember> joined_member;
-                if (lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
+                if (succeeded && lobby.is_valid() && operation != nullptr && operation->user.is_valid()) {
                     joined_member = lobby->find_member(operation->user->get_entity_key());
+                }
+                if (!succeeded && lobby.is_valid()) {
+                    _untrack_lobby(lobby);
+                    lobby->mark_disconnected();
                 }
                 _complete_pending_operation(operation, result);
                 _emit_lobby_change(PlayFabLobby::MEMBER_ADDED, lobby, result, joined_member);
@@ -1887,9 +1967,7 @@ int PlayFabMultiplayer::_dispatch_lobby_state_changes() {
     HRESULT finish_hr = PFMultiplayerFinishProcessingLobbyStateChanges(m_handle, state_change_count, state_changes);
     if (FAILED(finish_hr)) {
         Ref<PlayFabResult> result = multiplayer_hresult_error(finish_hr, "Failed to finish PlayFab lobby state changes.", "lobby_state_finish_failed");
-        if (_get_runtime() != nullptr) {
-        }
-        emit_signal("multiplayer_error", result);
+        _reset_after_state_change_finish_failure(result);
     }
     return static_cast<int>(state_change_count);
 }
@@ -1966,9 +2044,8 @@ int PlayFabMultiplayer::_dispatch_matchmaking_state_changes() {
     HRESULT finish_hr = PFMultiplayerFinishProcessingMatchmakingStateChanges(m_handle, state_change_count, state_changes);
     if (FAILED(finish_hr)) {
         Ref<PlayFabResult> result = multiplayer_hresult_error(finish_hr, "Failed to finish PlayFab matchmaking state changes.", "matchmaking_state_finish_failed");
-        if (_get_runtime() != nullptr) {
-        }
-        emit_signal("multiplayer_error", result);
+        _reset_after_state_change_finish_failure(result);
+        return static_cast<int>(state_change_count);
     }
 
     for (const Ref<PlayFabMatchTicket> &ticket : terminal_tickets) {

--- a/addons/godot_playfab/src/playfab_multiplayer.h
+++ b/addons/godot_playfab/src/playfab_multiplayer.h
@@ -6,6 +6,7 @@
 #endif
 #include <windows.h>
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -431,6 +432,7 @@ private:
     bool m_initialized = false;
     bool m_processing_state_changes = false;
     bool m_shutting_down = false;
+    uint64_t m_dispatch_generation = 0;
     std::vector<Ref<PlayFabLobby>> m_lobbies;
     std::vector<Ref<PlayFabMatchTicket>> m_tickets;
     std::vector<PendingOperation *> m_pending_operations;
@@ -445,7 +447,10 @@ private:
     Ref<PlayFabLobby> _find_lobby(PFLobbyHandle p_lobby_handle) const;
     Ref<PlayFabMatchTicket> _find_ticket(PFMatchmakingTicketHandle p_ticket_handle) const;
     void _track_lobby(const Ref<PlayFabLobby> &p_lobby);
+    void _untrack_lobby(const Ref<PlayFabLobby> &p_lobby);
     void _track_ticket(const Ref<PlayFabMatchTicket> &p_ticket);
+    void _terminate_multiplayer_queue();
+    void _reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result);
     int _dispatch_lobby_state_changes();
     int _dispatch_matchmaking_state_changes();
     void _emit_lobby_change(

--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -34,6 +34,7 @@ constexpr const char *PARTY_PEER_NOT_CONNECTED = "party_peer_not_connected";
 constexpr const char *PARTY_RESOURCE_NOT_READY = "party_resource_not_ready";
 constexpr const char *PARTY_CHAT_CONTROL_CREATE_FAILED = "party_chat_control_create_failed";
 constexpr const char *PARTY_CHAT_PERMISSION_FAILED = "party_chat_permission_failed";
+constexpr const char *PARTY_STATE_FINISH_FAILED = "party_state_finish_failed";
 
 // Reserved transport-control packet protocol marker. The first byte of every
 // envelope identifies the packet kind; gameplay packets are forwarded to
@@ -1608,6 +1609,49 @@ void PlayFabParty::_release_all_local_users() {
     m_local_users.clear();
 }
 
+void PlayFabParty::_reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result) {
+    Ref<PlayFabResult> result = p_result;
+    if (result.is_null()) {
+        result = PlayFabResult::error_result(E_FAIL, PARTY_STATE_FINISH_FAILED, "PartyManager::FinishProcessingStateChanges failed.");
+    }
+
+    if (m_initialized) {
+        Party::PartyManager::GetSingleton().Cleanup();
+        m_initialized = false;
+    }
+    m_local_users.clear();
+    m_orphan_chat_controls.clear();
+    if (m_chat.is_valid()) {
+        m_chat->clear();
+    }
+
+    std::vector<Ref<PlayFabPartyNetwork>> networks;
+    networks.swap(m_networks);
+    for (const Ref<PlayFabPartyNetwork> &network : networks) {
+        if (!network.is_valid()) {
+            continue;
+        }
+        network->set_state_value(NETWORK_STATE_FAILED);
+        network->detach_native();
+        _emit_network_state(network, NETWORK_CHANGE_ERROR, 0, result, "PlayFab Party state processing failed; PlayFab.party was reset.");
+        network->set_owner(nullptr);
+    }
+
+    std::vector<PendingOperation *> pending_operations;
+    pending_operations.swap(m_pending_operations);
+    for (PendingOperation *operation : pending_operations) {
+        if (operation != nullptr && operation->pending_signal.is_valid()) {
+            operation->pending_signal->complete(result);
+        }
+        delete operation;
+    }
+
+    ERR_PRINT("PlayFab.party: FinishProcessingStateChanges failed; Party was reset. Call PlayFab.party.initialize_async() before using it again.");
+    emit_signal("party_error", result);
+    m_processing_state_changes = false;
+    m_shutting_down = false;
+}
+
 PlayFabParty::PendingOperation *PlayFabParty::_create_pending(int32_t p_kind) {
     PendingOperation *operation = new PendingOperation;
     operation->kind = p_kind;
@@ -1925,7 +1969,12 @@ int PlayFabParty::_pump_state_changes() {
         ++processed;
     }
 
-    Party::PartyManager::GetSingleton().FinishProcessingStateChanges(change_count, changes);
+    err = Party::PartyManager::GetSingleton().FinishProcessingStateChanges(change_count, changes);
+    if (PARTY_FAILED(err)) {
+        Ref<PlayFabResult> result = _party_error_result(err, PARTY_STATE_FINISH_FAILED, "PartyManager::FinishProcessingStateChanges");
+        _reset_after_state_change_finish_failure(result);
+        return processed;
+    }
     m_processing_state_changes = false;
     return processed;
 }

--- a/addons/godot_playfab/src/playfab_party.h
+++ b/addons/godot_playfab/src/playfab_party.h
@@ -590,6 +590,7 @@ private:
     // batch). Callers should bail out when this returns true to avoid touching
     // the dead native network handle.
     bool _abort_join_op_if_network_dead(PendingOperation *p_operation);
+    void _reset_after_state_change_finish_failure(const Ref<PlayFabResult> &p_result);
 
     int _pump_state_changes();
     void _process_state_change(const Party::PartyStateChange *p_change);

--- a/addons/godot_playfab/src/playfab_runtime.cpp
+++ b/addons/godot_playfab/src/playfab_runtime.cpp
@@ -33,6 +33,14 @@ PlayFabRuntime::PlayFabRuntime() {
 
 PlayFabRuntime::~PlayFabRuntime() {
     shutdown();
+
+    // XGameRuntime is process-lifetime state. Keep initialize()/shutdown()
+    // re-armable and release this addon's runtime reference only when the
+    // extension singleton is torn down.
+    if (m_xgame_runtime_initialized) {
+        XGameRuntimeUninitialize();
+        m_xgame_runtime_initialized = false;
+    }
 }
 
 Ref<PlayFabResult> PlayFabRuntime::initialize() {
@@ -63,25 +71,24 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
         endpoint = "https://" + title_id + ".playfabapi.com";
     }
 
-    bool xgame_runtime_initialized = false;
     bool playfab_core_initialized = false;
     bool playfab_services_initialized = false;
     bool game_save_files_initialized = false;
 
-    HRESULT hr = XGameRuntimeInitialize();
-    if (FAILED(hr)) {
-        Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize the Gaming Runtime.", "runtime_initialize_failed");
-        return result;
+    if (!m_xgame_runtime_initialized) {
+        HRESULT runtime_hr = XGameRuntimeInitialize();
+        if (FAILED(runtime_hr)) {
+            Ref<PlayFabResult> result = PlayFabResult::hresult_error(runtime_hr, "Failed to initialize the Gaming Runtime.", "runtime_initialize_failed");
+            return result;
+        }
+        m_xgame_runtime_initialized = true;
     }
-    xgame_runtime_initialized = true;
 
-    hr = XTaskQueueCreate(
+    HRESULT hr = XTaskQueueCreate(
             XTaskQueueDispatchMode::ThreadPool,
             XTaskQueueDispatchMode::Manual,
             &m_task_queue);
     if (FAILED(hr)) {
-        XGameRuntimeUninitialize();
-
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to create the shared XTaskQueue.", "task_queue_create_failed");
         return result;
     }
@@ -90,7 +97,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
     if (FAILED(hr)) {
         XTaskQueueCloseHandle(m_task_queue);
         m_task_queue = nullptr;
-        XGameRuntimeUninitialize();
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize PlayFab Core.", "playfab_core_initialize_failed");
         return result;
@@ -104,7 +110,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
 
         XTaskQueueCloseHandle(m_task_queue);
         m_task_queue = nullptr;
-        XGameRuntimeUninitialize();
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize PlayFab Services.", "playfab_services_initialize_failed");
         return result;
@@ -129,7 +134,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
 
         XTaskQueueCloseHandle(m_task_queue);
         m_task_queue = nullptr;
-        XGameRuntimeUninitialize();
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to initialize PlayFab Game Save Files.", "playfab_gamesave_initialize_failed");
         return result;
@@ -163,9 +167,6 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
         m_task_queue = nullptr;
         m_title_id = "";
         m_endpoint = "";
-        if (xgame_runtime_initialized) {
-            XGameRuntimeUninitialize();
-        }
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to create the PlayFab service configuration.", "service_config_create_failed");
         return result;
@@ -229,7 +230,9 @@ void PlayFabRuntime::shutdown() {
     }
     m_active_pending_signals.clear();
 
-    XGameRuntimeUninitialize();
+    // XGameRuntimeUninitialize intentionally does not run here. It is paired
+    // with the first successful XGameRuntimeInitialize and released once from
+    // ~PlayFabRuntime() during extension teardown.
 
     m_initialized = false;
     m_shutting_down = false;

--- a/addons/godot_playfab/src/playfab_runtime.h
+++ b/addons/godot_playfab/src/playfab_runtime.h
@@ -26,6 +26,7 @@ class PlayFabResult;
 class PlayFabRuntime {
     bool m_initialized = false;
     bool m_shutting_down = false;
+    bool m_xgame_runtime_initialized = false;
     bool m_game_save_files_initialized = false;
     XTaskQueueHandle m_task_queue = nullptr;
     PFServiceConfigHandle m_service_config_handle = nullptr;

--- a/docs/gameinput/manual-tests.md
+++ b/docs/gameinput/manual-tests.md
@@ -76,6 +76,7 @@ With a vibration-capable controller connected:
 - [ ] **Rumble Pulse** scenario causes the controller to vibrate for ~0.4 s.
 - [ ] **Stop Rumble** ends any in-flight rumble immediately.
 - [ ] Event log records both events.
+- [ ] Disconnect or disable the target device and confirm `GameInput.set_vibration()` returns `false` (or logs the native HRESULT on SDKs that report one) instead of reporting success.
 
 ### Vibration — two controllers
 
@@ -99,6 +100,12 @@ node into a scene and assign a small `GameInputActionMap` with one binding.
 - [ ] When you create a custom `GameInputBinding` that targets an action
   **not** present in `InputMap`, the Mapper logs **one** warning per missing
   action (not per frame).
+- [ ] Hold a mapped action, then hot-swap the mapper's `action_map`, call
+  `set_bindings()` / `add_binding()` / `clear()` on the active map, and remove
+  the mapper from the tree. After each stop-driving path,
+  `Input.is_action_pressed(action)` returns `false`.
+- [ ] Hold a mapped action and unplug the target controller. The action is
+  released on the next frame and does not remain stuck in Godot's `InputMap`.
 
 ## Regression smoke
 

--- a/docs/gameinput/plugin.md
+++ b/docs/gameinput/plugin.md
@@ -91,9 +91,9 @@ func _process(_delta: float) -> void:
         return
     var reading := gi.get_current_reading(pad)
     if reading != null and reading.was_button_pressed(GameInputDevice.BUTTON_A):
-        gi.set_vibration(pad, 0.6, 0.3)
-        await get_tree().create_timer(0.15).timeout
-        gi.stop_haptics(pad)
+        if gi.set_vibration(pad, 0.6, 0.3):
+            await get_tree().create_timer(0.15).timeout
+            gi.stop_haptics(pad)
 ```
 
 ### Drive Godot actions with a `GameInputMapper`
@@ -121,18 +121,28 @@ In the editor:
 The Mapper calls `Input.action_press(action, strength)` /
 `Input.action_release(action)` each frame, so the rest of your code can stay
 on Godot's standard `Input.is_action_pressed("jump")` / `Input.get_axis()`
-APIs and gain GameInput device support transparently. On every
-press / release transition the Mapper also pushes an `InputEventAction`
-through `Input.parse_input_event` so event-driven consumers — UI focus
-traversal for `ui_*`, `_gui_input` listeners, `_input` /
-`_unhandled_input` handlers — actually see the action change. When Godot's
-built-in joypad backend is already wired to deliver the same action through
-a matching `InputEventJoypadButton` / `InputEventJoypadMotion` in your
-`InputMap` (the default project mapping for `ui_accept` etc.), the Mapper
-suppresses its own `InputEventAction` for that binding so menu actions fire
-exactly once per physical press instead of twice.
+APIs and gain GameInput device support transparently. If the mapper stops
+driving a held binding — the node exits the tree, you swap or mutate the
+active `GameInputActionMap`, the target device disappears, or the frame cannot
+produce a fresh reading — it releases the actions it previously held before
+clearing its per-binding cache. Runtime `InputMap` edits also refresh the
+native-event suppression cache by the next frame. On every press / release
+transition the Mapper also pushes an `InputEventAction` through
+`Input.parse_input_event` so event-driven consumers — UI focus traversal for
+`ui_*`, `_gui_input` listeners, `_input` / `_unhandled_input` handlers —
+actually see the action change. When Godot's built-in joypad backend is
+already wired to deliver the same action through a matching
+`InputEventJoypadButton` / `InputEventJoypadMotion` in your `InputMap` (the
+default project mapping for `ui_accept` etc.), the Mapper suppresses its own
+`InputEventAction` for that binding so menu actions fire exactly once per
+physical press instead of twice.
 
 ### Soft-fail behaviour
+
+`GameInput.set_vibration()` returns `false` when preflight fails (null or
+disconnected device, no rumble motors, uninitialized runtime) and also when an
+HRESULT-returning GameInput SDK reports a native `SetRumbleState` failure, so
+callers can skip timers or surface diagnostics.
 
 Every public method on `GameInput`, `GameInputDevice`, and `GameInputReading`
 returns a safe default and emits a single `push_warning` if called before

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -123,7 +123,7 @@ if title_data_result.ok:
 
 Game Saves still requires an Xbox-backed PlayFab session because the PlayFab Game Saves C API needs a local user handle. Use `PlayFab.users.sign_in_with_xuser_async(GDK.users.get_primary_user())` before calling `PlayFab.game_saves`; custom-ID users return `xbox_user_required` from Game Saves methods.
 
-Lobby and matchmaking calls use the signed-in user's native PlayFab entity handle. Match tickets do not auto-join arranged lobbies; title code decides whether to pass the reported connection string to `join_arranged_lobby_async`.
+Lobby and matchmaking calls use the signed-in user's native PlayFab entity handle. Match tickets do not auto-join arranged lobbies; title code decides whether to pass the reported connection string to `join_arranged_lobby_async`. Failed lobby create/join completions are removed from `PlayFab.multiplayer.get_lobbies()` before their failure result is surfaced. If the native Multiplayer or Party state-change finish call fails, the addon emits `multiplayer_error` or `party_error`, resets that service to an uninitialized state, and requires a fresh `initialize_async()` before more calls.
 
 ```gdscript
 var mp_result = await PlayFab.multiplayer.initialize_async()

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -9,7 +9,7 @@ This is the landing page for the `godot_playfab` docs set.
 ### Implemented now
 
 - root singleton registration through `PlayFab`
-- shared PlayFab runtime lifecycle through `XGameRuntimeInitialize`, `PFInitialize`, and `PFServicesInitialize`
+- shared PlayFab runtime lifecycle with a process-lifetime `XGameRuntimeInitialize` reference and re-armable `PFInitialize` / `PFServicesInitialize` cycles
 - shared Game Saves runtime lifecycle through `PFGameSaveFilesInitialize` and `PFGameSaveFilesUninitializeAsync`
 - default auto-dispatch through `playfab/runtime/embed_dispatch`
 - project-settings-backed PlayFab config through `playfab/runtime/title_id` and `playfab/runtime/endpoint`
@@ -55,6 +55,8 @@ The PlayFab runtime reads these settings from Project Settings:
 - `playfab/runtime/embed_dispatch` — defaults to `true`; disable only when you want to pump completions manually with `PlayFab.dispatch()`
 
 The `GodotPlayFab` editor plugin installs the `PlayFabBootstrap` autoload at `res://addons/godot_playfab/runtime/playfab_bootstrap.gd` when enabled, mirroring the `GDKBootstrap` pattern. Disabling the plugin removes the autoload again.
+
+`PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled when returning to a title screen or changing test fixtures: shutdown tears down PlayFab Core, Services, Game Save Files, the shared task queue, and cached users, then a later initialize recreates them. The underlying GDK `XGameRuntimeInitialize` reference is process-lifetime state, so the first successful runtime initialization acquires it and extension teardown releases it once. This mirrors `godot_gdk` and lets both addons coexist safely; each addon owns exactly one matching GDK runtime reference.
 
 ## Public GDScript surface
 

--- a/docs/playfab/prerequisites.md
+++ b/docs/playfab/prerequisites.md
@@ -51,6 +51,11 @@ runtime/initialize_on_startup=true
 `playfab/runtime/endpoint` may be left blank. When blank, the addon
 derives `https://<titleid>.playfabapi.com` from the Title ID.
 
+`PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled in tools and
+runtime flows. The PlayFab Core/Services/Game Save state and task queue are
+recreated on each initialize, while the GDK `XGameRuntimeInitialize` reference
+is held for the process lifetime and released once when the extension unloads.
+
 > **`PlayFab.initialize()` failing with `title_id_required`** indicates
 > the setting is empty at runtime. See
 > [Troubleshooting → `PlayFab.initialize()` fails with `title_id_required`](../troubleshooting.md#playfabinitialize-fails-with-title_id_required).

--- a/spec/gdext-gameinput.md
+++ b/spec/gdext-gameinput.md
@@ -34,7 +34,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Device discovery/lifecycle | Shipped | connected/disconnected device cache, hot-plug signals on the main thread |
 | Polling API | Shipped | `GameInput.poll()` is per-frame idempotent |
 | Reading callbacks | Deferred | event-driven readings — see [§ Deferred to v2](#deferred-to-v2) |
-| Vibration/rumble | Shipped | `SetRumbleState`-backed; `supportedRumbleMotors` checked first |
+| Vibration/rumble | Shipped | `SetRumbleState`-backed; `supportedRumbleMotors` checked first; native failures are surfaced as `false` when the SDK reports them |
 | Force feedback / advanced haptics | Deferred | optional follow-on after basic rumble |
 | Battery state | Removed | GameInput v3 SDK dropped the battery API (`IGameInputDevice::GetBatteryState`, `GameInputBatteryState`) — no replacement upstream |
 | Device info | Shipped | `GameInputDevice.get_device_info()` (issue #23, device-info half) |
@@ -137,7 +137,7 @@ get_timestamp() -> int
 | `GameInput.poll()` | `IGameInput::GetCurrentReading` | Refreshes cached readings for tracked devices in polling mode. |
 | `GameInput.get_devices()` / `GameInput.get_primary_device()` | `IGameInput::RegisterDeviceCallback` | Build a device cache from the initial enumeration delivered by callback registration and keep it current with subsequent device-status callbacks. |
 | `GameInput.get_current_reading()` | `IGameInput::GetCurrentReading` | Returns a wrapped `IGameInputReading` snapshot for the requested device. |
-| `GameInput.set_vibration()` | `IGameInputDevice::SetRumbleState` | v1 haptics path is controller rumble, including trigger rumble when supported. |
+| `GameInput.set_vibration()` | `IGameInputDevice::SetRumbleState` | v1 haptics path is controller rumble, including trigger rumble when supported; returns `false` when preflight fails or an HRESULT-returning SDK reports a native failure. |
 | `GameInput.stop_haptics()` | `IGameInputDevice::SetRumbleState` | Send a zeroed rumble state. Advanced force-feedback work can later layer on the force-feedback APIs. |
 | `GameInput.enable_device_callbacks()` | `IGameInput::RegisterDeviceCallback`, `IGameInput::RegisterReadingCallback`, `IGameInput::UnregisterCallback` | Toggles the event-driven device and reading feed. |
 | `GameInputDevice` getters | `IGameInputDevice::GetDeviceInfo` | Cache display name, kind mask, and vibration/haptics capability flags from `GameInputDeviceInfo`. |
@@ -156,10 +156,12 @@ get_timestamp() -> int
 
 `GameInputMapper` is a `Node` intended to live in the scene tree. It polls `GameInput` or consumes device updates each frame, then emits synthetic `InputEventAction` events against a configured `GameInputActionMap`.
 
-Use it when gameplay code already depends on `Input`, `InputMap`, and project-defined actions. Skip it when a system needs raw per-device state, custom deadzones, or device-specific UX.
+Use it when gameplay code already depends on `Input`, `InputMap`, and project-defined actions. Skip it when a system needs raw per-device state, custom deadzones, or device-specific UX. `GameInputActionMap` mutations, including contained `GameInputBinding` property edits, emit `changed` so active mappers can immediately release held actions before their index-keyed state becomes stale.
 
 - polls `GameInput` each frame
 - translates readings into `InputEventAction`
+- releases every action it previously held when it stops driving a binding (tree exit, action-map swap or mutation, target-device retarget/loss, or a missing reading)
+- refreshes the native-joypad suppression cache at least once per frame so runtime `InputMap` edits cannot stay stale indefinitely
 - lets game code keep using:
 
 ```gdscript

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -21,7 +21,7 @@ Lobby/matchmaking and Party design work are tracked separately in `spec\gdext-pl
 
 | Domain | Included | Notes |
 | --- | --- | --- |
-| Runtime init/shutdown | Yes | `XGameRuntimeInitialize`, PlayFab init, shared queue |
+| Runtime init/shutdown | Yes | Process-lifetime `XGameRuntimeInitialize` reference, re-armable PlayFab init/shutdown, shared queue |
 | Manual sign-in | Yes | `GDKUser` object and custom-ID entry points |
 | Cached user sessions | Yes | `PlayFabUser` keyed by local Xbox user id or custom id |
 | Game Saves | Yes | add/sync, upload, folder/quota/cloud-state queries |
@@ -77,6 +77,10 @@ The runtime reads these Project Settings keys:
 - `playfab/runtime/embed_dispatch`
 
 The endpoint setting is optional. When blank, the runtime derives the default endpoint from the title id.
+
+## Runtime lifecycle
+
+`PlayFab.initialize()` acquires this addon's GDK `XGameRuntimeInitialize` reference the first time the runtime initializes successfully and keeps it for the process lifetime. `PlayFab.shutdown()` tears down PlayFab-owned state (`PFGameSaveFiles`, service config, `PFServices`, `PFInitialize`, pending signals, cached users, and the shared task queue) but deliberately does not call `XGameRuntimeUninitialize`; the matching GDK runtime release happens once during extension teardown. This mirrors the `godot_gdk` singleton/runtime pattern and allows titles or tests to cycle `initialize() -> shutdown() -> initialize()` without racing the process-wide Gaming Runtime, even when both addons are loaded.
 
 ## Async model
 
@@ -181,7 +185,7 @@ Match tickets report `match_id` and `arranged_lobby_connection_string` through `
 
 - `tests\godot\playfab\tests\` is the PlayFab contract suite.
 - It should keep the root singleton, settings registration, deterministic
-  validation errors, API service contracts, Multiplayer class contracts, custom-ID sign-in, and optional live smoke flows aligned
+  validation errors, runtime lifecycle re-arm behavior, API service contracts, Multiplayer class contracts, custom-ID sign-in, and optional live smoke flows aligned
   with the shipped addon behavior.
 - `tools\configure_playfab_test_title.ps1` prepares the current sandbox title (`10D176` by default) for live coverage by ensuring the custom-ID account, Multiplayer worker accounts, a two-player matchmaking queue with a `run_id` equality rule, leaderboard/statistic definitions, and API-service fixtures used by the tests exist. It reads the developer secret from `PLAYFAB_DEVELOPER_SECRET_KEY` and never forwards the secret to Godot child processes.
 - `tools\run_all_tests.ps1 -Live -Hosts tests\godot\playfab -PlayFabTitleId "10D176" -PlayFabCustomId "godot-gdk-ext-live-smoke" -PlayFabMatchmakingQueue "godot_gdk_ext_live_smoke_queue"` also runs the opt-in PlayFab Multiplayer multi-client lobby orchestration plus matchmaking create/cancel, two-player match completion, explicit arranged-lobby join, and arranged-lobby cleanup coverage.

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -174,6 +174,10 @@ The MLP `PlayFab.multiplayer` service supports PlayFab Multiplayer initializatio
 
 Match tickets report `match_id` and `arranged_lobby_connection_string` through `PlayFabMatchTicketStateChange`; title code decides whether to call `join_arranged_lobby_async(...)`. The addon does not automatically join arranged lobbies.
 
+Failed lobby create/join completions are terminal for their temporary wrapper: the wrapper is removed from `PlayFab.multiplayer.get_lobbies()` and marked disconnected before the failure result is surfaced. If `PFLobbyFinishStateChanges` or `PFMatchmakingFinishStateChanges` fails, the service emits `multiplayer_error`, tears down native Multiplayer state (including the task queue), marks wrappers detached, and returns to `is_initialized() == false`; titles must call `initialize_async()` before issuing more Multiplayer calls.
+
+`PlayFab.party` follows the same fail-closed recovery contract for `PartyManager::FinishProcessingStateChanges`: it emits `party_error`, detaches active network/chat wrappers, resets `PartyManager`, and requires `initialize_async()` before further Party calls.
+
 ## Samples
 
 - `sample\playfab_demo` (now removed) demonstrated settings-backed init plus manual PlayFab sign-in

--- a/tests/godot/gameinput/tests/test_gameinput_bootstrap_contract.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_bootstrap_contract.gd
@@ -1,0 +1,189 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Audit C3 backfill for GameInputBootstrap project-setting side effects and
+## initialization ownership semantics.
+
+const BootstrapScript = preload("res://addons/godot_gameinput/runtime/gameinput_bootstrap.gd")
+
+const SETTING_INITIALIZE_ON_STARTUP := "game_input/runtime/initialize_on_startup"
+const SETTING_AUTO_POLL := "game_input/runtime/auto_poll"
+const SETTING_DEFAULT_ACTION_MAP := "game_input/mapper/default_action_map"
+
+var _saved_settings: Dictionary = {}
+var _files_to_cleanup: Array[String] = []
+
+
+func after_each() -> void:
+	for key in _saved_settings.keys():
+		ProjectSettings.set_setting(key, _saved_settings[key])
+	_saved_settings.clear()
+	for path in _files_to_cleanup:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+	_files_to_cleanup.clear()
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _set_bootstrap_setting(key: String, value: Variant) -> void:
+	if not _saved_settings.has(key):
+		_saved_settings[key] = ProjectSettings.get_setting(key, null)
+	ProjectSettings.set_setting(key, value)
+
+
+func _set_base_settings() -> void:
+	_set_bootstrap_setting(SETTING_INITIALIZE_ON_STARTUP, false)
+	_set_bootstrap_setting(SETTING_AUTO_POLL, false)
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, "")
+
+
+func _spawn_bootstrap() -> Node:
+	var bootstrap: Node = BootstrapScript.new()
+	get_tree().root.add_child(bootstrap)
+	await get_tree().process_frame
+	return bootstrap
+
+
+func _free_bootstrap(bootstrap: Node) -> void:
+	if bootstrap == null:
+		return
+	if bootstrap.get_parent() != null:
+		bootstrap.get_parent().remove_child(bootstrap)
+	bootstrap.free()
+
+
+func _new_action_map_resource():
+	if not ClassDB.class_exists("GameInputActionMap") or not ClassDB.class_exists("GameInputBinding"):
+		return null
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("action", &"bootstrap_contract_action")
+	binding.set("source", 2)
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	action_map.add_binding(binding)
+	return action_map
+
+
+func _save_resource(resource: Resource, file_name: String) -> String:
+	var path := "user://%s" % file_name
+	var err := ResourceSaver.save(resource, path)
+	assert_eq(err, OK, "ResourceSaver.save(%s) succeeds" % file_name)
+	_files_to_cleanup.append(path)
+	return path
+
+
+func test_auto_poll_setting_controls_process_mode() -> void:
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_AUTO_POLL, false)
+	var bootstrap := await _spawn_bootstrap()
+	assert_eq(bootstrap.get("_auto_poll"), false, "auto_poll=false is stored on bootstrap")
+	assert_false(bootstrap.is_processing(), "auto_poll=false disables processing")
+	_free_bootstrap(bootstrap)
+
+	_set_bootstrap_setting(SETTING_AUTO_POLL, true)
+	bootstrap = await _spawn_bootstrap()
+	assert_eq(bootstrap.get("_auto_poll"), true, "auto_poll=true is stored on bootstrap")
+	assert_true(bootstrap.is_processing(), "auto_poll=true enables processing")
+	_free_bootstrap(bootstrap)
+
+
+func test_default_action_map_valid_path_spawns_default_mapper() -> void:
+	_set_base_settings()
+	var action_map = _new_action_map_resource()
+	if action_map == null:
+		pending("GameInputActionMap / GameInputBinding missing")
+		return
+	var path := _save_resource(action_map, "gameinput_bootstrap_valid_map.tres")
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, path)
+
+	var bootstrap := await _spawn_bootstrap()
+	var mapper := bootstrap.get_node_or_null("DefaultMapper")
+	assert_not_null(mapper, "valid default_action_map spawns DefaultMapper child")
+	if mapper != null:
+		assert_true(mapper.is_class("GameInputMapper"), "DefaultMapper is a GameInputMapper")
+		var loaded_map = mapper.get("action_map")
+		assert_not_null(loaded_map, "DefaultMapper action_map is assigned")
+		if loaded_map != null:
+			assert_true(loaded_map.is_class("GameInputActionMap"),
+					"DefaultMapper action_map has GameInputActionMap class")
+			assert_eq(loaded_map.get_binding_count(), 1,
+					"DefaultMapper action_map preserves saved binding count")
+	_free_bootstrap(bootstrap)
+
+
+func test_default_action_map_invalid_path_soft_fails() -> void:
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, "user://missing_gameinput_bootstrap_map.tres")
+
+	var bootstrap := await _spawn_bootstrap()
+	assert_true(bootstrap.get_node_or_null("DefaultMapper") == null,
+			"invalid default_action_map path does not spawn a mapper")
+	assert_push_warning("does not exist",
+			"invalid default_action_map path emits a warning")
+	_free_bootstrap(bootstrap)
+
+
+func test_default_action_map_wrong_type_soft_fails() -> void:
+	_set_base_settings()
+	var wrong_resource := Resource.new()
+	var path := _save_resource(wrong_resource, "gameinput_bootstrap_wrong_type.tres")
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, path)
+
+	var bootstrap := await _spawn_bootstrap()
+	assert_true(bootstrap.get_node_or_null("DefaultMapper") == null,
+			"wrong-type default_action_map path does not spawn a mapper")
+	assert_push_warning("not a GameInputActionMap",
+			"wrong-type default_action_map emits a warning")
+	_free_bootstrap(bootstrap)
+
+
+func test_initialize_on_startup_owns_shutdown_when_bootstrap_initializes() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_INITIALIZE_ON_STARTUP, true)
+
+	var bootstrap := await _spawn_bootstrap()
+	if not gi.is_initialized():
+		_free_bootstrap(bootstrap)
+		pending("GameInput.initialize() returned false from bootstrap")
+		return
+	assert_eq(bootstrap.get("_initialized_here"), true,
+			"bootstrap records ownership when it initializes GameInput")
+	bootstrap.notification(NOTIFICATION_PREDELETE)
+	assert_eq(gi.is_initialized(), false,
+			"bootstrap-owned runtime shuts down on PREDELETE")
+	assert_eq(bootstrap.get("_initialized_here"), false,
+			"bootstrap clears ownership after shutdown")
+	_free_bootstrap(bootstrap)
+
+
+func test_initialize_on_startup_does_not_shutdown_preinitialized_runtime() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false before bootstrap")
+		return
+
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_INITIALIZE_ON_STARTUP, true)
+	var bootstrap := await _spawn_bootstrap()
+	assert_eq(bootstrap.get("_initialized_here"), false,
+			"bootstrap does not claim ownership of a preinitialized runtime")
+	bootstrap.notification(NOTIFICATION_PREDELETE)
+	assert_eq(gi.is_initialized(), true,
+			"bootstrap PREDELETE leaves caller-owned runtime initialized")
+	_free_bootstrap(bootstrap)
+
+
+func test_should_skip_bootstrap_is_false_in_normal_gut_runner() -> void:
+	var bootstrap: Node = BootstrapScript.new()
+	assert_eq(bootstrap.call("_should_skip_bootstrap"), false,
+			"normal GUT invocation does not trigger the gd-script-check skip path")
+	bootstrap.free()

--- a/tests/godot/gameinput/tests/test_gameinput_core.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_core.gd
@@ -58,6 +58,9 @@ func test_soft_fail_before_init() -> void:
 	var reading = gi.get_current_reading(null)
 	assert_true(reading == null, "get_current_reading(null) returns null before init")
 
+	assert_eq(gi.set_vibration(null, 1.0, 1.0), false,
+			"set_vibration(null) returns false before init")
+
 	gi.poll()
 	assert_true(true, "poll() is safe before initialize()")
 

--- a/tests/godot/gameinput/tests/test_gameinput_core_backfill.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_core_backfill.gd
@@ -1,0 +1,243 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Audit C3 backfill for singleton bind_methods, haptics, masks, signals,
+## and the init -> shutdown -> init callback re-arm cycle.
+
+
+func after_each() -> void:
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _find_signal_info(obj: Object, signal_name: StringName) -> Dictionary:
+	for info in obj.get_signal_list():
+		if info.get("name") == signal_name:
+			return info
+	return {}
+
+
+func _assert_device_payload(device: Object, label: String) -> void:
+	assert_not_null(device, "%s is non-null" % label)
+	if device == null:
+		return
+	assert_true(device.has_method("get_device_id"), "%s exposes get_device_id()" % label)
+	assert_true(device.has_method("get_kind_mask"), "%s exposes get_kind_mask()" % label)
+	assert_true(device.has_method("is_connected"), "%s exposes is_connected()" % label)
+	assert_true(device.call("is_connected"), "%s reports connected" % label)
+	assert_true(device.get_device_id() > 0, "%s has a positive session id" % label)
+	assert_true(device.get_kind_mask() != 0, "%s has a non-zero kind mask" % label)
+
+
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func test_signal_shapes_and_connected_count_surface() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	assert_has_signal_named(gi, "device_connected")
+	assert_has_signal_named(gi, "device_disconnected")
+	assert_has_method_named(gi, "get_connected_device_count")
+
+	var connected_info := _find_signal_info(gi, &"device_connected")
+	assert_false(connected_info.is_empty(), "device_connected signal metadata is registered")
+	if not connected_info.is_empty():
+		var args: Array = connected_info.get("args", [])
+		assert_eq(args.size(), 1, "device_connected has one argument")
+		if args.size() == 1:
+			assert_eq(str(args[0].get("name", "")), "device", "device_connected argument name")
+			assert_eq(args[0].get("type"), TYPE_OBJECT, "device_connected argument type")
+			var device_class := str(args[0].get("class_name", ""))
+			if device_class.is_empty():
+				device_class = str(args[0].get("hint_string", ""))
+			assert_eq(device_class, "GameInputDevice",
+					"device_connected argument class hint")
+
+	var disconnected_info := _find_signal_info(gi, &"device_disconnected")
+	assert_false(disconnected_info.is_empty(), "device_disconnected signal metadata is registered")
+	if not disconnected_info.is_empty():
+		var args: Array = disconnected_info.get("args", [])
+		assert_eq(args.size(), 1, "device_disconnected has one argument")
+		if args.size() == 1:
+			assert_eq(str(args[0].get("name", "")), "device_id",
+					"device_disconnected argument name")
+			assert_eq(args[0].get("type"), TYPE_INT, "device_disconnected argument type")
+
+	gi.shutdown()
+	assert_eq(gi.get_connected_device_count(), 0,
+			"get_connected_device_count() returns 0 after shutdown")
+
+
+func test_kind_mask_queries_return_consistent_content_after_initialize() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+
+	var all_mask := _device_constant("DEVICE_ALL")
+	var gamepad_mask := _device_constant("DEVICE_GAMEPAD")
+	var keyboard_mask := _device_constant("DEVICE_KEYBOARD")
+	var mouse_mask := _device_constant("DEVICE_MOUSE")
+	var unknown_mask := _device_constant("DEVICE_UNKNOWN")
+
+	var all_devices: Array = gi.get_devices(all_mask)
+	assert_eq(all_devices.size(), gi.get_connected_device_count(),
+			"DEVICE_ALL count matches get_connected_device_count()")
+	for device in all_devices:
+		_assert_device_payload(device, "DEVICE_ALL device")
+
+	for mask in [gamepad_mask, keyboard_mask, mouse_mask, all_mask]:
+		var devices: Array = gi.get_devices(mask)
+		assert_true(devices is Array, "get_devices(%d) returns Array" % mask)
+		for device in devices:
+			_assert_device_payload(device, "mask %d device" % mask)
+			assert_true((device.get_kind_mask() & mask) != 0,
+					"device kind mask intersects query mask %d" % mask)
+
+		var primary = gi.get_primary_device(mask)
+		if devices.is_empty():
+			assert_true(primary == null,
+					"get_primary_device(%d) returns null when no device matches" % mask)
+		else:
+			_assert_device_payload(primary, "primary mask %d" % mask)
+			assert_true((primary.get_kind_mask() & mask) != 0,
+					"primary device kind mask intersects query mask %d" % mask)
+
+	assert_eq(gi.get_devices(unknown_mask).size(), 0,
+			"get_devices(DEVICE_UNKNOWN) returns no devices")
+	assert_true(gi.get_primary_device(unknown_mask) == null,
+			"get_primary_device(DEVICE_UNKNOWN) returns null")
+
+
+func test_initialize_shutdown_initialize_rearms_device_enumeration() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var first_started: bool = gi.initialize()
+	if not first_started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var first_devices: Array = gi.get_devices(_device_constant("DEVICE_ALL"))
+	assert_eq(first_devices.size(), gi.get_connected_device_count(),
+			"first init drains device callbacks into the cache")
+
+	gi.shutdown()
+	assert_eq(gi.is_initialized(), false, "shutdown() tears down first init")
+	assert_eq(gi.get_connected_device_count(), 0, "shutdown() clears the device cache")
+
+	var second_started: bool = gi.initialize()
+	assert_true(second_started, "second initialize() after shutdown succeeds")
+	if not second_started:
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var second_devices: Array = gi.get_devices(_device_constant("DEVICE_ALL"))
+	assert_eq(second_devices.size(), gi.get_connected_device_count(),
+			"second init re-arms callbacks and exposes a consistent device cache")
+	for device in second_devices:
+		_assert_device_payload(device, "second init device")
+
+
+func test_haptics_soft_fail_on_null_and_stale_wrappers() -> void:
+	if pending_unless_runtime_available():
+		return
+	if not ClassDB.class_exists("GameInputDevice"):
+		pending("GameInputDevice missing")
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	assert_eq(gi.set_vibration(null, 1.0, 1.0, 1.0, 1.0), false,
+			"set_vibration(null) returns false while initialized")
+	gi.stop_haptics(null)
+	assert_true(true, "stop_haptics(null) soft-fails without crashing")
+
+	var stale_device = ClassDB.instantiate("GameInputDevice")
+	assert_eq(gi.set_vibration(stale_device, 0.25, 0.5, 0.75, 1.0), false,
+			"set_vibration(stale/disconnected wrapper) returns false")
+	gi.stop_haptics(stale_device)
+	assert_true(true, "stop_haptics(stale/disconnected wrapper) soft-fails without crashing")
+
+
+func test_live_vibration_success_path_and_stop_haptics() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for vibration coverage")
+		return
+	if not device.supports_vibration():
+		pending("Live GameInput gamepad does not report rumble support")
+		return
+
+	var ok: bool = gi.set_vibration(device, 1.5, -1.0, 2.0, -0.5)
+	assert_true(ok, "set_vibration() succeeds on a live rumble-capable device")
+	await get_tree().create_timer(0.05).timeout
+	gi.stop_haptics(device)
+	assert_true(true, "stop_haptics() sends a zero-rumble request after success")
+
+
+func test_live_device_connected_signal_emits_device_payload() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	watch_signals(gi)
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	if gi.get_connected_device_count() == 0:
+		pending("No live GameInput devices connected to assert device_connected emission")
+		return
+
+	assert_true(get_signal_emit_count(gi, "device_connected") > 0,
+			"initial enumeration emits device_connected on the main thread")
+	var params = get_signal_parameters(gi, "device_connected", 0)
+	assert_true(params is Array, "device_connected parameters are captured")
+	if params is Array and params.size() == 1:
+		_assert_device_payload(params[0], "device_connected payload")

--- a/tests/godot/gameinput/tests/test_gameinput_device.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_device.gd
@@ -67,7 +67,7 @@ func test_device_defaults_before_init() -> void:
 			"get_display_name() == \"\" before init")
 	assert_eq(device.get_kind_mask(), 0,
 			"get_kind_mask() == 0 (DEVICE_UNKNOWN) before init")
-	assert_eq(device.is_connected(), false,
+	assert_eq(device.call("is_connected"), false,
 			"is_connected() == false before init")
 	assert_eq(device.supports_vibration(), false,
 			"supports_vibration() == false before init")
@@ -104,7 +104,7 @@ func test_device_defaults_after_shutdown() -> void:
 			"get_display_name() == \"\" after shutdown()")
 	assert_eq(device.get_kind_mask(), 0,
 			"get_kind_mask() == 0 after shutdown()")
-	assert_eq(device.is_connected(), false,
+	assert_eq(device.call("is_connected"), false,
 			"is_connected() == false after shutdown()")
 	assert_eq(device.supports_vibration(), false,
 			"supports_vibration() == false after shutdown()")

--- a/tests/godot/gameinput/tests/test_gameinput_mapper_backfill.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_mapper_backfill.gd
@@ -1,0 +1,284 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Audit C3 backfill for mapper cache, EXIT_TREE, active-count, axis, and
+## missing-action debounce paths not covered by the stuck-action lane.
+
+var _actions_to_cleanup: Array[StringName] = []
+
+
+func after_each() -> void:
+	for action in _actions_to_cleanup:
+		Input.action_release(action)
+		if InputMap.has_action(action):
+			InputMap.erase_action(action)
+	_actions_to_cleanup.clear()
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _ensure_action(action: StringName) -> void:
+	if not InputMap.has_action(action):
+		InputMap.add_action(action)
+		_actions_to_cleanup.append(action)
+	Input.action_release(action)
+
+
+func _new_binding(action: StringName, source_value: int = 2, is_axis: bool = false):
+	if not ClassDB.class_exists("GameInputBinding"):
+		return null
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("action", action)
+	binding.set("source", source_value)
+	binding.set("is_axis", is_axis)
+	return binding
+
+
+func _new_action_map(bindings: Array):
+	if not ClassDB.class_exists("GameInputActionMap"):
+		return null
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	action_map.set("bindings", bindings)
+	return action_map
+
+
+func _new_action_map_with(action: StringName, source_value: int = 2, is_axis: bool = false):
+	var binding = _new_binding(action, source_value, is_axis)
+	if binding == null:
+		return null
+	return _new_action_map([binding])
+
+
+func _new_mapper():
+	if not ClassDB.class_exists("GameInputMapper"):
+		return null
+	var mapper = ClassDB.instantiate("GameInputMapper")
+	if not mapper.has_method("_test_mark_binding_pressed") \
+			or not mapper.has_method("_test_prime_native_handles_cache") \
+			or not mapper.has_method("_test_get_native_handles_cache_count"):
+		mapper.free()
+		return null
+	return mapper
+
+
+func _seed_mapper_press(mapper: Node, action: StringName) -> void:
+	mapper.call("_test_mark_binding_pressed", 0)
+	assert_true(Input.is_action_pressed(action), "test hook seeds a held action")
+	assert_eq(mapper.call("get_active_binding_count"), 1,
+			"get_active_binding_count() reports one held binding")
+
+
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func _source_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInputDevice", name)
+
+
+func test_native_handles_cache_reuses_identical_binding_index() -> void:
+	var action_a := &"test_gi_cache_a"
+	var action_b := &"test_gi_cache_b"
+	_ensure_action(action_a)
+	_ensure_action(action_b)
+
+	var mapper = _new_mapper()
+	var action_map = _new_action_map([
+		_new_binding(action_a),
+		_new_binding(action_b),
+	])
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper cache test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+			"native-handles cache starts empty")
+	mapper.call("_test_prime_native_handles_cache", 0, false)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"first lookup fills one cache entry")
+	mapper.call("_test_prime_native_handles_cache", 0, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"repeated identical-binding lookup reuses the cached entry")
+	mapper.call("_test_prime_native_handles_cache", 1, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 2,
+			"a different binding index gets its own cache entry")
+	mapper.free()
+
+
+func test_native_handles_cache_clears_on_map_swap_and_next_frame() -> void:
+	var first_action := &"test_gi_cache_swap_first"
+	var second_action := &"test_gi_cache_swap_second"
+	_ensure_action(first_action)
+	_ensure_action(second_action)
+
+	var mapper = _new_mapper()
+	var first = _new_action_map_with(first_action)
+	var second = _new_action_map_with(second_action)
+	if mapper == null or first == null or second == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper cache test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", first)
+	mapper.call("_test_prime_native_handles_cache", 0, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"cache primed before map swap")
+	mapper.set("action_map", second)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+			"set_action_map() clears native-handles cache")
+
+	mapper.call("_test_prime_native_handles_cache", 0, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"cache primed before next-frame invalidation")
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+			"mapper process clears stale native-handles cache entries on a new frame")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_exit_tree_after_processing_releases_held_action() -> void:
+	var held := &"test_gi_exit_tree_after_frame"
+	_ensure_action(held)
+
+	var mapper = _new_mapper()
+	var action_map = _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	_seed_mapper_press(mapper, held)
+	await get_tree().process_frame
+	holder.remove_child(mapper)
+	assert_false(Input.is_action_pressed(held),
+			"NOTIFICATION_EXIT_TREE releases held actions after at least one processed frame")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"EXIT_TREE clears the active binding cache")
+	mapper.free()
+	holder.free()
+
+
+func test_active_binding_count_zero_for_inert_mapper() -> void:
+	var mapper = _new_mapper()
+	if mapper == null:
+		pending("GameInputMapper test hooks missing")
+		return
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"new mapper has no active bindings")
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"mapper without action_map/device remains at zero active bindings")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_live_axis_binding_path_stays_bounded_below_threshold() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for axis binding coverage")
+		return
+
+	var action := &"test_gi_axis_bound"
+	_ensure_action(action)
+	var binding = _new_binding(action, _source_constant("SRC_AXIS_LEFT_X"), true)
+	if binding == null:
+		pending("GameInputBinding missing")
+		return
+	binding.set("axis_threshold", 1.0)
+	binding.set("deadzone", 0.0)
+	var action_map = _new_action_map([binding])
+	var mapper = _new_mapper()
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", device.get_device_id())
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_false(Input.is_action_pressed(action),
+			"axis binding with threshold 1.0 does not synthesize a pressed action")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"axis path leaves no active binding below threshold")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_live_missing_action_warning_is_debounced() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for missing-action debounce coverage")
+		return
+
+	var missing_action := &"test_gi_missing_action_debounce"
+	if InputMap.has_action(missing_action):
+		InputMap.erase_action(missing_action)
+	var action_map = _new_action_map_with(missing_action)
+	var mapper = _new_mapper()
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", device.get_device_id())
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_push_warning_count(1,
+			"missing InputMap action warning is emitted once across repeated frames")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()

--- a/tests/godot/gameinput/tests/test_gameinput_mapper_stuck_actions.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_mapper_stuck_actions.gd
@@ -1,0 +1,289 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Regression coverage for mapper-held action release paths.
+##
+## These tests use internal mapper hooks to seed the same per-binding cache that a
+## real GameInput press would populate, keeping the stuck-action sweep runnable on
+## CI hosts without controller hardware.
+
+const IMPOSSIBLE_DEVICE_ID := 9223372036854775807
+
+var _actions_to_cleanup: Array[StringName] = []
+
+
+func after_each() -> void:
+	for action in _actions_to_cleanup:
+		Input.action_release(action)
+		if InputMap.has_action(action):
+			InputMap.erase_action(action)
+	_actions_to_cleanup.clear()
+
+
+func _ensure_action(action: StringName) -> void:
+	if not InputMap.has_action(action):
+		InputMap.add_action(action)
+		_actions_to_cleanup.append(action)
+	Input.action_release(action)
+
+
+func _new_binding(action: StringName, source_value: int = 2):
+	if not ClassDB.class_exists("GameInputBinding"):
+		return null
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("action", action)
+	binding.set("source", source_value)
+	return binding
+
+
+func _new_action_map_with(action: StringName, source_value: int = 2):
+	if not ClassDB.class_exists("GameInputActionMap"):
+		return null
+	var binding = _new_binding(action, source_value)
+	if binding == null:
+		return null
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	action_map.set("bindings", [binding])
+	return action_map
+
+
+func _new_mapper():
+	if not ClassDB.class_exists("GameInputMapper"):
+		return null
+	var mapper = ClassDB.instantiate("GameInputMapper")
+	if not mapper.has_method("_test_mark_binding_pressed"):
+		mapper.free()
+		return null
+	return mapper
+
+
+func _seed_mapper_press(mapper: Node, action: StringName) -> void:
+	mapper.call("_test_mark_binding_pressed", 0)
+	assert_true(Input.is_action_pressed(action), "test hook seeds a held action")
+	assert_eq(mapper.call("get_active_binding_count"), 1,
+			"test hook seeds one active binding")
+
+
+func test_action_map_swap_releases_previous_held_action() -> void:
+	var old_action := &"test_gi_stuck_swap_old"
+	var new_action := &"test_gi_stuck_swap_new"
+	_ensure_action(old_action)
+	_ensure_action(new_action)
+
+	var mapper := _new_mapper()
+	var first := _new_action_map_with(old_action)
+	var second := _new_action_map_with(new_action)
+	if mapper == null or first == null or second == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", first)
+	_seed_mapper_press(mapper, old_action)
+
+	mapper.set("action_map", second)
+	assert_false(Input.is_action_pressed(old_action),
+			"set_action_map() releases actions held by the previous map")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"set_action_map() clears previous pressed-state cache")
+	mapper.free()
+
+
+func test_active_map_mutations_release_held_actions_and_invalidate_cache() -> void:
+	var cases := [
+		{
+			"name": "add_binding",
+			"held": &"test_gi_stuck_add_held",
+			"replacement": &"test_gi_stuck_add_new",
+		},
+		{
+			"name": "set_bindings",
+			"held": &"test_gi_stuck_set_held",
+			"replacement": &"test_gi_stuck_set_new",
+		},
+		{
+			"name": "clear",
+			"held": &"test_gi_stuck_clear_held",
+			"replacement": &"test_gi_stuck_clear_new",
+		},
+	]
+
+	for case in cases:
+		var held: StringName = case["held"]
+		var replacement: StringName = case["replacement"]
+		_ensure_action(held)
+		_ensure_action(replacement)
+
+		var mapper := _new_mapper()
+		var action_map := _new_action_map_with(held)
+		if mapper == null or action_map == null:
+			if mapper != null: mapper.free()
+			pending("GameInputMapper test hooks or action-map classes missing")
+			return
+
+		mapper.set("action_map", action_map)
+		_seed_mapper_press(mapper, held)
+		mapper.call("_test_prime_native_handles_cache", 0, true)
+		assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+				"%s primes native event cache" % case["name"])
+
+		match case["name"]:
+			"add_binding":
+				action_map.add_binding(_new_binding(replacement))
+			"set_bindings":
+				action_map.set("bindings", [_new_binding(replacement)])
+			"clear":
+				action_map.clear()
+
+		assert_false(Input.is_action_pressed(held),
+				"%s releases the action held by the active map" % case["name"])
+		assert_eq(mapper.call("get_active_binding_count"), 0,
+				"%s clears previous pressed-state cache" % case["name"])
+		assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+				"%s invalidates native event cache" % case["name"])
+		mapper.free()
+
+
+func test_binding_property_mutation_releases_held_action() -> void:
+	var held := &"test_gi_stuck_binding_mutation_held"
+	var replacement := &"test_gi_stuck_binding_mutation_new"
+	_ensure_action(held)
+	_ensure_action(replacement)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	var binding = action_map.get_binding(0)
+	mapper.set("action_map", action_map)
+	_seed_mapper_press(mapper, held)
+
+	binding.set("action", replacement)
+	assert_false(Input.is_action_pressed(held),
+			"mutating a binding on the active map releases the old held action")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"binding mutation clears previous pressed-state cache")
+	mapper.free()
+
+
+func test_uninitialized_runtime_early_return_releases_held_action() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var held := &"test_gi_stuck_runtime_unavailable"
+	_ensure_action(held)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	mapper.set("action_map", action_map)
+	_seed_mapper_press(mapper, held)
+
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+
+	assert_false(Input.is_action_pressed(held),
+			"process early-return when GameInput is stopped releases held actions")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"process early-return clears previous pressed-state cache")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_missing_target_device_releases_held_action() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	var held := &"test_gi_stuck_missing_device"
+	_ensure_action(held)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		gi.shutdown()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", IMPOSSIBLE_DEVICE_ID)
+	_seed_mapper_press(mapper, held)
+
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+
+	assert_false(Input.is_action_pressed(held),
+			"missing/disconnected target device releases held actions")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"missing/disconnected target device clears pressed-state cache")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+	gi.shutdown()
+
+
+func test_non_gamepad_target_without_reading_releases_held_action() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	var keyboard_kind: int = ClassDB.class_get_integer_constant("GameInput", "DEVICE_KEYBOARD")
+	var devices: Array = gi.get_devices(keyboard_kind)
+	if devices.is_empty():
+		gi.shutdown()
+		pending("No GameInput keyboard device available to exercise null-reading path")
+		return
+
+	var held := &"test_gi_stuck_null_reading"
+	_ensure_action(held)
+
+	var mapper := _new_mapper()
+	var action_map := _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		gi.shutdown()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", devices[0].get_device_id())
+	_seed_mapper_press(mapper, held)
+
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+
+	assert_false(Input.is_action_pressed(held),
+			"target with no gamepad reading releases held actions")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"null-reading path clears pressed-state cache")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+	gi.shutdown()

--- a/tests/godot/gameinput/tests/test_gameinput_mapper_stuck_actions.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_mapper_stuck_actions.gd
@@ -68,9 +68,9 @@ func test_action_map_swap_releases_previous_held_action() -> void:
 	_ensure_action(old_action)
 	_ensure_action(new_action)
 
-	var mapper := _new_mapper()
-	var first := _new_action_map_with(old_action)
-	var second := _new_action_map_with(new_action)
+	var mapper = _new_mapper()
+	var first = _new_action_map_with(old_action)
+	var second = _new_action_map_with(new_action)
 	if mapper == null or first == null or second == null:
 		if mapper != null: mapper.free()
 		pending("GameInputMapper test hooks or action-map classes missing")
@@ -112,8 +112,8 @@ func test_active_map_mutations_release_held_actions_and_invalidate_cache() -> vo
 		_ensure_action(held)
 		_ensure_action(replacement)
 
-		var mapper := _new_mapper()
-		var action_map := _new_action_map_with(held)
+		var mapper = _new_mapper()
+		var action_map = _new_action_map_with(held)
 		if mapper == null or action_map == null:
 			if mapper != null: mapper.free()
 			pending("GameInputMapper test hooks or action-map classes missing")
@@ -148,8 +148,8 @@ func test_binding_property_mutation_releases_held_action() -> void:
 	_ensure_action(held)
 	_ensure_action(replacement)
 
-	var mapper := _new_mapper()
-	var action_map := _new_action_map_with(held)
+	var mapper = _new_mapper()
+	var action_map = _new_action_map_with(held)
 	if mapper == null or action_map == null:
 		if mapper != null: mapper.free()
 		pending("GameInputMapper test hooks or action-map classes missing")
@@ -174,8 +174,8 @@ func test_uninitialized_runtime_early_return_releases_held_action() -> void:
 	var held := &"test_gi_stuck_runtime_unavailable"
 	_ensure_action(held)
 
-	var mapper := _new_mapper()
-	var action_map := _new_action_map_with(held)
+	var mapper = _new_mapper()
+	var action_map = _new_action_map_with(held)
 	if mapper == null or action_map == null:
 		if mapper != null: mapper.free()
 		pending("GameInputMapper test hooks or action-map classes missing")
@@ -214,8 +214,8 @@ func test_missing_target_device_releases_held_action() -> void:
 	var held := &"test_gi_stuck_missing_device"
 	_ensure_action(held)
 
-	var mapper := _new_mapper()
-	var action_map := _new_action_map_with(held)
+	var mapper = _new_mapper()
+	var action_map = _new_action_map_with(held)
 	if mapper == null or action_map == null:
 		if mapper != null: mapper.free()
 		gi.shutdown()
@@ -262,8 +262,8 @@ func test_non_gamepad_target_without_reading_releases_held_action() -> void:
 	var held := &"test_gi_stuck_null_reading"
 	_ensure_action(held)
 
-	var mapper := _new_mapper()
-	var action_map := _new_action_map_with(held)
+	var mapper = _new_mapper()
+	var action_map = _new_action_map_with(held)
 	if mapper == null or action_map == null:
 		if mapper != null: mapper.free()
 		gi.shutdown()

--- a/tests/godot/gameinput/tests/test_gameinput_reading.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_reading.gd
@@ -43,6 +43,20 @@ const _AXIS_NAMES := [
 ]
 
 
+func after_each() -> void:
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func _gameinput_device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInputDevice", name)
+
+
 func _new_reading() -> Object:
 	if not ClassDB.class_exists("GameInputReading"):
 		return null
@@ -127,3 +141,45 @@ func test_reading_unknown_button_axis_safe() -> void:
 			"get_axis(-1) ≈ 0.0")
 	assert_eq_approx(reading.get_axis(99999), 0.0,
 			"get_axis(99999) ≈ 0.0")
+
+
+func test_live_second_reading_exercises_previous_state_branch() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for previous-state reading coverage")
+		return
+
+	var first_reading = gi.get_current_reading(device)
+	if first_reading == null:
+		pending("Live GameInput device did not produce an initial reading")
+		return
+
+	await get_tree().process_frame
+	gi.poll()
+	var second_reading = gi.get_current_reading(device)
+	assert_not_null(second_reading, "second live reading is available")
+	if second_reading == null:
+		return
+
+	var button_a := _gameinput_device_constant("BUTTON_A")
+	assert_true(second_reading.was_button_pressed(button_a) is bool,
+			"was_button_pressed() returns bool after a previous reading exists")
+	assert_true(second_reading.was_button_released(button_a) is bool,
+			"was_button_released() returns bool after a previous reading exists")
+	assert_true(second_reading.get_buttons_mask() is int,
+			"second reading exposes buttons mask while previous state is populated")

--- a/tests/godot/gameinput/tests/test_gameinput_resource.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_resource.gd
@@ -35,6 +35,27 @@ func test_binding_defaults_and_setters() -> void:
 	assert_eq_approx(binding.get("deadzone"), 0.1, "binding.deadzone setter")
 
 
+func test_binding_clamps_axis_threshold_and_deadzone() -> void:
+	if not ClassDB.class_exists("GameInputBinding"):
+		pending("GameInputBinding missing")
+		return
+
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("axis_threshold", -1.0)
+	binding.set("deadzone", -0.25)
+	assert_eq_approx(binding.get("axis_threshold"), 0.0,
+			"axis_threshold clamps negative values to 0.0")
+	assert_eq_approx(binding.get("deadzone"), 0.0,
+			"deadzone clamps negative values to 0.0")
+
+	binding.set("axis_threshold", 2.0)
+	binding.set("deadzone", 1.5)
+	assert_eq_approx(binding.get("axis_threshold"), 1.0,
+			"axis_threshold clamps values above 1.0")
+	assert_eq_approx(binding.get("deadzone"), 1.0,
+			"deadzone clamps values above 1.0")
+
+
 func test_binding_save_load_roundtrip() -> void:
 	if not ClassDB.class_exists("GameInputBinding"):
 		pending("GameInputBinding missing")
@@ -94,6 +115,39 @@ func test_action_map_typed_array() -> void:
 	assert_eq(bindings.size(), 2, "action_map.bindings holds 2 entries")
 	assert_eq(bindings[0].get("action"), &"move_left", "first binding action preserved")
 	assert_eq(bindings[1].get("action"), &"move_right", "second binding action preserved")
+
+
+func test_action_map_add_get_binding_and_clear_methods() -> void:
+	if not ClassDB.class_exists("GameInputActionMap") or not ClassDB.class_exists("GameInputBinding"):
+		pending("GameInputActionMap / GameInputBinding missing")
+		return
+
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	assert_eq(action_map.get_binding_count(), 0, "new action map count starts at 0")
+	assert_true(action_map.get_binding(0) == null,
+			"get_binding(0) returns null for an empty map")
+	assert_true(action_map.get_binding(-1) == null,
+			"get_binding(-1) returns null for an empty map")
+
+	var b1 = ClassDB.instantiate("GameInputBinding")
+	b1.set("action", &"jump")
+	var b2 = ClassDB.instantiate("GameInputBinding")
+	b2.set("action", &"fire")
+	action_map.add_binding(b1)
+	action_map.add_binding(null)
+	action_map.add_binding(b2)
+
+	assert_eq(action_map.get_binding_count(), 2,
+			"add_binding ignores null and counts real bindings")
+	assert_eq(action_map.get_binding(0), b1, "get_binding(0) returns first binding")
+	assert_eq(action_map.get_binding(1), b2, "get_binding(1) returns second binding")
+	assert_true(action_map.get_binding(2) == null,
+			"get_binding(out-of-range) returns null")
+
+	action_map.clear()
+	assert_eq(action_map.get_binding_count(), 0, "clear() removes all bindings")
+	assert_true(action_map.get_binding(0) == null,
+			"get_binding(0) returns null after clear()")
 
 
 func test_action_map_save_load_roundtrip() -> void:

--- a/tests/godot/gameinput/tests/test_gameinput_threading_smoke.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_threading_smoke.gd
@@ -7,7 +7,8 @@ extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
 ## drains the pending queue inside `poll()` and is the only mutator of the
 ## device cache. This test exercises the no-hardware steady-state by hammering
 ## the public API across 100 frames and asserting:
-##   * `get_devices()` always returns an `Array` (no nulls / crashes / leaks).
+##   * `get_devices(DEVICE_ALL)` returns a coherent device cache and real
+##     `GameInputDevice` payloads when hardware is present.
 ##   * `get_current_reading(device)` is safe with a freshly instantiated bare
 ##     `GameInputDevice` (id `0`) — it must return null without dereferencing
 ##     into the worker's pending queue.
@@ -29,6 +30,22 @@ func _await_frames(n: int) -> void:
 		await tree.process_frame
 
 
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func _assert_device_payload(device: Object, label: String) -> void:
+	assert_not_null(device, "%s is non-null" % label)
+	if device == null:
+		return
+	assert_true(device.has_method("get_device_id"), "%s exposes get_device_id()" % label)
+	assert_true(device.has_method("get_kind_mask"), "%s exposes get_kind_mask()" % label)
+	assert_true(device.has_method("is_connected"), "%s exposes is_connected()" % label)
+	assert_true(device.call("is_connected"), "%s reports connected" % label)
+	assert_true(device.get_device_id() > 0, "%s has a positive session id" % label)
+	assert_true(device.get_kind_mask() != 0, "%s has a non-zero kind mask" % label)
+
+
 func test_repeated_get_devices_no_hardware() -> void:
 	if pending_unless_runtime_available():
 		return
@@ -41,20 +58,24 @@ func test_repeated_get_devices_no_hardware() -> void:
 		return
 
 	# Hammer get_devices() across many frames. With no device connected the
-	# returned Array must always be empty; the mapper API and threaded device
-	# callback queue must stay healthy under the repetition.
+	# returned Array must stay empty; if hardware is present, assert the content
+	# too so this test cannot pass on Array shape alone.
 	var saw_non_array := false
+	var all_mask := _device_constant("DEVICE_ALL")
 	for i in ITERATIONS:
-		var devices = gi.get_devices()
+		gi.poll()
+		var devices = gi.get_devices(all_mask)
 		if not (devices is Array):
 			saw_non_array = true
 			break
-		# The Array may grow if a device is plugged in mid-test; we only
-		# assert the type contract, not the count, to stay headless-safe.
+		assert_eq(devices.size(), gi.get_connected_device_count(),
+				"DEVICE_ALL count matches connected count on frame %d" % i)
+		for device in devices:
+			_assert_device_payload(device, "threading smoke device")
 		await get_tree().process_frame
 
 	assert_eq(saw_non_array, false,
-			"get_devices() always returned Array across %d frames" % ITERATIONS)
+			"get_devices(DEVICE_ALL) always returned Array across %d frames" % ITERATIONS)
 
 	gi.shutdown()
 	assert_eq(gi.is_initialized(), false,
@@ -75,6 +96,15 @@ func test_repeated_get_current_reading_no_hardware() -> void:
 	var bare_device = ClassDB.instantiate("GameInputDevice")
 	var saw_unexpected := false
 	for i in ITERATIONS:
+		# Poll before the bare-id check so the worker -> main queue drain is
+		# exercised even when the id-0 wrapper short-circuits to null.
+		gi.poll()
+		var devices = gi.get_devices(_device_constant("DEVICE_ALL"))
+		assert_eq(devices.size(), gi.get_connected_device_count(),
+				"worker queue drain keeps device cache count coherent on frame %d" % i)
+		for device in devices:
+			_assert_device_payload(device, "queue-drained device")
+
 		# null device → null reading. Bare wrapper (id 0) → null reading
 		# because no entry exists for id 0 in the cache.
 		var r_null = gi.get_current_reading(null)
@@ -84,7 +114,6 @@ func test_repeated_get_current_reading_no_hardware() -> void:
 			break
 		# Defensive: poll() is per-frame idempotent. Calling it twice on the
 		# same frame must not crash and must not re-drain the worker queue.
-		gi.poll()
 		gi.poll()
 		await get_tree().process_frame
 

--- a/tests/godot/playfab/tests/test_core.gd
+++ b/tests/godot/playfab/tests/test_core.gd
@@ -34,6 +34,7 @@ const PLAYFAB_ROOT_METHODS := [
 ]
 
 const PLAYFAB_ROOT_SIGNALS := ["initialized", "shutdown_completed"]
+const REARM_TEST_TITLE_ID := "00000"
 
 const REGISTERED_CLASSES := [
 	"PlayFab",
@@ -83,6 +84,18 @@ const REGISTERED_CLASSES := [
 	"PlayFabTitleData",
 	"PlayFabResult",
 ]
+
+
+func _restore_playfab_runtime_settings(original_title_id, original_endpoint) -> void:
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, original_title_id)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, original_endpoint)
+
+
+func _disconnect_playfab_lifecycle_handlers(playfab, initialized_handler: Callable, shutdown_handler: Callable) -> void:
+	if playfab.initialized.is_connected(initialized_handler):
+		playfab.initialized.disconnect(initialized_handler)
+	if playfab.shutdown_completed.is_connected(shutdown_handler):
+		playfab.shutdown_completed.disconnect(shutdown_handler)
 
 
 func test_singleton_availability() -> void:
@@ -211,3 +224,54 @@ func test_initialize_rejects_blank_title_id() -> void:
 
 	if playfab.initialized.is_connected(initialized_handler):
 		playfab.initialized.disconnect(initialized_handler)
+
+
+func test_initialize_shutdown_rearms_runtime_lifecycle() -> void:
+	if pending_unless_playfab_available():
+		return
+	var playfab = get_playfab()
+
+	reset_playfab_runtime()
+
+	var original_title_id = ProjectSettings.get_setting(PLAYFAB_TITLE_ID_SETTING, "")
+	var original_endpoint = ProjectSettings.get_setting(PLAYFAB_ENDPOINT_SETTING, "")
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, REARM_TEST_TITLE_ID)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, "")
+
+	var initialized_events: Array = []
+	var shutdown_events: Array = []
+	var initialized_handler := func() -> void:
+		initialized_events.append(true)
+	var shutdown_handler := func() -> void:
+		shutdown_events.append(true)
+
+	playfab.initialized.connect(initialized_handler)
+	playfab.shutdown_completed.connect(shutdown_handler)
+
+	var lifecycle_failed := false
+	for cycle_index in range(3):
+		var init_result = playfab.initialize()
+		if init_result == null:
+			assert_not_null(init_result, "PlayFab.initialize() returns a result on cycle %d" % (cycle_index + 1))
+			lifecycle_failed = true
+			break
+		if not init_result.is_ok():
+			assert_playfab_result_ok(init_result, "PlayFab.initialize() re-arms after shutdown on cycle %d" % (cycle_index + 1))
+			lifecycle_failed = true
+			break
+
+		assert_true(playfab.is_initialized(), "PlayFab is initialized on cycle %d" % (cycle_index + 1))
+		if cycle_index < 2:
+			playfab.shutdown()
+			assert_false(playfab.is_initialized(), "PlayFab shuts down cleanly on cycle %d" % (cycle_index + 1))
+
+	if not lifecycle_failed:
+		assert_eq(initialized_events.size(), 3, "PlayFab.initialized emits for each re-arm initialize")
+		assert_eq(shutdown_events.size(), 2, "PlayFab.shutdown_completed emits for the two explicit shutdowns before the third initialize")
+		assert_true(playfab.is_initialized(), "PlayFab remains initialized after the third re-arm initialize")
+
+	if playfab.is_initialized():
+		playfab.shutdown()
+	_restore_playfab_runtime_settings(original_title_id, original_endpoint)
+	reset_playfab_runtime()
+	_disconnect_playfab_lifecycle_handlers(playfab, initialized_handler, shutdown_handler)

--- a/tests/godot/playfab/tests/test_multiplayer_lobby_live.gd
+++ b/tests/godot/playfab/tests/test_multiplayer_lobby_live.gd
@@ -145,6 +145,63 @@ func test_lobby_shutdown_without_leave_does_not_emit_null_member() -> void:
 	# The lobby reference is now detached; no further teardown needed.
 
 
+func test_failed_lobby_join_does_not_leave_tracked_wrapper() -> void:
+	var session = await _begin_multiplayer_session()
+	var playfab_user = session.get("playfab_user")
+	if playfab_user == null:
+		return
+
+	var playfab: Object = session["playfab"]
+	var multiplayer: Object = session["multiplayer"]
+
+	var lobby_config = instantiate_class("PlayFabLobbyConfig")
+	if lobby_config == null:
+		_finish_session(playfab, null)
+		return
+	lobby_config.max_players = 2
+	lobby_config.access_policy = get_class_constant("PlayFabLobbyConfig", "ACCESS_POLICY_PRIVATE")
+
+	var create_result = await await_completion(multiplayer.create_lobby_async(playfab_user, lobby_config), _DEFAULT_OP_TIMEOUT_MSEC)
+	if create_result == null or not create_result.ok:
+		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % (create_result.message if create_result != null else "null result"))
+		_finish_session(playfab, null)
+		return
+
+	var lobby: Object = create_result.data
+	if lobby == null:
+		_finish_session(playfab, null)
+		return
+
+	var stale_connection_string := str(lobby.get_connection_string())
+	var leave_result = await await_completion(lobby.leave_async(), _DEFAULT_OP_TIMEOUT_MSEC)
+	if leave_result == null or not leave_result.ok:
+		pending("PlayFabLobby.leave_async failed before stale-join regression check: %s" % (leave_result.message if leave_result != null else "null result"))
+		_finish_session(playfab, null)
+		return
+	await advance_process_frames(_STATE_PUMP_FRAMES)
+
+	var before_count := multiplayer.get_lobbies().size()
+	var join_config = instantiate_class("PlayFabLobbyJoinConfig")
+	var join_result = await await_completion(multiplayer.join_lobby_async(playfab_user, stale_connection_string, join_config), _DEFAULT_OP_TIMEOUT_MSEC)
+	if join_result == null:
+		pending("PlayFab.multiplayer.join_lobby_async(stale_connection_string) timed out; cannot assert failure cleanup.")
+		_finish_session(playfab, null)
+		return
+	if join_result.ok:
+		var joined_lobby = join_result.data
+		if joined_lobby != null:
+			await await_completion(joined_lobby.leave_async(), _DEFAULT_OP_TIMEOUT_MSEC)
+		pending("PlayFab service accepted a stale lobby connection string; failure-cleanup path was not exercised.")
+		_finish_session(playfab, null)
+		return
+
+	await advance_process_frames(_STATE_PUMP_FRAMES)
+	assert_eq(multiplayer.get_lobbies().size(), before_count,
+			"failed join completion does not leave its PlayFabLobby wrapper tracked")
+
+	_finish_session(playfab, null)
+
+
 # ── Live setup helpers ────────────────────────────────────────────────────
 
 func _begin_multiplayer_session() -> Dictionary:


### PR DESCRIPTION
## Summary
- Backfills audit lane C3 GameInput coverage for T-01, T-02, T-04..T-12, T-14, and T-16 without duplicating the C1 stuck-action scenarios from #9 (old repo #137).
- Builds on #9's `set_vibration` HRESULT propagation by adding initialized soft-fail assertions plus a live-gated success/`stop_haptics` path.
- Adds mapper native-handle cache reuse/clear tests, init→shutdown→init re-arm coverage, EXIT_TREE-after-frame release coverage, bind_method coverage, mask/parameter branches, bootstrap contract tests, threading content assertions, and live-gated previous-reading coverage.
- Fixes existing GameInput GUT parse blockers (`is_connected` native method call ambiguity and `:=` inference in C1 tests) so device and stuck-action suites are actually discovered.

## Files
- `tests/godot/gameinput/tests/test_gameinput_core_backfill.gd`
- `tests/godot/gameinput/tests/test_gameinput_mapper_backfill.gd`
- `tests/godot/gameinput/tests/test_gameinput_bootstrap_contract.gd`
- Updates to existing GameInput resource, reading, device, mapper stuck-action, and threading smoke tests.

## Validation
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1` — failed on pre-existing sample/tutorial parse errors (`sample\tutorial_app\autoload\auth.gd` missing `GDKUser`).
- `cmake --preset default` — passed.
- `cmake --build build --preset debug` — passed.
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1 -SkipBuild -Hosts tests\godot\gameinput -ParseExcludeProjects sample -GutTimeoutSec 600` — passed (57 tests, 51 passing, 6 pending, 34850/34850 asserts).
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1 -ParseExcludeProjects sample -GutTimeoutSec 600` — parse/build/doctest/playfab/gameinput passed; overall failed on unrelated `tests\godot\gdk` GUT timeout after 600s during silent sign-in/bootstrap warnings.

## Live coverage
- Live tests were not run (`-Live` omitted). Hardware-required GameInput coverage is gated with the existing live-test helper and reports pending offline. No live writes.

## Stacking note
- PR #9 (old repo #137) is still open in this repo, so this PR targets `audit/gi-stuck-actions` to avoid duplicating C1 changes. Retarget to `main` after #9 merges.