### PR TITLE
gi-tests: backfill coverage for cache, init-cycle, untested bind_methods, bootstrap, parameter branches

### DIFF
--- a/tests/godot/gameinput/tests/test_gameinput_bootstrap_contract.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_bootstrap_contract.gd
@@ -1,0 +1,189 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Audit C3 backfill for GameInputBootstrap project-setting side effects and
+## initialization ownership semantics.
+
+const BootstrapScript = preload("res://addons/godot_gameinput/runtime/gameinput_bootstrap.gd")
+
+const SETTING_INITIALIZE_ON_STARTUP := "game_input/runtime/initialize_on_startup"
+const SETTING_AUTO_POLL := "game_input/runtime/auto_poll"
+const SETTING_DEFAULT_ACTION_MAP := "game_input/mapper/default_action_map"
+
+var _saved_settings: Dictionary = {}
+var _files_to_cleanup: Array[String] = []
+
+
+func after_each() -> void:
+	for key in _saved_settings.keys():
+		ProjectSettings.set_setting(key, _saved_settings[key])
+	_saved_settings.clear()
+	for path in _files_to_cleanup:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+	_files_to_cleanup.clear()
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _set_bootstrap_setting(key: String, value: Variant) -> void:
+	if not _saved_settings.has(key):
+		_saved_settings[key] = ProjectSettings.get_setting(key, null)
+	ProjectSettings.set_setting(key, value)
+
+
+func _set_base_settings() -> void:
+	_set_bootstrap_setting(SETTING_INITIALIZE_ON_STARTUP, false)
+	_set_bootstrap_setting(SETTING_AUTO_POLL, false)
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, "")
+
+
+func _spawn_bootstrap() -> Node:
+	var bootstrap: Node = BootstrapScript.new()
+	get_tree().root.add_child(bootstrap)
+	await get_tree().process_frame
+	return bootstrap
+
+
+func _free_bootstrap(bootstrap: Node) -> void:
+	if bootstrap == null:
+		return
+	if bootstrap.get_parent() != null:
+		bootstrap.get_parent().remove_child(bootstrap)
+	bootstrap.free()
+
+
+func _new_action_map_resource():
+	if not ClassDB.class_exists("GameInputActionMap") or not ClassDB.class_exists("GameInputBinding"):
+		return null
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("action", &"bootstrap_contract_action")
+	binding.set("source", 2)
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	action_map.add_binding(binding)
+	return action_map
+
+
+func _save_resource(resource: Resource, file_name: String) -> String:
+	var path := "user://%s" % file_name
+	var err := ResourceSaver.save(resource, path)
+	assert_eq(err, OK, "ResourceSaver.save(%s) succeeds" % file_name)
+	_files_to_cleanup.append(path)
+	return path
+
+
+func test_auto_poll_setting_controls_process_mode() -> void:
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_AUTO_POLL, false)
+	var bootstrap := await _spawn_bootstrap()
+	assert_eq(bootstrap.get("_auto_poll"), false, "auto_poll=false is stored on bootstrap")
+	assert_false(bootstrap.is_processing(), "auto_poll=false disables processing")
+	_free_bootstrap(bootstrap)
+
+	_set_bootstrap_setting(SETTING_AUTO_POLL, true)
+	bootstrap = await _spawn_bootstrap()
+	assert_eq(bootstrap.get("_auto_poll"), true, "auto_poll=true is stored on bootstrap")
+	assert_true(bootstrap.is_processing(), "auto_poll=true enables processing")
+	_free_bootstrap(bootstrap)
+
+
+func test_default_action_map_valid_path_spawns_default_mapper() -> void:
+	_set_base_settings()
+	var action_map = _new_action_map_resource()
+	if action_map == null:
+		pending("GameInputActionMap / GameInputBinding missing")
+		return
+	var path := _save_resource(action_map, "gameinput_bootstrap_valid_map.tres")
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, path)
+
+	var bootstrap := await _spawn_bootstrap()
+	var mapper := bootstrap.get_node_or_null("DefaultMapper")
+	assert_not_null(mapper, "valid default_action_map spawns DefaultMapper child")
+	if mapper != null:
+		assert_true(mapper.is_class("GameInputMapper"), "DefaultMapper is a GameInputMapper")
+		var loaded_map = mapper.get("action_map")
+		assert_not_null(loaded_map, "DefaultMapper action_map is assigned")
+		if loaded_map != null:
+			assert_true(loaded_map.is_class("GameInputActionMap"),
+					"DefaultMapper action_map has GameInputActionMap class")
+			assert_eq(loaded_map.get_binding_count(), 1,
+					"DefaultMapper action_map preserves saved binding count")
+	_free_bootstrap(bootstrap)
+
+
+func test_default_action_map_invalid_path_soft_fails() -> void:
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, "user://missing_gameinput_bootstrap_map.tres")
+
+	var bootstrap := await _spawn_bootstrap()
+	assert_true(bootstrap.get_node_or_null("DefaultMapper") == null,
+			"invalid default_action_map path does not spawn a mapper")
+	assert_push_warning("does not exist",
+			"invalid default_action_map path emits a warning")
+	_free_bootstrap(bootstrap)
+
+
+func test_default_action_map_wrong_type_soft_fails() -> void:
+	_set_base_settings()
+	var wrong_resource := Resource.new()
+	var path := _save_resource(wrong_resource, "gameinput_bootstrap_wrong_type.tres")
+	_set_bootstrap_setting(SETTING_DEFAULT_ACTION_MAP, path)
+
+	var bootstrap := await _spawn_bootstrap()
+	assert_true(bootstrap.get_node_or_null("DefaultMapper") == null,
+			"wrong-type default_action_map path does not spawn a mapper")
+	assert_push_warning("not a GameInputActionMap",
+			"wrong-type default_action_map emits a warning")
+	_free_bootstrap(bootstrap)
+
+
+func test_initialize_on_startup_owns_shutdown_when_bootstrap_initializes() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_INITIALIZE_ON_STARTUP, true)
+
+	var bootstrap := await _spawn_bootstrap()
+	if not gi.is_initialized():
+		_free_bootstrap(bootstrap)
+		pending("GameInput.initialize() returned false from bootstrap")
+		return
+	assert_eq(bootstrap.get("_initialized_here"), true,
+			"bootstrap records ownership when it initializes GameInput")
+	bootstrap.notification(NOTIFICATION_PREDELETE)
+	assert_eq(gi.is_initialized(), false,
+			"bootstrap-owned runtime shuts down on PREDELETE")
+	assert_eq(bootstrap.get("_initialized_here"), false,
+			"bootstrap clears ownership after shutdown")
+	_free_bootstrap(bootstrap)
+
+
+func test_initialize_on_startup_does_not_shutdown_preinitialized_runtime() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false before bootstrap")
+		return
+
+	_set_base_settings()
+	_set_bootstrap_setting(SETTING_INITIALIZE_ON_STARTUP, true)
+	var bootstrap := await _spawn_bootstrap()
+	assert_eq(bootstrap.get("_initialized_here"), false,
+			"bootstrap does not claim ownership of a preinitialized runtime")
+	bootstrap.notification(NOTIFICATION_PREDELETE)
+	assert_eq(gi.is_initialized(), true,
+			"bootstrap PREDELETE leaves caller-owned runtime initialized")
+	_free_bootstrap(bootstrap)
+
+
+func test_should_skip_bootstrap_is_false_in_normal_gut_runner() -> void:
+	var bootstrap: Node = BootstrapScript.new()
+	assert_eq(bootstrap.call("_should_skip_bootstrap"), false,
+			"normal GUT invocation does not trigger the gd-script-check skip path")
+	bootstrap.free()

