### PR TITLE
pk-shell-safety: quote gdkpkg.cmd args + constrain WdappManager taskkill to config-named exe

### DIFF
--- a/.github/instructions/godot-gdk-packaging.instructions.md
+++ b/.github/instructions/godot-gdk-packaging.instructions.md
@@ -136,6 +136,8 @@ before committing.
 
 - `tests/godot/gdk/tests/packaging/test_packaging_cli.gd` — argv parsing
   and verb-flag matrix.
+- `tests/godot/gdk/tests/packaging/test_gdkpkg_forwarder.gd` — shell
+  forwarder argument-preservation regressions.
 - `tests/godot/gdk/tests/packaging/test_packaging_config_resolver.gd` —
   precedence chain + key remap + encrypt key:<path> split.
 - `tests/godot/gdk/tests/packaging/test_packaging_result.gd` — result

--- a/addons/godot_gdk_packaging/core/wdapp_manager.gd
+++ b/addons/godot_gdk_packaging/core/wdapp_manager.gd
@@ -39,6 +39,7 @@ signal uninstall_completed(result: Dictionary)
 const GDKToolchainScript = preload("res://addons/godot_gdk_packaging/core/gdk_toolchain.gd")
 
 var _toolchain: RefCounted
+var _taskkill_runner: Callable
 
 # Async dispatch state. _busy / _disposed are only written from the main
 # thread (in _start_async / _join_thread / dispose). The worker thread only
@@ -49,8 +50,9 @@ var _busy: bool = false
 var _disposed: bool = false
 
 
-func _init(toolchain: RefCounted) -> void:
+func _init(toolchain: RefCounted, taskkill_runner: Callable = Callable()) -> void:
 	_toolchain = toolchain
+	_taskkill_runner = taskkill_runner
 
 
 func is_available() -> bool:
@@ -86,19 +88,13 @@ func terminate_app(pfn: String, build_dir: String) -> Dictionary:
 		result["terminated_with"] = "wdapp"
 		return result
 
-	var exe_name: String = _find_primary_executable(build_dir)
+	var exe_name: String = _resolve_taskkill_executable(build_dir)
 	if exe_name == "":
 		result["terminated_with"] = "wdapp"
+		result["taskkill_skipped_reason"] = "no configured executable available"
 		return result
 
-	var output: Array = []
-	var exit_code: int = OS.execute("taskkill", PackedStringArray(["/IM", exe_name, "/F"]), output, true, false)
-	return {
-		"exit_code": exit_code,
-		"stdout": str(output[0]) if output.size() > 0 else "",
-		"stderr": "",
-		"terminated_with": "taskkill",
-	}
+	return _execute_taskkill(exe_name)
 
 
 func install_package(msixvc_path: String) -> Dictionary:
@@ -214,8 +210,13 @@ func _join_thread() -> void:
 # still join the worker before the RefCounted destructor runs to avoid
 # leaking a live Godot Thread.
 func _notification(what: int) -> void:
-	if what == NOTIFICATION_PREDELETE:
-		dispose()
+	if what != NOTIFICATION_PREDELETE or _disposed:
+		return
+	_disposed = true
+	if _thread != null and _thread.is_started():
+		_thread.wait_to_finish()
+		_thread = null
+	_busy = false
 
 
 # --- Static helpers --------------------------------------------------------
@@ -239,20 +240,58 @@ func _get_wdapp_path() -> String:
 	return _toolchain.get_bin_dir().path_join("wdapp.exe")
 
 
-func _find_primary_executable(build_dir: String) -> String:
-	if not DirAccess.dir_exists_absolute(build_dir):
+func _execute_taskkill(exe_name: String) -> Dictionary:
+	if _taskkill_runner.is_valid():
+		var custom_result: Variant = _taskkill_runner.call(exe_name)
+		if typeof(custom_result) == TYPE_DICTIONARY:
+			return custom_result as Dictionary
+		return {"exit_code": 1, "stdout": "", "stderr": "taskkill runner did not return a Dictionary", "terminated_with": "taskkill"}
+
+	var output: Array = []
+	var exit_code: int = OS.execute("taskkill", PackedStringArray(["/IM", exe_name, "/F"]), output, true, false)
+	return {
+		"exit_code": exit_code,
+		"stdout": "\n".join(output),
+		"stderr": "",
+		"terminated_with": "taskkill",
+	}
+
+
+static func _resolve_taskkill_executable(build_dir: String) -> String:
+	if build_dir.is_empty() or not DirAccess.dir_exists_absolute(build_dir):
 		return ""
 
-	var dir: DirAccess = DirAccess.open(build_dir)
-	if dir == null:
+	var exe_name: String = _read_config_executable(build_dir.path_join("MicrosoftGame.config"))
+	if not _is_safe_taskkill_image_name(exe_name):
+		return ""
+	if not FileAccess.file_exists(build_dir.path_join(exe_name)):
+		return ""
+	return exe_name
+
+
+static func _read_config_executable(config_path: String) -> String:
+	if config_path.is_empty() or not FileAccess.file_exists(config_path):
 		return ""
 
-	dir.list_dir_begin()
-	var fname: String = dir.get_next()
-	while fname != "":
-		if fname.ends_with(".exe") and not fname.ends_with(".console.exe"):
-			dir.list_dir_end()
-			return fname
-		fname = dir.get_next()
-	dir.list_dir_end()
+	var parser := XMLParser.new()
+	if parser.open(config_path) != OK:
+		return ""
+
+	while parser.read() == OK:
+		if parser.get_node_type() != XMLParser.NODE_ELEMENT or parser.get_node_name() != "Executable":
+			continue
+		for index: int in parser.get_attribute_count():
+			if parser.get_attribute_name(index) == "Name":
+				return parser.get_attribute_value(index).strip_edges()
 	return ""
+
+
+static func _is_safe_taskkill_image_name(exe_name: String) -> bool:
+	if exe_name.is_empty() or exe_name != exe_name.get_file():
+		return false
+	if not exe_name.to_lower().ends_with(".exe"):
+		return false
+	for forbidden: String in ["\\", "/", ":", "*", "?", "\"", "<", ">", "|"]:
+		if exe_name.contains(forbidden):
+			return false
+	return true

--- a/addons/godot_gdk_packaging/gdkpkg.cmd
+++ b/addons/godot_gdk_packaging/gdkpkg.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal EnableDelayedExpansion
+setlocal EnableExtensions DisableDelayedExpansion
 rem ============================================================================
 rem  gdkpkg.cmd — Windows shell forwarder for the godot_gdk_packaging runner.
 rem
@@ -25,74 +25,68 @@ rem ============================================================================
 set "SCRIPT_DIR=%~dp0"
 set "GODOT_EXE="
 set "PROJECT_PATH=%CD%"
-set "FORWARD_ARGS="
+set "ARG_COUNT=0"
 
 rem ── Argument scan: pull off --godot and --path; forward everything else ────
 :scan
 if "%~1"=="" goto scan_done
-if /i "%~1"=="--godot" (
-    set "GODOT_EXE=%~2"
-    shift
-    shift
-    goto scan
-)
-if /i "%~1"=="--path" (
-    set "PROJECT_PATH=%~2"
-    rem --path is consumed here and passed to Godot as its own --path flag below.
-    rem It is intentionally NOT forwarded to run.gd's user args.
-    shift
-    shift
-    goto scan
-)
-if not defined FORWARD_ARGS (
-    set "FORWARD_ARGS=%~1"
-) else (
-    set FORWARD_ARGS=!FORWARD_ARGS! %1
-)
+if /i "%~1"=="--godot" goto scan_godot
+if /i "%~1"=="--path" goto scan_path
+set /a ARG_COUNT+=1
+set "GDKPKG_ARG_%ARG_COUNT%=%~1"
 shift
 goto scan
+
+:scan_godot
+set "GODOT_EXE=%~2"
+shift
+shift
+goto scan
+
+:scan_path
+set "PROJECT_PATH=%~2"
+rem --path is consumed here and passed to Godot as its own --path flag below.
+rem It is intentionally NOT forwarded to run.gd's user args.
+shift
+shift
+goto scan
+
 :scan_done
 
 rem ── Godot discovery: env var → repo-local sample\ → CWD → PATH ───────────
 if defined GODOT_EXE goto have_godot
 