--- a/tests/godot/gameinput/tests/test_gameinput_core_backfill.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_core_backfill.gd
@@ -1,0 +1,243 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Audit C3 backfill for singleton bind_methods, haptics, masks, signals,
+## and the init -> shutdown -> init callback re-arm cycle.
+
+
+func after_each() -> void:
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _find_signal_info(obj: Object, signal_name: StringName) -> Dictionary:
+	for info in obj.get_signal_list():
+		if info.get("name") == signal_name:
+			return info
+	return {}
+
+
+func _assert_device_payload(device: Object, label: String) -> void:
+	assert_not_null(device, "%s is non-null" % label)
+	if device == null:
+		return
+	assert_true(device.has_method("get_device_id"), "%s exposes get_device_id()" % label)
+	assert_true(device.has_method("get_kind_mask"), "%s exposes get_kind_mask()" % label)
+	assert_true(device.has_method("is_connected"), "%s exposes is_connected()" % label)
+	assert_true(device.call("is_connected"), "%s reports connected" % label)
+	assert_true(device.get_device_id() > 0, "%s has a positive session id" % label)
+	assert_true(device.get_kind_mask() != 0, "%s has a non-zero kind mask" % label)
+
+
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func test_signal_shapes_and_connected_count_surface() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	assert_has_signal_named(gi, "device_connected")
+	assert_has_signal_named(gi, "device_disconnected")
+	assert_has_method_named(gi, "get_connected_device_count")
+
+	var connected_info := _find_signal_info(gi, &"device_connected")
+	assert_false(connected_info.is_empty(), "device_connected signal metadata is registered")
+	if not connected_info.is_empty():
+		var args: Array = connected_info.get("args", [])
+		assert_eq(args.size(), 1, "device_connected has one argument")
+		if args.size() == 1:
+			assert_eq(str(args[0].get("name", "")), "device", "device_connected argument name")
+			assert_eq(args[0].get("type"), TYPE_OBJECT, "device_connected argument type")
+			var device_class := str(args[0].get("class_name", ""))
+			if device_class.is_empty():
+				device_class = str(args[0].get("hint_string", ""))
+			assert_eq(device_class, "GameInputDevice",
+					"device_connected argument class hint")
+
+	var disconnected_info := _find_signal_info(gi, &"device_disconnected")
+	assert_false(disconnected_info.is_empty(), "device_disconnected signal metadata is registered")
+	if not disconnected_info.is_empty():
+		var args: Array = disconnected_info.get("args", [])
+		assert_eq(args.size(), 1, "device_disconnected has one argument")
+		if args.size() == 1:
+			assert_eq(str(args[0].get("name", "")), "device_id",
+					"device_disconnected argument name")
+			assert_eq(args[0].get("type"), TYPE_INT, "device_disconnected argument type")
+
+	gi.shutdown()
+	assert_eq(gi.get_connected_device_count(), 0,
+			"get_connected_device_count() returns 0 after shutdown")
+
+
+func test_kind_mask_queries_return_consistent_content_after_initialize() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+
+	var all_mask := _device_constant("DEVICE_ALL")
+	var gamepad_mask := _device_constant("DEVICE_GAMEPAD")
+	var keyboard_mask := _device_constant("DEVICE_KEYBOARD")
+	var mouse_mask := _device_constant("DEVICE_MOUSE")
+	var unknown_mask := _device_constant("DEVICE_UNKNOWN")
+
+	var all_devices: Array = gi.get_devices(all_mask)
+	assert_eq(all_devices.size(), gi.get_connected_device_count(),
+			"DEVICE_ALL count matches get_connected_device_count()")
+	for device in all_devices:
+		_assert_device_payload(device, "DEVICE_ALL device")
+
+	for mask in [gamepad_mask, keyboard_mask, mouse_mask, all_mask]:
+		var devices: Array = gi.get_devices(mask)
+		assert_true(devices is Array, "get_devices(%d) returns Array" % mask)
+		for device in devices:
+			_assert_device_payload(device, "mask %d device" % mask)
+			assert_true((device.get_kind_mask() & mask) != 0,
+					"device kind mask intersects query mask %d" % mask)
+
+		var primary = gi.get_primary_device(mask)
+		if devices.is_empty():
+			assert_true(primary == null,
+					"get_primary_device(%d) returns null when no device matches" % mask)
+		else:
+			_assert_device_payload(primary, "primary mask %d" % mask)
+			assert_true((primary.get_kind_mask() & mask) != 0,
+					"primary device kind mask intersects query mask %d" % mask)
+
+	assert_eq(gi.get_devices(unknown_mask).size(), 0,
+			"get_devices(DEVICE_UNKNOWN) returns no devices")
+	assert_true(gi.get_primary_device(unknown_mask) == null,
+			"get_primary_device(DEVICE_UNKNOWN) returns null")
+
+
+func test_initialize_shutdown_initialize_rearms_device_enumeration() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var first_started: bool = gi.initialize()
+	if not first_started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var first_devices: Array = gi.get_devices(_device_constant("DEVICE_ALL"))
+	assert_eq(first_devices.size(), gi.get_connected_device_count(),
+			"first init drains device callbacks into the cache")
+
+	gi.shutdown()
+	assert_eq(gi.is_initialized(), false, "shutdown() tears down first init")
+	assert_eq(gi.get_connected_device_count(), 0, "shutdown() clears the device cache")
+
+	var second_started: bool = gi.initialize()
+	assert_true(second_started, "second initialize() after shutdown succeeds")
+	if not second_started:
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var second_devices: Array = gi.get_devices(_device_constant("DEVICE_ALL"))
+	assert_eq(second_devices.size(), gi.get_connected_device_count(),
+			"second init re-arms callbacks and exposes a consistent device cache")
+	for device in second_devices:
+		_assert_device_payload(device, "second init device")
+
+
+func test_haptics_soft_fail_on_null_and_stale_wrappers() -> void:
+	if pending_unless_runtime_available():
+		return
+	if not ClassDB.class_exists("GameInputDevice"):
+		pending("GameInputDevice missing")
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	assert_eq(gi.set_vibration(null, 1.0, 1.0, 1.0, 1.0), false,
+			"set_vibration(null) returns false while initialized")
+	gi.stop_haptics(null)
+	assert_true(true, "stop_haptics(null) soft-fails without crashing")
+
+	var stale_device = ClassDB.instantiate("GameInputDevice")
+	assert_eq(gi.set_vibration(stale_device, 0.25, 0.5, 0.75, 1.0), false,
+			"set_vibration(stale/disconnected wrapper) returns false")
+	gi.stop_haptics(stale_device)
+	assert_true(true, "stop_haptics(stale/disconnected wrapper) soft-fails without crashing")
+
+
+func test_live_vibration_success_path_and_stop_haptics() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for vibration coverage")
+		return
+	if not device.supports_vibration():
+		pending("Live GameInput gamepad does not report rumble support")
+		return
+
+	var ok: bool = gi.set_vibration(device, 1.5, -1.0, 2.0, -0.5)
+	assert_true(ok, "set_vibration() succeeds on a live rumble-capable device")
+	await get_tree().create_timer(0.05).timeout
+	gi.stop_haptics(device)
+	assert_true(true, "stop_haptics() sends a zero-rumble request after success")
+
+
+func test_live_device_connected_signal_emits_device_payload() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	watch_signals(gi)
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	if gi.get_connected_device_count() == 0:
+		pending("No live GameInput devices connected to assert device_connected emission")
+		return
+
+	assert_true(get_signal_emit_count(gi, "device_connected") > 0,
+			"initial enumeration emits device_connected on the main thread")
+	var params = get_signal_parameters(gi, "device_connected", 0)
+	assert_true(params is Array, "device_connected parameters are captured")
+	if params is Array and params.size() == 1:
+		_assert_device_payload(params[0], "device_connected payload")

--- a/tests/godot/gameinput/tests/test_gameinput_device.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_device.gd
@@ -67,7 +67,7 @@ func test_device_defaults_before_init() -> void:
 			"get_display_name() == \"\" before init")
 	assert_eq(device.get_kind_mask(), 0,
 			"get_kind_mask() == 0 (DEVICE_UNKNOWN) before init")
-	assert_eq(device.is_connected(), false,
+	assert_eq(device.call("is_connected"), false,
 			"is_connected() == false before init")
 	assert_eq(device.supports_vibration(), false,
 			"supports_vibration() == false before init")
@@ -104,7 +104,7 @@ func test_device_defaults_after_shutdown() -> void:
 			"get_display_name() == \"\" after shutdown()")
 	assert_eq(device.get_kind_mask(), 0,
 			"get_kind_mask() == 0 after shutdown()")
-	assert_eq(device.is_connected(), false,
+	assert_eq(device.call("is_connected"), false,
 			"is_connected() == false after shutdown()")
 	assert_eq(device.supports_vibration(), false,
 			"supports_vibration() == false after shutdown()")

--- a/tests/godot/gameinput/tests/test_gameinput_mapper_backfill.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_mapper_backfill.gd
@@ -1,0 +1,290 @@
+extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
+## Audit C3 backfill for mapper cache, EXIT_TREE, active-count, axis, and
+## missing-action debounce paths not covered by the stuck-action lane.
+
+var _actions_to_cleanup: Array[StringName] = []
+
+
+func after_each() -> void:
+	for action in _actions_to_cleanup:
+		Input.action_release(action)
+		if InputMap.has_action(action):
+			InputMap.erase_action(action)
+	_actions_to_cleanup.clear()
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _ensure_action(action: StringName) -> void:
+	if not InputMap.has_action(action):
+		InputMap.add_action(action)
+		_actions_to_cleanup.append(action)
+	Input.action_release(action)
+
+
+func _new_binding(action: StringName, source_value: int = 2, is_axis: bool = false):
+	if not ClassDB.class_exists("GameInputBinding"):
+		return null
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("action", action)
+	binding.set("source", source_value)
+	binding.set("is_axis", is_axis)
+	return binding
+
+
+func _new_action_map(bindings: Array):
+	if not ClassDB.class_exists("GameInputActionMap"):
+		return null
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	action_map.set("bindings", bindings)
+	return action_map
+
+
+func _new_action_map_with(action: StringName, source_value: int = 2, is_axis: bool = false):
+	var binding = _new_binding(action, source_value, is_axis)
+	if binding == null:
+		return null
+	return _new_action_map([binding])
+
+
+func _new_mapper_basic():
+	if not ClassDB.class_exists("GameInputMapper"):
+		return null
+	return ClassDB.instantiate("GameInputMapper")
+
+
+func _new_mapper_with_test_hooks():
+	var mapper = _new_mapper_basic()
+	if mapper == null:
+		return null
+	if not mapper.has_method("_test_mark_binding_pressed") \
+			or not mapper.has_method("_test_prime_native_handles_cache") \
+			or not mapper.has_method("_test_get_native_handles_cache_count"):
+		mapper.free()
+		return null
+	return mapper
+
+
+func _seed_mapper_press(mapper: Node, action: StringName) -> void:
+	mapper.call("_test_mark_binding_pressed", 0)
+	assert_true(Input.is_action_pressed(action), "test hook seeds a held action")
+	assert_eq(mapper.call("get_active_binding_count"), 1,
+			"get_active_binding_count() reports one held binding")
+
+
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func _source_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInputDevice", name)
+
+
+func test_native_handles_cache_reuses_identical_binding_index() -> void:
+	var action_a := &"test_gi_cache_a"
+	var action_b := &"test_gi_cache_b"
+	_ensure_action(action_a)
+	_ensure_action(action_b)
+
+	var mapper = _new_mapper_with_test_hooks()
+	var action_map = _new_action_map([
+		_new_binding(action_a),
+		_new_binding(action_b),
+	])
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper cache test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+			"native-handles cache starts empty")
+	mapper.call("_test_prime_native_handles_cache", 0, false)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"first lookup fills one cache entry")
+	mapper.call("_test_prime_native_handles_cache", 0, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"repeated identical-binding lookup reuses the cached entry")
+	mapper.call("_test_prime_native_handles_cache", 1, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 2,
+			"a different binding index gets its own cache entry")
+	mapper.free()
+
+
+func test_native_handles_cache_clears_on_map_swap_and_next_frame() -> void:
+	var first_action := &"test_gi_cache_swap_first"
+	var second_action := &"test_gi_cache_swap_second"
+	_ensure_action(first_action)
+	_ensure_action(second_action)
+
+	var mapper = _new_mapper_with_test_hooks()
+	var first = _new_action_map_with(first_action)
+	var second = _new_action_map_with(second_action)
+	if mapper == null or first == null or second == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper cache test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", first)
+	mapper.call("_test_prime_native_handles_cache", 0, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"cache primed before map swap")
+	mapper.set("action_map", second)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+			"set_action_map() clears native-handles cache")
+
+	mapper.call("_test_prime_native_handles_cache", 0, true)
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 1,
+			"cache primed before next-frame invalidation")
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	assert_eq(mapper.call("_test_get_native_handles_cache_count"), 0,
+			"mapper process clears stale native-handles cache entries on a new frame")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_exit_tree_after_processing_releases_held_action() -> void:
+	var held := &"test_gi_exit_tree_after_frame"
+	_ensure_action(held)
+
+	var mapper = _new_mapper_with_test_hooks()
+	var action_map = _new_action_map_with(held)
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper test hooks or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	_seed_mapper_press(mapper, held)
+	await get_tree().process_frame
+	holder.remove_child(mapper)
+	assert_false(Input.is_action_pressed(held),
+			"NOTIFICATION_EXIT_TREE releases held actions after at least one processed frame")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"EXIT_TREE clears the active binding cache")
+	mapper.free()
+	holder.free()
+
+
+func test_active_binding_count_zero_for_inert_mapper() -> void:
+	var mapper = _new_mapper_basic()
+	if mapper == null:
+		pending("GameInputMapper missing")
+		return
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"new mapper has no active bindings")
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"mapper without action_map/device remains at zero active bindings")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_live_axis_binding_path_stays_bounded_below_threshold() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for axis binding coverage")
+		return
+
+	var action := &"test_gi_axis_bound"
+	_ensure_action(action)
+	var binding = _new_binding(action, _source_constant("SRC_AXIS_LEFT_X"), true)
+	if binding == null:
+		pending("GameInputBinding missing")
+		return
+	binding.set("axis_threshold", 1.0)
+	binding.set("deadzone", 0.0)
+	var action_map = _new_action_map([binding])
+	var mapper = _new_mapper_basic()
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", device.get_device_id())
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_false(Input.is_action_pressed(action),
+			"axis binding with threshold 1.0 does not synthesize a pressed action")
+	assert_eq(mapper.call("get_active_binding_count"), 0,
+			"axis path leaves no active binding below threshold")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()
+
+
+func test_live_missing_action_warning_is_debounced() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for missing-action debounce coverage")
+		return
+
+	var missing_action := &"test_gi_missing_action_debounce"
+	if InputMap.has_action(missing_action):
+		InputMap.erase_action(missing_action)
+	var action_map = _new_action_map_with(missing_action)
+	var mapper = _new_mapper_basic()
+	if mapper == null or action_map == null:
+		if mapper != null: mapper.free()
+		pending("GameInputMapper or action-map classes missing")
+		return
+
+	mapper.set("action_map", action_map)
+	mapper.set("target_device_id", device.get_device_id())
+	var holder := Node.new()
+	get_tree().root.add_child(holder)
+	holder.add_child(mapper)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_push_warning_count(1,
+			"missing InputMap action warning is emitted once across repeated frames")
+	holder.remove_child(mapper)
+	mapper.free()
+	holder.free()