-for %%V in (GODOT_CONSOLE GODOT_BIN GODOT) do (
-    if defined %%V (
-        call set "_CANDIDATE=%%%%V%%"
-        call :try_candidate "!_CANDIDATE!"
-        if defined GODOT_EXE goto have_godot
-    )
-)
+if defined GODOT_CONSOLE call :try_candidate "%GODOT_CONSOLE%"
+if defined GODOT_BIN call :try_candidate "%GODOT_BIN%"
+if defined GODOT call :try_candidate "%GODOT%"
 
 for %%P in ("%SCRIPT_DIR%..\..\sample" "%CD%") do (
     if exist "%%~P" (
-        for %%F in ("%%~P\Godot*_console.exe") do (
-            call :try_candidate "%%~fF"
-            if defined GODOT_EXE goto have_godot
-        )
-        for %%F in ("%%~P\Godot*.exe") do (
-            call :try_candidate "%%~fF"
-            if defined GODOT_EXE goto have_godot
-        )
+        for %%F in ("%%~P\Godot*_console.exe") do call :try_candidate "%%~fF"
+        for %%F in ("%%~P\Godot*.exe") do call :try_candidate "%%~fF"
     )
 )
 
 for %%C in (godot godot4) do (
-    for /f "delims=" %%R in ('where %%C 2^>nul') do (
-        call :try_candidate "%%~R"
-        if defined GODOT_EXE goto have_godot
-    )
+    for /f "delims=" %%R in ('where %%C 2^>nul') do call :try_candidate "%%~R"
 )
+
+if defined GODOT_EXE goto have_godot
 
 echo [gdkpkg] error: could not find a Godot 4 executable. 1>&2
 echo [gdkpkg] set GODOT_CONSOLE / GODOT_BIN / GODOT, or pass --godot ^<path^>. 1>&2
 exit /b 3
 
 :have_godot
-"%GODOT_EXE%" --headless --path "%PROJECT_PATH%" -s res://addons/godot_gdk_packaging/run.gd -- %FORWARD_ARGS%
+set "GDKPKG_GODOT_EXE=%GODOT_EXE%"
+set "GDKPKG_PROJECT_PATH=%PROJECT_PATH%"
+set "GDKPKG_ARG_COUNT=%ARG_COUNT%"
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; $forwardArgs = @(); for ($i = 1; $i -le [int]$env:GDKPKG_ARG_COUNT; $i++) { $forwardArgs += [Environment]::GetEnvironmentVariable('GDKPKG_ARG_' + $i) }; & $env:GDKPKG_GODOT_EXE --headless --path $env:GDKPKG_PROJECT_PATH -s 'res://addons/godot_gdk_packaging/run.gd' -- @forwardArgs; if ($null -ne $global:LASTEXITCODE) { exit $global:LASTEXITCODE }; exit 0"
 exit /b %ERRORLEVEL%
 
 :try_candidate
+if defined GODOT_EXE exit /b 0
 if "%~1"=="" goto :eof
 if exist "%~1" set "GODOT_EXE=%~1"
 goto :eof

--- a/addons/godot_gdk_packaging/gdkpkg.sh
+++ b/addons/godot_gdk_packaging/gdkpkg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ============================================================================
-#  gdkpkg.sh — POSIX shell forwarder for the godot_gdk_packaging runner.
+#  gdkpkg.sh — Bash shell forwarder for the godot_gdk_packaging runner.
 #
 #  Usage:
 #      addons/godot_gdk_packaging/gdkpkg.sh <verb> [--flag value] [...]