--- a/tests/godot/gameinput/tests/test_gameinput_reading.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_reading.gd
@@ -43,6 +43,20 @@ const _AXIS_NAMES := [
 ]
 
 
+func after_each() -> void:
+	var gi = get_gameinput()
+	if gi != null:
+		gi.shutdown()
+
+
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func _gameinput_device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInputDevice", name)
+
+
 func _new_reading() -> Object:
 	if not ClassDB.class_exists("GameInputReading"):
 		return null
@@ -127,3 +141,45 @@ func test_reading_unknown_button_axis_safe() -> void:
 			"get_axis(-1) ≈ 0.0")
 	assert_eq_approx(reading.get_axis(99999), 0.0,
 			"get_axis(99999) ≈ 0.0")
+
+
+func test_live_second_reading_exercises_previous_state_branch() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_runtime_available():
+		return
+
+	var gi = get_gameinput()
+	gi.shutdown()
+	var started: bool = gi.initialize()
+	if not started:
+		pending("GameInput.initialize() returned false (no GameInput on host)")
+		return
+
+	gi.poll()
+	await get_tree().process_frame
+	gi.poll()
+	var device = gi.get_primary_device(_device_constant("DEVICE_GAMEPAD"))
+	if device == null:
+		pending("No live GameInput gamepad connected for previous-state reading coverage")
+		return
+
+	var first_reading = gi.get_current_reading(device)
+	if first_reading == null:
+		pending("Live GameInput device did not produce an initial reading")
+		return
+
+	await get_tree().process_frame
+	gi.poll()
+	var second_reading = gi.get_current_reading(device)
+	assert_not_null(second_reading, "second live reading is available")
+	if second_reading == null:
+		return
+
+	var button_a := _gameinput_device_constant("BUTTON_A")
+	assert_true(second_reading.was_button_pressed(button_a) is bool,
+			"was_button_pressed() returns bool after a previous reading exists")
+	assert_true(second_reading.was_button_released(button_a) is bool,
+			"was_button_released() returns bool after a previous reading exists")
+	assert_true(second_reading.get_buttons_mask() is int,
+			"second reading exposes buttons mask while previous state is populated")

--- a/tests/godot/gameinput/tests/test_gameinput_resource.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_resource.gd
@@ -35,6 +35,27 @@ func test_binding_defaults_and_setters() -> void:
 	assert_eq_approx(binding.get("deadzone"), 0.1, "binding.deadzone setter")
 
 
+func test_binding_clamps_axis_threshold_and_deadzone() -> void:
+	if not ClassDB.class_exists("GameInputBinding"):
+		pending("GameInputBinding missing")
+		return
+
+	var binding = ClassDB.instantiate("GameInputBinding")
+	binding.set("axis_threshold", -1.0)
+	binding.set("deadzone", -0.25)
+	assert_eq_approx(binding.get("axis_threshold"), 0.0,
+			"axis_threshold clamps negative values to 0.0")
+	assert_eq_approx(binding.get("deadzone"), 0.0,
+			"deadzone clamps negative values to 0.0")
+
+	binding.set("axis_threshold", 2.0)
+	binding.set("deadzone", 1.5)
+	assert_eq_approx(binding.get("axis_threshold"), 1.0,
+			"axis_threshold clamps values above 1.0")
+	assert_eq_approx(binding.get("deadzone"), 1.0,
+			"deadzone clamps values above 1.0")
+
+
 func test_binding_save_load_roundtrip() -> void:
 	if not ClassDB.class_exists("GameInputBinding"):
 		pending("GameInputBinding missing")