@@ -65,7 +65,7 @@ try_candidate() {
 
 if [ -z "$godot_exe" ]; then
     for env_name in GODOT_CONSOLE GODOT_BIN GODOT; do
-        eval "candidate=\${$env_name:-}"
+        candidate="${!env_name:-}"
         if try_candidate "$candidate"; then break; fi
     done
 fi

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -57,7 +57,9 @@ Godot discovery order in the forwarders:
 
 Both forwarders accept `--path <project_dir>` to override the project
 root (otherwise the current working directory is used). Pass `--godot
-<exe>` to override discovery.
+<exe>` to override discovery. The Windows forwarder preserves each
+forwarded argument as a separate token, so Godot paths and packaging flags
+may contain spaces (for example under `C:\Program Files (x86)\...`).
 
 ## Verbs
 
@@ -76,7 +78,7 @@ on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 | `install`          | `--package`                          | wdapp install on an .msixvc file.                                 |
 | `uninstall`        | `--package-name`                     | wdapp uninstall by package full name.                             |
 | `launch`           | `--package-name` or `--aumid`        | wdapp launch. Resolves AUMID from PFN when needed.                |
-| `terminate`        | `--package-name`                     | wdapp terminate; falls back to taskkill on the build's `.exe`.    |
+| `terminate`        | `--package-name`                     | wdapp terminate; taskkill fallback is limited to the build's config-named `.exe`. |
 | `sandbox`          | `--action {get,set,retail}`          | `set` additionally requires `--sandbox-id`.                       |
 | `config_template`  | (none)                               | Writes a starter MicrosoftGame.config (use `--overwrite` to replace). |
 | `config_editor`    | (none)                               | Detached GameConfigEditor.exe launch on the current config.       |
@@ -184,6 +186,11 @@ addons\godot_gdk_packaging\gdkpkg.cmd terminate --package-name MyPublisher.MyGam
 - **`EXIT_CONFIG: wdapp.exe not found`.** Set `GDK_BIN` to point at your
   GDK install's `bin\` directory, or install the GDK to the default
   location.
+- **`terminate` falls back to `wdapp` failure instead of `taskkill`.** The
+  fallback only targets the exact executable named by `MicrosoftGame.config`
+  and only when that file exists in the build directory. The config value
+  must be a bare `.exe` file name (no path separators, drive prefixes,
+  quotes, or wildcards); extra `.exe` files are intentionally ignored.
 - **`PACKAGING_RESULT_JSON:` line missing.** You passed `--no-json`. Drop
   it to re-enable the marker.
 - **Form B (`--main-loop GdkPackagingRunner`) reports unknown class.** The

--- a/spec/gdext-packaging.md
+++ b/spec/gdext-packaging.md
@@ -74,7 +74,9 @@ Layer summary:
   (`GODOT_CONSOLE` -> `GODOT_BIN` -> `GODOT`), fall back to the repo-local
   `sample\Godot*_console.exe` for dev use, then `where godot` / `which godot`.
   They forward all remaining args using form A (`-s ...`) so they work even
-  before a `--import` pass has populated the class registry.
+  before a `--import` pass has populated the class registry. The forwarders
+  preserve argument boundaries for paths with spaces; `gdkpkg.sh` uses Bash
+  arrays and `gdkpkg.cmd` invokes Godot through a PowerShell argument array.
 
 ## Verb contract
 
@@ -150,7 +152,7 @@ Verb list (14):
 | `install`          | `--package`                   | wdapp install.                                         |
 | `uninstall`        | `--package-name`              | wdapp uninstall.                                       |
 | `launch`           | `--package-name` or `--aumid` | Resolves AUMID via `wdapp list` when only PFN given.   |
-| `terminate`        | `--package-name`              | Falls back to taskkill on the build's primary .exe.    |
+| `terminate`        | `--package-name`              | Falls back to taskkill only for the exact bare `.exe` basename named by MicrosoftGame.config, with path/wildcard/quote characters rejected and the file required in the build dir. |
 | `sandbox`          | `--action {get,set,retail}`   | `set` also requires `--sandbox-id`.                    |
 | `config_template`  | (none)                        | Writes a starter MicrosoftGame.config.                 |
 | `config_editor`    | (none)                        | Detached GameConfigEditor.exe launch.                  |

--- a/tests/godot/gdk/tests/packaging/test_gdkpkg_forwarder.gd
+++ b/tests/godot/gdk/tests/packaging/test_gdkpkg_forwarder.gd
@@ -1,0 +1,145 @@
+extends GutTest
+
+const TEMP_ROOT := "res://.tmp_gdkpkg_forwarder_tests"
+
+
+func after_each() -> void:
+	_remove_recursive(ProjectSettings.globalize_path(TEMP_ROOT))
+
+
+func test_posix_forwarder_uses_arrays_without_eval() -> void:
+	var source: String = _read_text(ProjectSettings.globalize_path("res://addons/godot_gdk_packaging/gdkpkg.sh"))
+
+	assert_false(source.contains("eval"), "gdkpkg.sh must not reintroduce eval-based env lookup or argv forwarding")
+	assert_string_contains(source, "forward_args+=(\"$1\")")
+	assert_string_contains(source, "\"${forward_args[@]}\"")
+
+
+func test_windows_forwarder_preserves_args_with_spaces_end_to_end() -> void:
+	if OS.get_name() != "Windows":
+		pending("gdkpkg.cmd tokenization is Windows-specific")
+		return
+
+	var root: String = _make_temp_root("with space")
+	var forwarder_path: String = root.path_join("gdkpkg.cmd")
+	var fake_godot_path: String = root.path_join("Fake Godot Console.cmd")
+	var runner_path: String = root.path_join("run forwarder.cmd")
+	var captured_args_path: String = root.path_join("captured args.txt")
+	var project_path: String = root.path_join("Project With Space")
+	var source_dir: String = root.path_join("Source Dir With Space")
+	var output_dir: String = root.path_join("Output Dir With Space")
+	DirAccess.make_dir_recursive_absolute(project_path)
+	DirAccess.make_dir_recursive_absolute(source_dir)
+	DirAccess.make_dir_recursive_absolute(output_dir)
+	_copy_file(ProjectSettings.globalize_path("res://addons/godot_gdk_packaging/gdkpkg.cmd"), forwarder_path)
+	_write_file(fake_godot_path, _fake_godot_script(captured_args_path))
+	_write_file(runner_path, _runner_script(forwarder_path, fake_godot_path, project_path, source_dir, output_dir))
+
+	var output: Array = []
+	var exit_code: int = OS.execute("cmd.exe", PackedStringArray(["/D", "/C", runner_path]), output, true, false)
+
+	assert_eq(exit_code, 0, "forwarder output: %s" % "\n".join(output))
+	assert_true(FileAccess.file_exists(captured_args_path), "fake Godot captured the forwarded argv")
+	assert_eq(_read_lines(captured_args_path), [
+		"--headless",
+		"--path",
+		project_path,
+		"-s",
+		"res://addons/godot_gdk_packaging/run.gd",
+		"--",
+		"pack",
+		"--source-dir",
+		source_dir,
+		"--output-dir",
+		output_dir,
+		"--no-prepare",
+	])
+
+
+func _fake_godot_script(captured_args_path: String) -> String:
+	return """@echo off
+break > "%s"
+:loop
+if "%%~1"=="" exit /b 0
+>>"%s" echo(%%~1
+shift
+goto loop
+""" % [captured_args_path, captured_args_path]
+
+
+func _runner_script(forwarder_path: String, fake_godot_path: String, project_path: String, source_dir: String, output_dir: String) -> String:
+	return """@echo off
+call "%s" --godot "%s" --path "%s" pack --source-dir "%s" --output-dir "%s" --no-prepare
+exit /b %%ERRORLEVEL%%
+""" % [forwarder_path, fake_godot_path, project_path, source_dir, output_dir]
+
+
+func _make_temp_root(name: String) -> String:
+	var root: String = ProjectSettings.globalize_path(TEMP_ROOT.path_join(name))
+	_remove_recursive(root)
+	DirAccess.make_dir_recursive_absolute(root)
+	return root
+
+
+func _copy_file(source_path: String, destination_path: String) -> void:
+	var source := FileAccess.open(source_path, FileAccess.READ)
+	assert_not_null(source, "opened %s" % source_path)
+	if source == null:
+		return
+	var destination := FileAccess.open(destination_path, FileAccess.WRITE)
+	assert_not_null(destination, "opened %s" % destination_path)
+	if destination == null:
+		return
+	destination.store_buffer(source.get_buffer(source.get_length()))
+	source.close()
+	destination.close()
+
+
+func _write_file(path: String, contents: String) -> void:
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "opened %s" % path)
+	if file == null:
+		return
+	file.store_string(contents)
+	file.close()
+
+
+func _read_lines(path: String) -> Array:
+	var text: String = _read_text(path).replace("\r\n", "\n").strip_edges()
+	if text.is_empty():
+		return []
+	return Array(text.split("\n", false))
+
+
+func _read_text(path: String) -> String:
+	var file := FileAccess.open(path, FileAccess.READ)
+	assert_not_null(file, "opened %s" % path)
+	if file == null:
+		return ""
+	var text: String = file.get_as_text()
+	file.close()
+	return text
+
+
+func _remove_recursive(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
+		return
+	if not DirAccess.dir_exists_absolute(path):
+		return
+	var dir := DirAccess.open(path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry: String = dir.get_next()
+	while entry != "":
+		if entry != "." and entry != "..":
+			var child: String = path.path_join(entry)
+			if dir.current_is_dir():
+				_remove_recursive(child)
+			else:
+				DirAccess.remove_absolute(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+	DirAccess.remove_absolute(path)

--- a/tests/godot/gdk/tests/packaging/test_wdapp_manager.gd
+++ b/tests/godot/gdk/tests/packaging/test_wdapp_manager.gd
@@ -1,0 +1,139 @@
+extends GutTest
+
+const WdappManager = preload("res://addons/godot_gdk_packaging/core/wdapp_manager.gd")
+const TEMP_ROOT := "res://.tmp_wdapp_manager_tests"
+
+class FakeToolchain:
+	extends RefCounted
+
+	var bin_dir: String
+
+	func _init(p_bin_dir: String) -> void:
+		bin_dir = p_bin_dir
+
+	func get_bin_dir() -> String:
+		return bin_dir
+
+	func execute_tool(_tool_path: String, _args: PackedStringArray) -> Dictionary:
+		return {"exit_code": 99, "stdout": "wdapp failed", "stderr": "simulated failure"}
+
+
+var _taskkill_images: Array[String] = []
+
+
+func before_each() -> void:
+	_taskkill_images.clear()
+
+
+func after_each() -> void:
+	_remove_recursive(ProjectSettings.globalize_path(TEMP_ROOT))
+
+
+func test_taskkill_uses_microsoft_game_config_executable_and_ignores_extra_exes() -> void:
+	var root: String = _make_temp_root("configured_executable")
+	var bin_dir: String = root.path_join("gdk bin")
+	var build_dir: String = root.path_join("build dir")
+	DirAccess.make_dir_recursive_absolute(bin_dir)
+	DirAccess.make_dir_recursive_absolute(build_dir)
+	_write_file(bin_dir.path_join("wdapp.exe"), "")
+	_write_config(build_dir.path_join("MicrosoftGame.config"), "Configured Game.exe")
+	_write_file(build_dir.path_join("code.exe"), "attacker-controlled extra exe")
+	_write_file(build_dir.path_join("Configured Game.exe"), "configured game exe")
+
+	var manager: RefCounted = WdappManager.new(FakeToolchain.new(bin_dir), Callable(self, "_capture_taskkill"))
+	var result: Dictionary = manager.terminate_app("Publisher.Game_1.0.0.0_x64__abc123", build_dir)
+
+	assert_eq(result.get("exit_code", -1), 0)
+	assert_eq(result.get("terminated_with", ""), "taskkill")
+	assert_eq(_taskkill_images.size(), 1)
+	assert_eq(_taskkill_images[0], "Configured Game.exe")
+
+
+func test_taskkill_is_skipped_when_configured_executable_is_missing() -> void:
+	var root: String = _make_temp_root("missing_configured_executable")
+	var bin_dir: String = root.path_join("gdk bin")
+	var build_dir: String = root.path_join("build dir")
+	DirAccess.make_dir_recursive_absolute(bin_dir)
+	DirAccess.make_dir_recursive_absolute(build_dir)
+	_write_file(bin_dir.path_join("wdapp.exe"), "")
+	_write_config(build_dir.path_join("MicrosoftGame.config"), "Configured Game.exe")
+	_write_file(build_dir.path_join("code.exe"), "attacker-controlled extra exe")
+
+	var manager: RefCounted = WdappManager.new(FakeToolchain.new(bin_dir), Callable(self, "_capture_taskkill"))
+	var result: Dictionary = manager.terminate_app("Publisher.Game_1.0.0.0_x64__abc123", build_dir)
+
+	assert_eq(result.get("exit_code", -1), 99)
+	assert_eq(result.get("terminated_with", ""), "wdapp")
+	assert_eq(result.get("taskkill_skipped_reason", ""), "no configured executable available")
+	assert_eq(_taskkill_images.size(), 0)
+
+
+func test_taskkill_rejects_non_bare_config_executable_names() -> void:
+	var index := 0
+	for invalid_name: String in ["*.exe", "subdir/Game.exe", "subdir\\Game.exe", "Game", "Bad:Game.exe", "&quot;Game.exe&quot;"]:
+		var root: String = _make_temp_root("invalid_%d" % index)
+		index += 1
+		var build_dir: String = root.path_join("build dir")
+		DirAccess.make_dir_recursive_absolute(build_dir)
+		DirAccess.make_dir_recursive_absolute(build_dir.path_join("subdir"))
+		_write_config(build_dir.path_join("MicrosoftGame.config"), invalid_name)
+		_write_file(build_dir.path_join("Game.exe"), "extra bare exe")
+		_write_file(build_dir.path_join("subdir").path_join("Game.exe"), "nested exe")
+
+		assert_eq(WdappManager._resolve_taskkill_executable(build_dir), "", "rejected %s" % invalid_name)
+
+
+func _capture_taskkill(exe_name: String) -> Dictionary:
+	_taskkill_images.append(exe_name)
+	return {"exit_code": 0, "stdout": exe_name, "stderr": "", "terminated_with": "taskkill"}
+
+
+func _write_config(path: String, executable_name: String) -> void:
+	_write_file(path, """
+<?xml version="1.0" encoding="utf-8"?>
+<Game>
+  <ExecutableList>
+    <Executable Name="%s" Id="Game" />
+  </ExecutableList>
+</Game>
+""" % executable_name)
+
+
+func _make_temp_root(name: String) -> String:
+	var root: String = ProjectSettings.globalize_path(TEMP_ROOT.path_join(name))
+	_remove_recursive(root)
+	DirAccess.make_dir_recursive_absolute(root)
+	return root
+
+
+func _write_file(path: String, contents: String) -> void:
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "opened %s" % path)
+	if file == null:
+		return
+	file.store_string(contents)
+	file.close()
+
+
+func _remove_recursive(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
+		return
+	if not DirAccess.dir_exists_absolute(path):
+		return
+	var dir := DirAccess.open(path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry: String = dir.get_next()
+	while entry != "":
+		if entry != "." and entry != "..":
+			var child: String = path.path_join(entry)
+			if dir.current_is_dir():
+				_remove_recursive(child)
+			else:
+				DirAccess.remove_absolute(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+	DirAccess.remove_absolute(path)


### PR DESCRIPTION
## Audit lane D1 (#11/#12)  Targets the public repo. Rebased with:  ```powershell git fetch public git rebase --onto public/main origin/main git push public HEAD:audit/pk-shell-safety --force-with-lease ```  Fixes audit executive summary items #11 and #12: - `gdkpkg.cmd` now stores forwarded args in numbered variables and invokes Godot through a PowerShell argument array so paths with spaces remain single tokens. - `gdkpkg.sh` no longer uses `eval` for env-var discovery and remains array-based. - `WdappManager.terminate_app` no longer scans for the first `.exe`; taskkill fallback only uses the bare `.exe` basename from `MicrosoftGame.config`, rejects path/wildcard/quote/drive characters, requires that file in the build dir, and ignores extra `.exe` files.  ## Files changed  - `addons/godot_gdk_packaging/gdkpkg.cmd` - `addons/godot_gdk_packaging/gdkpkg.sh` - `addons/godot_gdk_packaging/core/wdapp_manager.gd` - `tests/godot/gdk/tests/packaging/test_gdkpkg_forwarder.gd` - `tests/godot/gdk/tests/packaging/test_wdapp_manager.gd` - `docs/packaging/plugin.md` - `spec/gdext-packaging.md` - `.github/instructions/godot-gdk-packaging.instructions.md`  ## Validation  Passed after rebasing onto `public/main`: - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1 -Projects addons` - Direct packaging GUT subset from `tests\godot\gdk`: `godot --headless -s res://addons/gut/gut_cmdln.gd -gdir=res://tests/packaging -ginclude_subdirs -gexit` - Manual `gdkpkg.cmd` path-with-spaces smoke (captured below; temp directory removed)  Previously passed before redirect/rebase: - `cmake --preset default` - `cmake --build build --preset debug` - Adversarial review loop rerun to no high-signal findings.  Attempted after public rebase but blocked by unrelated unchanged GameInput compile errors: - `cmake --build build --preset debug`   - Failure was in `addons\godot_gameinput\src\gameinput_mapper.cpp` (for example line 185 parser errors), which this PR does not touch.  Manual `gdkpkg.cmd` path-with-spaces smoke on the public-rebased branch:  ```text exit=0 --headless --path R:\repos\godot-public-gdk-ext-pk-shell-safety\build\manual smoke with space public\Project With Space -s res://addons/godot_gdk_packaging/run.gd -- pack --source-dir R:\repos\godot-public-gdk-ext-pk-shell-safety\build\manual smoke with space public\Source Dir With Space --output-dir R:\repos\godot-public-gdk-ext-pk-shell-safety\build\manual smoke with space public\Output Dir With Space --no-prepare ```  ## Live coverage  Live tests were skipped (default; no `-Live`). No live-write coverage was run and no `-AllowLiveWrites` flow was used. 