@@ -94,6 +115,39 @@ func test_action_map_typed_array() -> void:
 	assert_eq(bindings.size(), 2, "action_map.bindings holds 2 entries")
 	assert_eq(bindings[0].get("action"), &"move_left", "first binding action preserved")
 	assert_eq(bindings[1].get("action"), &"move_right", "second binding action preserved")
+
+
+func test_action_map_add_get_binding_and_clear_methods() -> void:
+	if not ClassDB.class_exists("GameInputActionMap") or not ClassDB.class_exists("GameInputBinding"):
+		pending("GameInputActionMap / GameInputBinding missing")
+		return
+
+	var action_map = ClassDB.instantiate("GameInputActionMap")
+	assert_eq(action_map.get_binding_count(), 0, "new action map count starts at 0")
+	assert_true(action_map.get_binding(0) == null,
+			"get_binding(0) returns null for an empty map")
+	assert_true(action_map.get_binding(-1) == null,
+			"get_binding(-1) returns null for an empty map")
+
+	var b1 = ClassDB.instantiate("GameInputBinding")
+	b1.set("action", &"jump")
+	var b2 = ClassDB.instantiate("GameInputBinding")
+	b2.set("action", &"fire")
+	action_map.add_binding(b1)
+	action_map.add_binding(null)
+	action_map.add_binding(b2)
+
+	assert_eq(action_map.get_binding_count(), 2,
+			"add_binding ignores null and counts real bindings")
+	assert_eq(action_map.get_binding(0), b1, "get_binding(0) returns first binding")
+	assert_eq(action_map.get_binding(1), b2, "get_binding(1) returns second binding")
+	assert_true(action_map.get_binding(2) == null,
+			"get_binding(out-of-range) returns null")
+
+	action_map.clear()
+	assert_eq(action_map.get_binding_count(), 0, "clear() removes all bindings")
+	assert_true(action_map.get_binding(0) == null,
+			"get_binding(0) returns null after clear()")
 
 
 func test_action_map_save_load_roundtrip() -> void:

--- a/tests/godot/gameinput/tests/test_gameinput_threading_smoke.gd
+++ b/tests/godot/gameinput/tests/test_gameinput_threading_smoke.gd
@@ -7,7 +7,8 @@ extends "res://addons/godot_gdk_tests/gameinput_test_base.gd"
 ## drains the pending queue inside `poll()` and is the only mutator of the
 ## device cache. This test exercises the no-hardware steady-state by hammering
 ## the public API across 100 frames and asserting:
-##   * `get_devices()` always returns an `Array` (no nulls / crashes / leaks).
+##   * `get_devices(DEVICE_ALL)` returns a coherent device cache and real
+##     `GameInputDevice` payloads when hardware is present.
 ##   * `get_current_reading(device)` is safe with a freshly instantiated bare
 ##     `GameInputDevice` (id `0`) — it must return null without dereferencing
 ##     into the worker's pending queue.
@@ -29,6 +30,22 @@ func _await_frames(n: int) -> void:
 		await tree.process_frame
 
 
+func _device_constant(name: String) -> int:
+	return ClassDB.class_get_integer_constant("GameInput", name)
+
+
+func _assert_device_payload(device: Object, label: String) -> void:
+	assert_not_null(device, "%s is non-null" % label)
+	if device == null:
+		return
+	assert_true(device.has_method("get_device_id"), "%s exposes get_device_id()" % label)
+	assert_true(device.has_method("get_kind_mask"), "%s exposes get_kind_mask()" % label)
+	assert_true(device.has_method("is_connected"), "%s exposes is_connected()" % label)
+	assert_true(device.call("is_connected"), "%s reports connected" % label)
+	assert_true(device.get_device_id() > 0, "%s has a positive session id" % label)
+	assert_true(device.get_kind_mask() != 0, "%s has a non-zero kind mask" % label)
+
+
 func test_repeated_get_devices_no_hardware() -> void:
 	if pending_unless_runtime_available():
 		return
@@ -41,20 +58,24 @@ func test_repeated_get_devices_no_hardware() -> void:
 		return
 
 	# Hammer get_devices() across many frames. With no device connected the
-	# returned Array must always be empty; the mapper API and threaded device
-	# callback queue must stay healthy under the repetition.
+	# returned Array must stay empty; if hardware is present, assert the content
+	# too so this test cannot pass on Array shape alone.
 	var saw_non_array := false
+	var all_mask := _device_constant("DEVICE_ALL")
 	for i in ITERATIONS:
-		var devices = gi.get_devices()
+		gi.poll()
+		var devices = gi.get_devices(all_mask)
 		if not (devices is Array):
 			saw_non_array = true
 			break
-		# The Array may grow if a device is plugged in mid-test; we only
-		# assert the type contract, not the count, to stay headless-safe.
+		assert_eq(devices.size(), gi.get_connected_device_count(),
+				"DEVICE_ALL count matches connected count on frame %d" % i)
+		for device in devices:
+			_assert_device_payload(device, "threading smoke device")
 		await get_tree().process_frame
 
 	assert_eq(saw_non_array, false,
-			"get_devices() always returned Array across %d frames" % ITERATIONS)
+			"get_devices(DEVICE_ALL) always returned Array across %d frames" % ITERATIONS)
 
 	gi.shutdown()
 	assert_eq(gi.is_initialized(), false,
@@ -75,6 +96,15 @@ func test_repeated_get_current_reading_no_hardware() -> void:
 	var bare_device = ClassDB.instantiate("GameInputDevice")
 	var saw_unexpected := false
 	for i in ITERATIONS:
+		# Poll before the bare-id check so the worker -> main queue drain is
+		# exercised even when the id-0 wrapper short-circuits to null.
+		gi.poll()
+		var devices = gi.get_devices(_device_constant("DEVICE_ALL"))
+		assert_eq(devices.size(), gi.get_connected_device_count(),
+				"worker queue drain keeps device cache count coherent on frame %d" % i)
+		for device in devices:
+			_assert_device_payload(device, "queue-drained device")
+
 		# null device → null reading. Bare wrapper (id 0) → null reading
 		# because no entry exists for id 0 in the cache.
 		var r_null = gi.get_current_reading(null)
@@ -84,7 +114,6 @@ func test_repeated_get_current_reading_no_hardware() -> void:
 			break
 		# Defensive: poll() is per-frame idempotent. Calling it twice on the
 		# same frame must not crash and must not re-drain the worker queue.
-		gi.poll()
 		gi.poll()
 		await get_tree().process_frame
 


### PR DESCRIPTION
## Summary
- Rebased onto `public/main`; this PR targets `microsoft/GodotforXBOXonPC:main` and the diff is limited to `tests/godot/gameinput/tests/*`.
- Backfills audit lane C3 GameInput coverage for T-01, T-02, T-04..T-12, T-14, and T-16 without duplicating C1 stuck-action scenarios.
- Builds on C1's public PR (link forthcoming) by adding initialized `set_vibration` soft-fail assertions plus live-gated success/`stop_haptics` coverage.
- Adds mapper native-handle cache reuse/clear tests, init→shutdown→init re-arm coverage, EXIT_TREE-after-frame release coverage, bind_method coverage, mask/parameter branches, bootstrap contract tests, threading content assertions, and live-gated previous-reading coverage.
- Fixes existing GameInput GUT parse blockers (`is_connected` native method call ambiguity and `:=` inference in C1 tests) so device and stuck-action suites are discovered.

## Files
- `tests/godot/gameinput/tests/test_gameinput_core_backfill.gd`
- `tests/godot/gameinput/tests/test_gameinput_mapper_backfill.gd`
- `tests/godot/gameinput/tests/test_gameinput_bootstrap_contract.gd`
- Updates to existing GameInput resource, reading, device, mapper stuck-action, and threading smoke tests.

## Validation
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1` — failed on pre-existing sample/tutorial parse errors (`sample\tutorial_app\autoload\auth.gd` missing `GDKUser`).
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1 -ExcludeProjects sample` — passed.
- `cmake --build build --preset debug` after rebasing onto `public/main` — blocked by a pre-existing `public/main` C++ syntax error in `addons\godot_gameinput\src\gameinput_mapper.cpp` at lines 184/185. This PR has no C++ diff.
- Last targeted GameInput run before the public-main redirect: `run_all_tests.ps1 -SkipBuild -Hosts tests\godot\gameinput -ParseExcludeProjects sample -GutTimeoutSec 600` — passed (57 tests, 51 passing, 6 pending, 34850/34850 asserts).

## Live coverage
- Live tests were not run (`-Live` omitted). Hardware-required GameInput coverage is gated with the existing live-test helper and reports pending offline. No live writes.