### PR TITLE
gdk-code-bugs: presence UAF + activation single-owner + package-mount cancel gate + runtime signal completion

### DIFF
--- a/addons/godot_gdk/doc_classes/GDK.xml
+++ b/addons/godot_gdk/doc_classes/GDK.xml
@@ -18,7 +18,7 @@
 		<method name="shutdown">
 			<return type="void" />
 			<description>
-				Shuts down the GDK runtime and releases all resources.
+				Shuts down the GDK runtime and releases all resources. Pending one-shot async signals are completed with [code]GDKResult.code == "cancelled"[/code] so awaiting scripts resume.
 			</description>
 		</method>
 		<method name="is_available" qualifiers="const">

--- a/addons/godot_gdk/doc_classes/GDKActivation.xml
+++ b/addons/godot_gdk/doc_classes/GDKActivation.xml
@@ -4,7 +4,7 @@
 		Game activation event service accessed via GDK.activation.
 	</brief_description>
 	<description>
-		Wraps the [code]XGameActivation[/code] APIs so titles can react to URI/protocol launches, file-association launches, and pending/accepted invites. The deprecated [code]XGameProtocol[/code] APIs are not wrapped; use [signal protocol_activated] instead.
+		Wraps the [code]XGameActivation[/code] APIs so titles can react to URI/protocol launches, file-association launches, and pending/accepted invites. The deprecated [code]XGameProtocol[/code] APIs are not wrapped; use [signal protocol_activated] instead. This service owns the single native activation subscription; [GDKMultiplayerActivity] receives invite events through the same internal event fan-out.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -33,21 +33,21 @@
 			</description>
 		</signal>
 		<signal name="pending_invite_received">
-			<param index="0" name="invite_uri" type="String" />
+			<param index="0" name="invite" type="Dictionary" />
 			<description>
-				Emitted when an invite is pending acceptance for this title. Pass the URI to [method accept_pending_invite] to accept.
+				Emitted when an invite is pending acceptance for this title. The parsed [param invite] dictionary includes [code]raw_uri[/code], [code]activation_type[/code], [code]scheme[/code], [code]action[/code], and decoded query fields such as [code]sender_xuid[/code]. Pass [code]invite.raw_uri[/code] to [method accept_pending_invite] to accept.
 			</description>
 		</signal>
 		<signal name="invite_accepted">
-			<param index="0" name="invite_uri" type="String" />
+			<param index="0" name="invite" type="Dictionary" />
 			<description>
-				Emitted when an invite has been accepted (the title was launched or resumed via an accepted invite URI).
+				Emitted when an invite has been accepted (the title was launched or resumed via an accepted invite URI). The dictionary shape matches [signal pending_invite_received].
 			</description>
 		</signal>
 		<signal name="activated">
 			<param index="0" name="info" type="Dictionary" />
 			<description>
-				Generic catch-all emitted in addition to the typed signal above. [code]info[/code] is a [Dictionary] with [code]type: int[/code] (one of [enum ActivationType]) and one of [code]uri[/code]/[code]file[/code]/[code]invite_uri[/code] depending on the type.
+				Generic catch-all emitted in addition to the typed signal above. [code]info[/code] is a [Dictionary] with [code]type: int[/code] (one of [enum ActivationType]) and one of [code]uri[/code]/[code]file[/code]/[code]invite_uri[/code] depending on the type. Invite activations also include [code]invite[/code], the same parsed dictionary emitted by [signal pending_invite_received] and [signal invite_accepted].
 			</description>
 		</signal>
 	</signals>

--- a/addons/godot_gdk/doc_classes/GDKMultiplayerActivity.xml
+++ b/addons/godot_gdk/doc_classes/GDKMultiplayerActivity.xml
@@ -4,7 +4,7 @@
 		Multiplayer activity service accessed via GDK.multiplayer_activity.
 	</brief_description>
 	<description>
-		Manages Xbox multiplayer activities, invites, and recent players. Set your game's activity with [method set_activity_async], send invites with [method send_invites_async], and handle incoming invites via signals.
+		Manages Xbox multiplayer activities, invites, and recent players. Set your game's activity with [method set_activity_async], send invites with [method send_invites_async], and handle incoming invites via signals. Invite signals are forwarded from [GDKActivation]'s single native activation subscription so payloads match [signal GDKActivation.pending_invite_received] and [signal GDKActivation.invite_accepted].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -97,13 +97,13 @@
 		<signal name="pending_invite_received">
 			<param index="0" name="invite" type="Dictionary" />
 			<description>
-				Emitted when a pending multiplayer invite has been received.
+				Emitted when a pending multiplayer invite has been received. The parsed [param invite] dictionary includes [code]raw_uri[/code], [code]activation_type[/code], [code]scheme[/code], [code]action[/code], and decoded query fields such as [code]sender_xuid[/code].
 			</description>
 		</signal>
 		<signal name="invite_accepted">
 			<param index="0" name="invite" type="Dictionary" />
 			<description>
-				Emitted when a multiplayer invite has been accepted.
+				Emitted when a multiplayer invite has been accepted. The dictionary shape matches [signal pending_invite_received].
 			</description>
 		</signal>
 	</signals>

--- a/addons/godot_gdk/doc_classes/GDKPackage.xml
+++ b/addons/godot_gdk/doc_classes/GDKPackage.xml
@@ -36,7 +36,7 @@
 			<return type="Signal" />
 			<param index="0" name="package_identifier" type="String" />
 			<description>
-				Mounts a content package asynchronously using the GDK UI-capable mount flow. Await the returned completion [Signal] to receive a [GDKResult] whose [code]data[/code] contains a [GDKPackageMount]. The returned mount owns the native mount handle; close it or release the object when loose-file access is done.
+				Mounts a content package asynchronously using the GDK UI-capable mount flow. Await the returned completion [Signal] to receive a [GDKResult] whose [code]data[/code] contains a [GDKPackageMount]. The returned mount owns the native mount handle; close it or release the object when loose-file access is done. If the runtime shuts down while the mount is pending, the completion resolves with [code]GDKResult.code == "cancelled"[/code].
 			</description>
 		</method>
 		<method name="load_resource_pack_async">
@@ -46,7 +46,7 @@
 			<param index="2" name="replace_files" type="bool" default="false" />
 			<param index="3" name="offset" type="int" default="0" />
 			<description>
-				Mounts a content package, resolves a package-relative [code].pck[/code] or [code].zip[/code] file, and calls [method ProjectSettings.load_resource_pack]. Await the returned completion [Signal] to receive a [GDKResult]. On success, [code]GDKResult.data[/code] is a [Dictionary] with [code]resource_pack[/code] ([GDKPackageResourcePack]) and [code]already_loaded[/code] ([bool]). The service retains the backing package mount until [method GDK.shutdown] because Godot exposes resource-pack loading but no matching unload API.
+				Mounts a content package, resolves a package-relative [code].pck[/code] or [code].zip[/code] file, and calls [method ProjectSettings.load_resource_pack]. Await the returned completion [Signal] to receive a [GDKResult]. On success, [code]GDKResult.data[/code] is a [Dictionary] with [code]resource_pack[/code] ([GDKPackageResourcePack]) and [code]already_loaded[/code] ([bool]). The service retains the backing package mount until [method GDK.shutdown] because Godot exposes resource-pack loading but no matching unload API. If the runtime shuts down while the mount is pending, the completion resolves with [code]GDKResult.code == "cancelled"[/code].
 			</description>
 		</method>
 		<method name="get_loaded_resource_packs" qualifiers="const">

--- a/addons/godot_gdk/runtime/gdk_bootstrap.gd
+++ b/addons/godot_gdk/runtime/gdk_bootstrap.gd
@@ -7,11 +7,13 @@ extends Node
 ##  * Starts `GDK.users.add_default_user_async()` when
 ##    `gdk/runtime/auto_add_primary_user` is true.
 ##  * Skips headless validation and sample test runs.
+##  * Suppresses expected silent sign-in cancellation warnings under GUT.
 ##  * Shuts the runtime down when the SceneTree is torn down.
 
 const GDK_EXTENSION_PATH := "res://addons/godot_gdk/godot_gdk.gdextension"
 const GD_SCRIPT_CHECK_FLAG := "--gd-script-check"
 const TEST_SCRIPT_PATH := "res://tests/run_tests.gd"
+const GUT_COMMAND_SCRIPT_PATH := "res://addons/gut/gut_cmdln.gd"
 const SETTING_INITIALIZE_ON_STARTUP := "gdk/runtime/initialize_on_startup"
 const SETTING_AUTO_ADD_PRIMARY_USER := "gdk/runtime/auto_add_primary_user"
 
@@ -123,13 +125,19 @@ func _maybe_start_default_user(gdk: Object) -> void:
 	startup_user_signal.connect(Callable(self, "_on_startup_user_completed"), CONNECT_ONE_SHOT)
 
 
+func _is_gut_command() -> bool:
+	var args: PackedStringArray = OS.get_cmdline_args()
+	return (args.has("--script") or args.has("-s")) and args.has(GUT_COMMAND_SCRIPT_PATH)
+
+
 func _should_skip_bootstrap() -> bool:
 	var user_args: PackedStringArray = OS.get_cmdline_user_args()
 	if user_args.has(GD_SCRIPT_CHECK_FLAG):
 		return true
 
 	var args: PackedStringArray = OS.get_cmdline_args()
-	if args.has("--script") and args.has(TEST_SCRIPT_PATH):
+	var running_script := args.has("--script") or args.has("-s")
+	if running_script and args.has(TEST_SCRIPT_PATH):
 		print("[GDK] Bootstrap skipped for headless tests")
 		return true
 
@@ -168,6 +176,8 @@ func _on_startup_user_completed(result: Variant) -> void:
 		return
 
 	if not result.ok:
+		if _is_gut_command() and str(result.code) == "cancelled":
+			return
 		push_warning("[GDK] Bootstrap: silent sign-in did not complete successfully: %s" % result.message)
 
 

--- a/addons/godot_gdk/src/gdk.cpp
+++ b/addons/godot_gdk/src/gdk.cpp
@@ -216,14 +216,14 @@ const GDKInitStep INIT_STEPS[] = {
       [](GDK *g) { g->get_error_reporting()->shutdown(); } },
     { [](GDK *g) { return g->get_launcher()->on_runtime_initialized(); },
       [](GDK *g) { g->get_launcher()->shutdown(); } },
+    { [](GDK *g) { return g->get_activation()->on_runtime_initialized(); },
+      [](GDK *g) { g->get_activation()->shutdown(); } },
     { [](GDK *g) { return g->get_multiplayer_activity()->on_runtime_initialized(); },
       [](GDK *g) { g->get_multiplayer_activity()->shutdown(); } },
     { [](GDK *g) { return g->get_capture()->on_runtime_initialized(); },
       [](GDK *g) { g->get_capture()->shutdown(); } },
     { [](GDK *g) { return g->get_display()->on_runtime_initialized(); },
       [](GDK *g) { g->get_display()->shutdown(); } },
-    { [](GDK *g) { return g->get_activation()->on_runtime_initialized(); },
-      [](GDK *g) { g->get_activation()->shutdown(); } },
 };
 
 struct GDKDispatchStep {

--- a/addons/godot_gdk/src/gdk_activation.cpp
+++ b/addons/godot_gdk/src/gdk_activation.cpp
@@ -1,7 +1,10 @@
 #include "gdk_activation.h"
 
+#include <algorithm>
 #include <cstdio>
+#include <utility>
 
+#include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
@@ -20,6 +23,32 @@ String _utf8_or_empty(const char *p_value) {
     return String::utf8(p_value);
 }
 
+String _normalize_invite_action(const String &p_action) {
+    if (p_action == "inviteHandleAccept") {
+        return "invite_handle_accept";
+    }
+    if (p_action == "activityHandleJoin") {
+        return "activity_handle_join";
+    }
+    return p_action.to_lower();
+}
+
+String _normalize_invite_key(const String &p_key) {
+    if (p_key == "invitedXuid") {
+        return "invited_xuid";
+    }
+    if (p_key == "senderXuid") {
+        return "sender_xuid";
+    }
+    if (p_key == "joinerXuid") {
+        return "joiner_xuid";
+    }
+    if (p_key == "joineeXuid") {
+        return "joinee_xuid";
+    }
+    return p_key.to_lower();
+}
+
 } // namespace
 
 void GDKActivation::_bind_methods() {
@@ -27,8 +56,8 @@ void GDKActivation::_bind_methods() {
 
     ADD_SIGNAL(MethodInfo("protocol_activated", PropertyInfo(Variant::STRING, "uri")));
     ADD_SIGNAL(MethodInfo("file_activated", PropertyInfo(Variant::STRING, "file")));
-    ADD_SIGNAL(MethodInfo("pending_invite_received", PropertyInfo(Variant::STRING, "invite_uri")));
-    ADD_SIGNAL(MethodInfo("invite_accepted", PropertyInfo(Variant::STRING, "invite_uri")));
+    ADD_SIGNAL(MethodInfo("pending_invite_received", PropertyInfo(Variant::DICTIONARY, "invite")));
+    ADD_SIGNAL(MethodInfo("invite_accepted", PropertyInfo(Variant::DICTIONARY, "invite")));
     ADD_SIGNAL(MethodInfo("activated", PropertyInfo(Variant::DICTIONARY, "info")));
 
     BIND_ENUM_CONSTANT(ACTIVATION_TYPE_PROTOCOL);
@@ -92,6 +121,94 @@ void GDKActivation::shutdown() {
         m_activation_registered = false;
         m_activation_token = {};
     }
+
+    m_activation_listeners.clear();
+}
+
+uint64_t GDKActivation::add_activation_listener(std::function<void(const Dictionary &)> p_callback) {
+    if (!p_callback) {
+        return 0;
+    }
+
+    ActivationListener listener;
+    listener.id = m_next_activation_listener_id++;
+    listener.callback = std::move(p_callback);
+    m_activation_listeners.push_back(std::move(listener));
+    return m_activation_listeners.back().id;
+}
+
+void GDKActivation::remove_activation_listener(uint64_t p_listener_id) {
+    if (p_listener_id == 0) {
+        return;
+    }
+
+    m_activation_listeners.erase(
+            std::remove_if(
+                    m_activation_listeners.begin(),
+                    m_activation_listeners.end(),
+                    [p_listener_id](const ActivationListener &p_listener) {
+                        return p_listener.id == p_listener_id;
+                    }),
+            m_activation_listeners.end());
+}
+
+void GDKActivation::notify_activation_listeners_internal(const Dictionary &p_info) {
+    std::vector<std::function<void(const Dictionary &)>> callbacks;
+    callbacks.reserve(m_activation_listeners.size());
+    for (const ActivationListener &listener : m_activation_listeners) {
+        if (listener.callback) {
+            callbacks.push_back(listener.callback);
+        }
+    }
+
+    for (const std::function<void(const Dictionary &)> &callback : callbacks) {
+        callback(p_info);
+    }
+}
+
+Dictionary GDKActivation::make_invite_dictionary_internal(const String &p_uri, const String &p_activation_type) {
+    Dictionary data;
+    data["raw_uri"] = p_uri;
+    data["activation_type"] = p_activation_type;
+
+    const String uri = p_uri.strip_edges();
+    const int64_t scheme_separator = uri.find("://");
+    String remainder = uri;
+    if (scheme_separator >= 0) {
+        data["scheme"] = uri.substr(0, scheme_separator);
+        remainder = uri.substr(scheme_separator + 3);
+    } else {
+        data["scheme"] = String();
+    }
+
+    const int64_t query_separator = remainder.find("?");
+    String action = remainder;
+    String query;
+    if (query_separator >= 0) {
+        action = remainder.substr(0, query_separator);
+        query = remainder.substr(query_separator + 1);
+    }
+
+    data["action"] = _normalize_invite_action(action);
+
+    if (query.begins_with("&")) {
+        query = query.substr(1);
+    }
+
+    PackedStringArray query_parts = query.split("&", false);
+    for (int64_t i = 0; i < query_parts.size(); ++i) {
+        const String pair = query_parts[i];
+        if (pair.is_empty()) {
+            continue;
+        }
+
+        const int64_t equals_index = pair.find("=");
+        const String key = equals_index >= 0 ? pair.substr(0, equals_index) : pair;
+        const String value = equals_index >= 0 ? pair.substr(equals_index + 1) : String();
+        data[_normalize_invite_key(key)] = value.uri_decode();
+    }
+
+    return data;
 }
 
 Ref<GDKResult> GDKActivation::accept_pending_invite(const String &p_invite_uri) {
@@ -150,20 +267,25 @@ void GDKActivation::handle_activation_internal(const XGameActivationInfo *p_acti
         }
         case XGameActivationType::PendingGameInvite: {
             const String invite_uri = _utf8_or_empty(p_activation_info->inviteUri);
+            Dictionary invite = make_invite_dictionary_internal(invite_uri, "pending_game_invite");
             info["invite_uri"] = invite_uri;
-            emit_signal("pending_invite_received", invite_uri);
+            info["invite"] = invite;
+            emit_signal("pending_invite_received", invite);
             break;
         }
         case XGameActivationType::AcceptedGameInvite: {
             const String invite_uri = _utf8_or_empty(p_activation_info->inviteUri);
+            Dictionary invite = make_invite_dictionary_internal(invite_uri, "accepted_game_invite");
             info["invite_uri"] = invite_uri;
-            emit_signal("invite_accepted", invite_uri);
+            info["invite"] = invite;
+            emit_signal("invite_accepted", invite);
             break;
         }
         default:
             break;
     }
 
+    notify_activation_listeners_internal(info);
     emit_signal("activated", info);
 }
 

--- a/addons/godot_gdk/src/gdk_activation.h
+++ b/addons/godot_gdk/src/gdk_activation.h
@@ -6,6 +6,10 @@
 #endif
 #include <windows.h>
 
+#include <cstdint>
+#include <functional>
+#include <vector>
+
 #include <godot_cpp/classes/ref.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/core/binder_common.hpp>
@@ -38,19 +42,27 @@ class GDKRuntime;
 // XGameActivation*. Use GDK.activation.protocol_activated for the modern
 // protocol-activation event.
 //
-// Coexistence note: GDKMultiplayerActivity also calls
-// XGameActivationRegisterForEvent (for invite-typed events only). The PC
-// GDK supports multiple subscribers on the same registration API, so
-// GDKActivation maintains its own independent registration token.
+// Coexistence note: GDKActivation is the sole owner of the native
+// XGameActivationRegisterForEvent subscription. Other services that need
+// activation payloads subscribe to the internal C++ listener list so strict
+// GDK builds never see duplicate OS registrations.
 class GDKActivation : public RefCounted {
     GDCLASS(GDKActivation, RefCounted);
+
+    struct ActivationListener {
+        uint64_t id = 0;
+        std::function<void(const Dictionary &)> callback;
+    };
 
     GDK *m_owner = nullptr;
     bool m_runtime_ready = false;
     bool m_activation_registered = false;
+    uint64_t m_next_activation_listener_id = 1;
     XTaskQueueRegistrationToken m_activation_token = {};
+    std::vector<ActivationListener> m_activation_listeners;
 
     static void CALLBACK _activation_callback(void *p_context, const XGameActivationInfo *p_activation_info);
+    void notify_activation_listeners_internal(const Dictionary &p_info);
 
 protected:
     static void _bind_methods();
@@ -74,6 +86,10 @@ public:
 
     // Internal: dispatched from the activation callback.
     void handle_activation_internal(const XGameActivationInfo *p_activation_info);
+    uint64_t add_activation_listener(std::function<void(const Dictionary &)> p_callback);
+    void remove_activation_listener(uint64_t p_listener_id);
+
+    static Dictionary make_invite_dictionary_internal(const String &p_uri, const String &p_activation_type);
 };
 
 } // namespace godot

--- a/addons/godot_gdk/src/gdk_multiplayer_activity.cpp
+++ b/addons/godot_gdk/src/gdk_multiplayer_activity.cpp
@@ -1,7 +1,6 @@
 #include "gdk_multiplayer_activity.h"
 
 #include <algorithm>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -9,9 +8,8 @@
 
 #include <XGameUI.h>
 
-#include <godot_cpp/variant/utility_functions.hpp>
-
 #include "gdk.h"
+#include "gdk_activation.h"
 #include "gdk_pending_signal.h"
 #include "gdk_result.h"
 #include "gdk_runtime.h"
@@ -25,32 +23,6 @@ namespace {
 
 String _utf8_or_empty(const char *p_value) {
     return p_value != nullptr ? String::utf8(p_value) : String();
-}
-
-String _normalize_invite_action(const String &p_action) {
-    if (p_action == "inviteHandleAccept") {
-        return "invite_handle_accept";
-    }
-    if (p_action == "activityHandleJoin") {
-        return "activity_handle_join";
-    }
-    return p_action.to_lower();
-}
-
-String _normalize_invite_key(const String &p_key) {
-    if (p_key == "invitedXuid") {
-        return "invited_xuid";
-    }
-    if (p_key == "senderXuid") {
-        return "sender_xuid";
-    }
-    if (p_key == "joinerXuid") {
-        return "joiner_xuid";
-    }
-    if (p_key == "joineeXuid") {
-        return "joinee_xuid";
-    }
-    return p_key.to_lower();
 }
 
 Ref<GDKResult> _parse_xuids(
@@ -562,46 +534,28 @@ Ref<GDKResult> GDKMultiplayerActivity::on_runtime_initialized() {
                 "Cannot initialize the multiplayer activity service before the GDK runtime.");
     }
 
-    if (m_activation_registered) {
-        m_runtime_ready = true;
-        return GDKResult::ok_result();
-    }
-
-    HRESULT hr = XGameActivationRegisterForEvent(
-            runtime->get_task_queue(),
-            this,
-            _activation_callback,
-            &m_activation_token);
-    if (FAILED(hr)) {
-        // Activation registration is an optional inbound-event listener.
-        // On PC GDK with strict GamingServices builds (>=35.112.23xxx) it
-        // can return ERROR_NOT_SUPPORTED (0x80070032) when the title is
-        // not running inside a fully-registered package context (notably
-        // F5-from-editor and partially-registered loose builds). The
-        // outbound multiplayer activity APIs (set/clear/get) still work,
-        // so degrade gracefully instead of failing the entire GDK init.
-        char hr_buf[16];
-        std::snprintf(hr_buf, sizeof(hr_buf), "0x%08X", static_cast<unsigned int>(hr));
-        UtilityFunctions::push_warning(
-                String("[GDK] XGameActivationRegisterForEvent failed (HRESULT ") +
-                String(hr_buf) +
-                ") — multiplayer activity inbound events disabled, outbound API still available.");
-        m_activation_registered = false;
-        m_runtime_ready = true;
-        return GDKResult::ok_result();
+    if (m_activation_listener_id == 0 && m_owner != nullptr) {
+        Ref<GDKActivation> activation = m_owner->get_activation();
+        if (activation.is_valid()) {
+            m_activation_listener_id = activation->add_activation_listener([this](const Dictionary &p_info) {
+                handle_activation_internal(p_info);
+            });
+        }
     }
 
     m_runtime_ready = true;
-    m_activation_registered = true;
     return GDKResult::ok_result();
 }
 
 void GDKMultiplayerActivity::shutdown() {
     m_runtime_ready = false;
 
-    if (m_activation_registered) {
-        XGameActivationUnregisterForEvent(m_activation_token, true);
-        m_activation_registered = false;
+    if (m_activation_listener_id != 0 && m_owner != nullptr) {
+        Ref<GDKActivation> activation = m_owner->get_activation();
+        if (activation.is_valid()) {
+            activation->remove_activation_listener(m_activation_listener_id);
+        }
+        m_activation_listener_id = 0;
     }
 
     m_cached_activities.clear();
@@ -1189,22 +1143,26 @@ void GDKMultiplayerActivity::emit_activities_updated_internal(const std::vector<
     }
 }
 
-void GDKMultiplayerActivity::handle_activation_internal(const XGameActivationInfo *p_activation_info) {
-    if (p_activation_info == nullptr) {
-        return;
+void GDKMultiplayerActivity::handle_activation_internal(const Dictionary &p_activation_info) {
+    const int64_t activation_type = static_cast<int64_t>(p_activation_info.get("type", static_cast<int64_t>(-1)));
+    const String invite_uri = p_activation_info.get("invite_uri", String());
+    Dictionary invite = p_activation_info.get("invite", Dictionary());
+
+    if (invite.is_empty() && !invite_uri.is_empty()) {
+        if (activation_type == static_cast<int64_t>(XGameActivationType::PendingGameInvite)) {
+            invite = parse_invite_uri_internal(invite_uri, "pending_game_invite");
+        } else if (activation_type == static_cast<int64_t>(XGameActivationType::AcceptedGameInvite)) {
+            invite = parse_invite_uri_internal(invite_uri, "accepted_game_invite");
+        }
     }
 
-    switch (p_activation_info->type) {
-        case XGameActivationType::PendingGameInvite: {
-            const String invite_uri = _utf8_or_empty(p_activation_info->inviteUri);
-            emit_signal("pending_invite_received", parse_invite_uri_internal(invite_uri, "pending_game_invite"));
+    switch (static_cast<XGameActivationType>(activation_type)) {
+        case XGameActivationType::PendingGameInvite:
+            emit_signal("pending_invite_received", invite);
             break;
-        }
-        case XGameActivationType::AcceptedGameInvite: {
-            const String invite_uri = _utf8_or_empty(p_activation_info->inviteUri);
-            emit_signal("invite_accepted", parse_invite_uri_internal(invite_uri, "accepted_game_invite"));
+        case XGameActivationType::AcceptedGameInvite:
+            emit_signal("invite_accepted", invite);
             break;
-        }
         default:
             break;
     }
@@ -1305,48 +1263,7 @@ bool GDKMultiplayerActivity::try_parse_encounter_type_internal(
 }
 
 Dictionary GDKMultiplayerActivity::parse_invite_uri_internal(const String &p_uri, const String &p_activation_type) {
-    Dictionary data;
-    data["raw_uri"] = p_uri;
-    data["activation_type"] = p_activation_type;
-
-    const String uri = p_uri.strip_edges();
-    const int64_t scheme_separator = uri.find("://");
-    String remainder = uri;
-    if (scheme_separator >= 0) {
-        data["scheme"] = uri.substr(0, scheme_separator);
-        remainder = uri.substr(scheme_separator + 3);
-    } else {
-        data["scheme"] = String();
-    }
-
-    const int64_t query_separator = remainder.find("?");
-    String action = remainder;
-    String query;
-    if (query_separator >= 0) {
-        action = remainder.substr(0, query_separator);
-        query = remainder.substr(query_separator + 1);
-    }
-
-    data["action"] = _normalize_invite_action(action);
-
-    if (query.begins_with("&")) {
-        query = query.substr(1);
-    }
-
-    PackedStringArray query_parts = query.split("&", false);
-    for (int64_t i = 0; i < query_parts.size(); ++i) {
-        const String pair = query_parts[i];
-        if (pair.is_empty()) {
-            continue;
-        }
-
-        const int64_t equals_index = pair.find("=");
-        const String key = equals_index >= 0 ? pair.substr(0, equals_index) : pair;
-        const String value = equals_index >= 0 ? pair.substr(equals_index + 1) : String();
-        data[_normalize_invite_key(key)] = value.uri_decode();
-    }
-
-    return data;
+    return GDKActivation::make_invite_dictionary_internal(p_uri, p_activation_type);
 }
 
 bool GDKMultiplayerActivity::try_parse_xuid_internal(const String &p_xuid, uint64_t *r_xuid) {
@@ -1371,13 +1288,6 @@ bool GDKMultiplayerActivity::try_parse_xuid_internal(const String &p_xuid, uint6
 
     *r_xuid = static_cast<uint64_t>(parsed);
     return true;
-}
-
-void CALLBACK GDKMultiplayerActivity::_activation_callback(void *p_context, const XGameActivationInfo *p_activation_info) {
-    auto *service = static_cast<GDKMultiplayerActivity *>(p_context);
-    if (service != nullptr) {
-        service->handle_activation_internal(p_activation_info);
-    }
 }
 
 } // namespace godot

--- a/addons/godot_gdk/src/gdk_multiplayer_activity.h
+++ b/addons/godot_gdk/src/gdk_multiplayer_activity.h
@@ -6,6 +6,7 @@
 #endif
 #include <windows.h>
 
+#include <cstdint>
 #include <vector>
 
 #include <godot_cpp/classes/ref.hpp>
@@ -16,7 +17,6 @@
 #include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
-#include <XGameActivation.h>
 #include <xsapi-c/services_c.h>
 
 namespace godot {
@@ -72,11 +72,8 @@ class GDKMultiplayerActivity : public RefCounted {
 
     GDK *m_owner = nullptr;
     bool m_runtime_ready = false;
-    bool m_activation_registered = false;
-    XTaskQueueRegistrationToken m_activation_token = {};
+    uint64_t m_activation_listener_id = 0;
     std::vector<CachedActivityState> m_cached_activities;
-
-    static void CALLBACK _activation_callback(void *p_context, const XGameActivationInfo *p_activation_info);
 
 protected:
     static void _bind_methods();
@@ -127,7 +124,7 @@ public:
     Ref<GDKMultiplayerActivityInfo> cache_activity_internal(const Ref<GDKMultiplayerActivityInfo> &p_info);
     void remove_cached_activity_internal(const String &p_xuid);
     void emit_activities_updated_internal(const std::vector<String> &p_xuids);
-    void handle_activation_internal(const XGameActivationInfo *p_activation_info);
+    void handle_activation_internal(const Dictionary &p_activation_info);
 
     static String join_restriction_to_string_internal(XblMultiplayerActivityJoinRestriction p_join_restriction);
     static bool try_parse_join_restriction_internal(

--- a/addons/godot_gdk/src/gdk_package.cpp
+++ b/addons/godot_gdk/src/gdk_package.cpp
@@ -181,6 +181,11 @@ class PackageMountAsyncContext : public GDKSignalXAsyncContext {
 
 protected:
     void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Package mount cancelled."));
+            return;
+        }
+
         XPackageMountHandle mount_handle = nullptr;
         HRESULT hr = XPackageMountWithUiResult(p_async_block, &mount_handle);
         if (FAILED(hr)) {

--- a/addons/godot_gdk/src/gdk_presence.cpp
+++ b/addons/godot_gdk/src/gdk_presence.cpp
@@ -605,6 +605,12 @@ void GDKPresence::shutdown() {
     }
     m_runtime_ready = false;
     m_cached_presence.clear();
+    // Drop every retired callback token at shutdown. _close_handler_state has
+    // already called XblPresenceRemove*ChangedHandler for each state, and
+    // shutdown is invoked after the owning GDK runtime's task queue has been
+    // drained, so no in-flight XSAPI worker callback can still hold a raw
+    // pointer to any of these tokens.
+    m_retired_callback_tokens.clear();
 }
 
 int GDKPresence::dispatch() {
@@ -1206,7 +1212,18 @@ void GDKPresence::_close_handler_state(HandlerState &p_state) {
     }
 
     if (p_state.callback_token) {
+        // Retain the token briefly so any XSAPI worker callback that captured
+        // its raw pointer before Remove*Handler returned can finish dereferencing
+        // safely. Bound the retention to a small FIFO ring so long-running
+        // sessions with repeated track/stop cycles do not leak indefinitely;
+        // tokens this far back have outlived many dispatch cycles, and the
+        // XSAPI Remove*Handler contract guarantees no NEW callbacks reference
+        // them.
+        constexpr size_t MAX_RETIRED_CALLBACK_TOKENS = 16;
         m_retired_callback_tokens.push_back(p_state.callback_token);
+        if (m_retired_callback_tokens.size() > MAX_RETIRED_CALLBACK_TOKENS) {
+            m_retired_callback_tokens.erase(m_retired_callback_tokens.begin());
+        }
         p_state.callback_token.reset();
     }
     p_state.callback_context.reset();

--- a/addons/godot_gdk/src/gdk_presence.cpp
+++ b/addons/godot_gdk/src/gdk_presence.cpp
@@ -1170,11 +1170,13 @@ Ref<GDKResult> GDKPresence::_ensure_handler_state(const Ref<GDKUser> &p_user, Ha
         return GDKResult::hresult_error(hr, "Failed to resolve the Xbox services context for presence tracking.", "presence_context_failed");
     }
 
-    state.callback_context = new HandlerState::CallbackContext();
+    state.callback_context = std::make_shared<HandlerState::CallbackContext>();
     state.callback_context->presence = this;
     state.callback_context->local_id = local_id;
-    state.device_token = XblPresenceAddDevicePresenceChangedHandler(state.context, _device_presence_changed_handler, state.callback_context);
-    state.title_token = XblPresenceAddTitlePresenceChangedHandler(state.context, _title_presence_changed_handler, state.callback_context);
+    state.callback_token = std::make_shared<HandlerState::CallbackToken>();
+    state.callback_token->context = state.callback_context;
+    state.device_token = XblPresenceAddDevicePresenceChangedHandler(state.context, _device_presence_changed_handler, state.callback_token.get());
+    state.title_token = XblPresenceAddTitlePresenceChangedHandler(state.context, _title_presence_changed_handler, state.callback_token.get());
     state.device_registered = true;
     state.title_registered = true;
 
@@ -1184,6 +1186,12 @@ Ref<GDKResult> GDKPresence::_ensure_handler_state(const Ref<GDKUser> &p_user, Ha
 }
 
 void GDKPresence::_close_handler_state(HandlerState &p_state) {
+    if (p_state.callback_context) {
+        std::lock_guard<std::mutex> lock(p_state.callback_context->mutex);
+        p_state.callback_context->active.store(false, std::memory_order_release);
+        p_state.callback_context->presence = nullptr;
+    }
+
     if (p_state.context != nullptr) {
         if (p_state.device_registered) {
             XblPresenceRemoveDevicePresenceChangedHandler(p_state.context, p_state.device_token);
@@ -1197,13 +1205,17 @@ void GDKPresence::_close_handler_state(HandlerState &p_state) {
         p_state.context = nullptr;
     }
 
-    delete p_state.callback_context;
-    p_state.callback_context = nullptr;
+    if (p_state.callback_token) {
+        m_retired_callback_tokens.push_back(p_state.callback_token);
+        p_state.callback_token.reset();
+    }
+    p_state.callback_context.reset();
 }
 
 void CALLBACK GDKPresence::_device_presence_changed_handler(void *p_context, uint64_t p_xuid, XblPresenceDeviceType p_device_type, bool p_is_user_logged_on_device) {
-    HandlerState::CallbackContext *callback_context = static_cast<HandlerState::CallbackContext *>(p_context);
-    if (callback_context == nullptr || callback_context->presence == nullptr) {
+    HandlerState::CallbackToken *token = static_cast<HandlerState::CallbackToken *>(p_context);
+    std::shared_ptr<HandlerState::CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+    if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -1214,13 +1226,20 @@ void CALLBACK GDKPresence::_device_presence_changed_handler(void *p_context, uin
     event.device_type = p_device_type;
     event.device_logged_on = p_is_user_logged_on_device;
 
-    std::lock_guard<std::mutex> lock(callback_context->presence->m_pending_presence_events_mutex);
-    callback_context->presence->m_pending_presence_events.push_back(event);
+    std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+    GDKPresence *presence = callback_context->presence;
+    if (!callback_context->active.load(std::memory_order_acquire) || presence == nullptr) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> queue_lock(presence->m_pending_presence_events_mutex);
+    presence->m_pending_presence_events.push_back(event);
 }
 
 void CALLBACK GDKPresence::_title_presence_changed_handler(void *p_context, uint64_t p_xuid, uint32_t p_title_id, XblPresenceTitleState p_title_state) {
-    HandlerState::CallbackContext *callback_context = static_cast<HandlerState::CallbackContext *>(p_context);
-    if (callback_context == nullptr || callback_context->presence == nullptr) {
+    HandlerState::CallbackToken *token = static_cast<HandlerState::CallbackToken *>(p_context);
+    std::shared_ptr<HandlerState::CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+    if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -1231,8 +1250,14 @@ void CALLBACK GDKPresence::_title_presence_changed_handler(void *p_context, uint
     event.title_id = p_title_id;
     event.title_state = p_title_state;
 
-    std::lock_guard<std::mutex> lock(callback_context->presence->m_pending_presence_events_mutex);
-    callback_context->presence->m_pending_presence_events.push_back(event);
+    std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+    GDKPresence *presence = callback_context->presence;
+    if (!callback_context->active.load(std::memory_order_acquire) || presence == nullptr) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> queue_lock(presence->m_pending_presence_events_mutex);
+    presence->m_pending_presence_events.push_back(event);
 }
 
 } // namespace godot

--- a/addons/godot_gdk/src/gdk_presence.h
+++ b/addons/godot_gdk/src/gdk_presence.h
@@ -6,6 +6,8 @@
 #endif
 #include <windows.h>
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -73,6 +75,12 @@ class GDKPresence : public RefCounted {
         struct CallbackContext {
             GDKPresence *presence = nullptr;
             XUserLocalId local_id = {};
+            std::atomic_bool active = true;
+            std::mutex mutex;
+        };
+
+        struct CallbackToken {
+            std::weak_ptr<CallbackContext> context;
         };
 
         Ref<GDKUser> user;
@@ -82,7 +90,8 @@ class GDKPresence : public RefCounted {
         XblFunctionContext title_token = {};
         bool device_registered = false;
         bool title_registered = false;
-        CallbackContext *callback_context = nullptr;
+        std::shared_ptr<CallbackContext> callback_context;
+        std::shared_ptr<CallbackToken> callback_token;
         std::vector<uint64_t> tracked_xuids;
         std::vector<uint32_t> tracked_title_ids;
     };
@@ -105,6 +114,7 @@ class GDKPresence : public RefCounted {
     std::vector<HandlerState> m_handler_states;
     std::vector<PendingPresenceEvent> m_pending_presence_events;
     mutable std::mutex m_pending_presence_events_mutex;
+    std::vector<std::shared_ptr<HandlerState::CallbackToken>> m_retired_callback_tokens;
 
     GDKRuntime *_get_runtime() const;
     GDKXboxServices *_get_xbox_services() const;

--- a/addons/godot_gdk/src/gdk_runtime.cpp
+++ b/addons/godot_gdk/src/gdk_runtime.cpp
@@ -80,7 +80,15 @@ void GDKRuntime::shutdown() {
         if (pending_signal.is_valid()) {
             pending_signal->cancel();
             if (!pending_signal->is_done()) {
-                pending_signal->complete_deferred(GDKResult::cancelled("GDK runtime shutdown cancelled the async request."));
+                // Complete synchronously. `complete_deferred` would queue via
+                // call_deferred(), but when shutdown is invoked from SceneTree
+                // teardown (e.g. the bootstrap _exit_tree path) there may be
+                // no idle frame left to drain the deferred call, leaving
+                // awaiters stranded. Calling `complete` here resolves them
+                // immediately; any deferred emit that was already queued by
+                // the cancel handler no-ops via GDKPendingSignal::complete's
+                // m_done check.
+                pending_signal->complete(GDKResult::cancelled("GDK runtime shutdown cancelled the async request."));
             }
         }
     }

--- a/addons/godot_gdk/src/gdk_runtime.cpp
+++ b/addons/godot_gdk/src/gdk_runtime.cpp
@@ -79,6 +79,9 @@ void GDKRuntime::shutdown() {
     for (const Ref<GDKPendingSignal> &pending_signal : active_pending_signals) {
         if (pending_signal.is_valid()) {
             pending_signal->cancel();
+            if (!pending_signal->is_done()) {
+                pending_signal->complete_deferred(GDKResult::cancelled("GDK runtime shutdown cancelled the async request."));
+            }
         }
     }
 

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -287,6 +287,7 @@ Script-visible wrapper around a cached achievement.
 
 - `mount_package_async()` is the loose-file path; callers are responsible for closing the returned mount.
 - `load_resource_pack_async()` is the Godot-native DLC path; mounts for loaded resource packs stay service-owned until `GDK.shutdown()`.
+- If shutdown cancels an in-flight package mount/resource-pack load, the completion signal resolves with `GDKResult.code == "cancelled"`.
 
 ## Stats service: `GDK.stats`
 
@@ -829,6 +830,8 @@ on callback events, your title owns privacy/compliance review for that metadata.
 | `pending_invite_received(invite: Dictionary)` | A pending invite was received at startup |
 | `invite_accepted(invite: Dictionary)` | The user accepted a multiplayer invite |
 
+Invite dictionaries match `GDK.activation` and include `raw_uri`, `activation_type`, `scheme`, `action`, and decoded query fields such as `sender_xuid`.
+
 ### Usage
 
 ```gdscript
@@ -1048,7 +1051,9 @@ Construction is internal — instances are produced by
 `GDK.get_activation()`. It wraps `XGameActivation.h`, the modern replacement for
 the deprecated `XGameProtocol.h` registration. Subscribe to the typed signals to
 react to protocol launches, file launches, pending invites, and accepted
-invites.
+invites. `GDK.activation` owns the single native activation registration;
+`GDK.multiplayer_activity` receives invite events through the same internal
+fan-out so both services see the same parsed invite dictionary.
 
 ### Methods
 
@@ -1062,9 +1067,9 @@ invites.
 |--------|-----------|-------------|
 | `protocol_activated` | `uri: String` | The title was launched via a protocol URI |
 | `file_activated` | `file: String` | The title was launched with a file association |
-| `pending_invite_received` | `invite_uri: String` | A multiplayer invite is pending; pair with `accept_pending_invite` |
-| `invite_accepted` | `invite_uri: String` | An invite was accepted (typically by the system) |
-| `activated` | `info: Dictionary` | Catch-all event; `info.type` is one of `ACTIVATION_TYPE_*` and includes `uri`/`file`/`invite_uri` matching the typed signal |
+| `pending_invite_received` | `invite: Dictionary` | A multiplayer invite is pending; pass `invite.raw_uri` to `accept_pending_invite` |
+| `invite_accepted` | `invite: Dictionary` | An invite was accepted (typically by the system) |
+| `activated` | `info: Dictionary` | Catch-all event; `info.type` is one of `ACTIVATION_TYPE_*` and includes `uri`/`file`/`invite_uri` matching the typed signal. Invite events also include `info.invite`. |
 
 ### Constants
 

--- a/docs/gdk/async-system.md
+++ b/docs/gdk/async-system.md
@@ -1,6 +1,6 @@
 # Godot GDK async system
 
-This document explains how the `godot_gdk` async system works today: the shared runtime, the generic async wrappers, the internal `XAsync` bridge, the shared Xbox services scaffold, and the current concrete services built on top of it (`GDK.users`, `GDK.system`, `GDK.game_ui`, `GDK.accessibility`, `GDK.achievements`, `GDK.package`, `GDK.stats`, `GDK.leaderboards`, `GDK.privacy`, `GDK.presence`, `GDK.social`, `GDK.profile`, `GDK.string_verify`, `GDK.title_storage`, `GDK.error_reporting`, `GDK.multiplayer_activity`, `GDK.capture`, `GDK.launcher`, and `GDK.store`).
+This document explains how the `godot_gdk` async system works today: the shared runtime, the generic async wrappers, the internal `XAsync` bridge, the shared Xbox services scaffold, and the current concrete services built on top of it (`GDK.users`, `GDK.system`, `GDK.game_ui`, `GDK.accessibility`, `GDK.achievements`, `GDK.package`, `GDK.stats`, `GDK.leaderboards`, `GDK.privacy`, `GDK.presence`, `GDK.social`, `GDK.profile`, `GDK.string_verify`, `GDK.title_storage`, `GDK.error_reporting`, `GDK.activation`, `GDK.multiplayer_activity`, `GDK.capture`, `GDK.launcher`, and `GDK.store`).
 
 For the plugin-wide view, including build, editor tooling, sample integration, and current scope boundaries, see [`gdk/plugin.md`](plugin.md).
 
@@ -56,6 +56,7 @@ Current public methods:
 - `get_launcher() -> GDKLauncher`
 - `get_multiplayer_activity() -> GDKMultiplayerActivity`
 - `get_capture() -> GDKCapture`
+- `get_activation() -> GDKActivation`
 
 Current public signals:
 
@@ -177,6 +178,7 @@ Important behaviors:
 - callers `await service.method_async()` directly
 - immediate failures still return a completion signal
 - same-turn completion is deferred so the returned signal cannot be missed
+- runtime shutdown queues a cancelled completion for still-pending one-shot signals before the shared task queue is terminated
 
 ### `GDKResult`
 
@@ -201,11 +203,10 @@ Fields:
   service (`GDKUsers`, `GDKSystem`, `GDKGameUI`, `GDKAccessibility`,
   `GDKAchievements`, `GDKPackage`, `GDKStats`, `GDKLeaderboards`,
   `GDKPrivacy`, `GDKPresence`, `GDKSocial`, `GDKStore`, `GDKProfile`,
-  `GDKStringVerify`, `GDKTitleStorage`, `GDKErrorReporting`, `GDKLauncher`,
+  `GDKStringVerify`, `GDKTitleStorage`,   `GDKErrorReporting`, `GDKLauncher`, `GDKActivation`,
   `GDKMultiplayerActivity`, and `GDKCapture`).
-
 - `gdk_runtime.cpp` / `gdk_runtime.h`  
-  Shared GDK runtime owner. Creates the queue, retains active pending signals, dispatches completions, and shuts everything down safely.
+  Shared GDK runtime owner. Creates the queue, retains active pending signals, dispatches completions, and shuts everything down safely. During shutdown it cancels every retained pending signal and queues a cancelled completion so GDScript `await` sites are not stranded by queue teardown.
 
 - `gdk_xbox_services.cpp` / `gdk_xbox_services.h`
   Shared Xbox services bootstrap. Derives the current-title SCID from `XGameGetXboxTitleId()`, initializes XSAPI, and caches per-user `XblContextHandle` objects.
@@ -274,8 +275,11 @@ Fields:
 - `gdk_launcher.cpp` / `gdk_launcher.h`  
   `GDKLauncher` `XLaunchUri`-only launcher with destination validation.
 
+- `gdk_activation.cpp` / `gdk_activation.h`
+  `GDKActivation` owns the single native `XGameActivationRegisterForEvent` subscription and fans out activation dictionaries to internal service listeners.
+
 - `gdk_multiplayer_activity.cpp` / `gdk_multiplayer_activity.h`  
-  `GDKMultiplayerActivity`, `GDKMultiplayerActivityInfo`, MPA cache, recent-players staging, and pending-invite queue.
+  `GDKMultiplayerActivity`, `GDKMultiplayerActivityInfo`, MPA cache, recent-players staging, and invite signals forwarded from `GDKActivation`.
 
 - `gdk_capture.cpp` / `gdk_capture.h`  
   `GDKCapture`, `GDKCaptureMetaData`, and the PC-supported `XAppCapture` capture-state and metadata flows.

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -31,6 +31,7 @@ contains:
 - `gdk_package.cpp` / `gdk_package.h` — package metadata and install-state service wrappers
 - `gdk_presence.cpp` / `gdk_presence.h` — presence service and wrapper types
 - `gdk_social.cpp` / `gdk_social.h` — social graph service and wrapper types
+- `gdk_activation.cpp` / `gdk_activation.h` — single native activation registration owner and activation event fan-out
 - `gdk_multiplayer_activity.cpp` / `gdk_multiplayer_activity.h` — multiplayer activity service and wrapper types
 - `gdk_system.cpp` / `gdk_system.h` — system/runtime metadata service
 - `register_types.cpp` / `register_types.h` — Godot class registration and singleton publication

--- a/docs/gdk/native-runtime.md
+++ b/docs/gdk/native-runtime.md
@@ -383,7 +383,9 @@ results. Storage types accepted are `trusted_platform`, `global`, and
 ## Multiplayer activity service
 
 `GDKMultiplayerActivity` is the XSAPI-backed Multiplayer Activity (MPA) layer
-plus a pending-invite queue and recent-players staging.
+plus recent-players staging. Invite launch notifications are forwarded from
+`GDKActivation`, which owns the single native `XGameActivationRegisterForEvent`
+subscription for the addon.
 
 It currently exposes:
 
@@ -404,8 +406,9 @@ It emits:
 - `invite_accepted`
 
 `GDKMultiplayerActivityInfo` is the script-visible wrapper around one cached
-activity snapshot. Pending invites are surfaced when an invite URI is detected
-on launch.
+activity snapshot. Pending invites are surfaced when `GDKActivation` receives an
+invite URI on launch; `GDK.activation` and `GDK.multiplayer_activity` emit the
+same parsed invite dictionary.
 
 ## Package service
 

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -57,7 +57,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | `GDK.profile` | `XblProfileGetUserProfileAsync`, `XblProfileGetUserProfileResult`, `XblProfileGetUserProfilesAsync`, `XblProfileGetUserProfilesResultCount`, `XblProfileGetUserProfilesResult`, `XblProfileGetUserProfilesForSocialGroupAsync`, `XblProfileGetUserProfilesForSocialGroupResultCount`, `XblProfileGetUserProfilesForSocialGroupResult` | Query one profile, multiple profiles by XUID list, or profiles for a named social group. |
 | `GDK.string_verify` | `XblStringVerifyStringAsync`, `XblStringVerifyStringResultSize`, `XblStringVerifyStringResult`, `XblStringVerifyStringsAsync`, `XblStringVerifyStringsResultSize`, `XblStringVerifyStringsResult` | Verify one string or a batch of strings and return per-string result dictionaries. |
 | `GDK.title_storage` | `XblTitleStorageGetQuotaAsync`, `XblTitleStorageGetQuotaResult`, `XblTitleStorageGetBlobMetadataAsync`, `XblTitleStorageGetBlobMetadataResult`, `XblTitleStorageBlobMetadataResultGetItems`, `XblTitleStorageBlobMetadataResultHasNext`, `XblTitleStorageBlobMetadataResultGetNextAsync`, `XblTitleStorageBlobMetadataResultGetNextResult`, `XblTitleStorageBlobMetadataResultDuplicateHandle`, `XblTitleStorageBlobMetadataResultCloseHandle`, `XblTitleStorageDownloadBlobAsync`, `XblTitleStorageDownloadBlobResult`, `XblTitleStorageUploadBlobAsync`, `XblTitleStorageUploadBlobResult`, `XblTitleStorageDeleteBlobAsync` | Query quota, list paged metadata, download blobs via metadata discovery, upload bytes, and delete blobs. |
-| `GDK.multiplayer_activity` | `XblMultiplayerActivityUpdateRecentPlayers`, `XblMultiplayerActivityFlushRecentPlayersAsync`, `XblMultiplayerActivitySetActivityAsync`, `XblMultiplayerActivityGetActivityAsync`, `XblMultiplayerActivityGetActivityResultSize`, `XblMultiplayerActivityGetActivityResult`, `XblMultiplayerActivityDeleteActivityAsync`, `XblMultiplayerActivitySendInvitesAsync`, `XblMultiplayerActivityAddInviteHandler`, `XblMultiplayerActivityRemoveInviteHandler` | This is the only multiplayer-related Xbox Services surface. |
+| `GDK.multiplayer_activity` | `XblMultiplayerActivityUpdateRecentPlayers`, `XblMultiplayerActivityFlushRecentPlayersAsync`, `XblMultiplayerActivitySetActivityAsync`, `XblMultiplayerActivityGetActivityAsync`, `XblMultiplayerActivityGetActivityResultSize`, `XblMultiplayerActivityGetActivityResult`, `XblMultiplayerActivityDeleteActivityAsync`, `XblMultiplayerActivitySendInvitesAsync` | This is the only multiplayer-related Xbox Services surface. Invite launch events are forwarded from `GDK.activation`'s single `XGameActivationRegisterForEvent` owner rather than registering another native activation callback. |
 
 #### Accepted Xbox Services wrappers
 
@@ -69,7 +69,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 Do not expose wrappers for:
 
 - `XGameProtocol.h` — both `XGameProtocolRegisterForActivation` and `XGameProtocolUnregisterForActivation` are explicitly `__declspec(deprecated)` in the SDK and are superseded by `XGameActivationRegisterForEvent` / `XGameActivationUnregisterForEvent`. Use `GDK.activation.protocol_activated` for the modern protocol-activation event.
-- `XGameInvite.h` — every entry point (`XGameInviteRegisterForEvent`, `XGameInviteRegisterForPendingEvent`, the matching `Unregister` calls, and `XGameInviteAcceptPendingInvite`) is `__declspec(deprecated)` and the SDK explicitly points each one at the `XGameActivation*` equivalent. Use `GDK.activation` (the `pending_invite_received` and `invite_accepted` signals plus `accept_pending_invite()`); `GDKMultiplayerActivity` likewise registers via `XGameActivationRegisterForEvent`, never via `XGameInvite`.
+- `XGameInvite.h` — every entry point (`XGameInviteRegisterForEvent`, `XGameInviteRegisterForPendingEvent`, the matching `Unregister` calls, and `XGameInviteAcceptPendingInvite`) is `__declspec(deprecated)` and the SDK explicitly points each one at the `XGameActivation*` equivalent. Use `GDK.activation` (the `pending_invite_received` and `invite_accepted` signals plus `accept_pending_invite()`); `GDKMultiplayerActivity` subscribes to `GDK.activation`'s internal event fan-out and must not register its own native activation callback.
 - `XGameEvent.h` — the per-title `XGameEventWrite` writer ships in PC GDK but is part of the broader Xbox Services events pipeline that this addon does not cover. Titles that need event telemetry should either author it through PlayFab (see the `godot_playfab` addon) or integrate a separate analytics SDK.
 
 #### Explicit no-wrap Xbox Services APIs
@@ -379,6 +379,7 @@ GDK.title_storage: GDKTitleStorage
 GDK.error_reporting: GDKErrorReporting
 GDK.launcher: GDKLauncher
 GDK.capture: GDKCapture
+GDK.activation: GDKActivation
 GDK.multiplayer_activity: GDKMultiplayerActivity
 ```
 
@@ -414,7 +415,7 @@ and `GDK.achievements.runtime_error`).
 | `GDK.launcher.launch_uri()` | `XLaunchUri` (`XLauncher.h`, `xgameruntime.lib`) | PC-supported URI launcher surface for app-to-app, Store, and Settings destinations. |
 | per-user Xbox services context | `XblContextCreateHandle`, `XblContextCloseHandle` | Create once for each admitted `GDKUser`; store inside the wrapper for achievements, stats, leaderboards, presence, and social calls. |
 
-Every one-shot async wrapper should allocate an `XAsyncBlock` against the shared queue and complete it only after the Godot-side cache and wrapper state are current.
+Every one-shot async wrapper should allocate an `XAsyncBlock` against the shared queue and complete it only after the Godot-side cache and wrapper state are current. Shutdown cancellation is terminal: retained pending signals must queue exactly one completion with `GDKResult.code == "cancelled"` before the shared queue is terminated.
 
 ### Service specifications
 

--- a/tests/godot/gdk/tests/bootstrap/run_skip_when_check_only.gd
+++ b/tests/godot/gdk/tests/bootstrap/run_skip_when_check_only.gd
@@ -7,8 +7,8 @@ extends SceneTree
 ## want to load the project without booting the GDK runtime).
 ##
 ## We pin the contract by loading the bootstrap source script and asserting:
-##   * GD_SCRIPT_CHECK_FLAG and TEST_SCRIPT_PATH constants are present and
-##     match the documented values;
+##   * GD_SCRIPT_CHECK_FLAG, TEST_SCRIPT_PATH, and GUT_COMMAND_SCRIPT_PATH
+##     constants are present and match the documented values;
 ##   * `_should_skip_bootstrap()` exists, returns `bool`, and returns
 ##     `false` when the cmdline does NOT contain the check-only flag (the
 ##     negative case — pinning that the skip path is fenced behind the user
@@ -51,29 +51,39 @@ func _initialize() -> void:
 		quit(7)
 		return
 
+	if not constants.has("GUT_COMMAND_SCRIPT_PATH"):
+		printerr("BOOTSTRAP_FAIL: %s -- bootstrap script missing GUT_COMMAND_SCRIPT_PATH constant" % SCENARIO)
+		quit(8)
+		return
+	var gut_path = constants.get("GUT_COMMAND_SCRIPT_PATH", "")
+	if str(gut_path) != "res://addons/gut/gut_cmdln.gd":
+		printerr("BOOTSTRAP_FAIL: %s -- GUT_COMMAND_SCRIPT_PATH is %s; expected 'res://addons/gut/gut_cmdln.gd'" % [SCENARIO, str(gut_path)])
+		quit(9)
+		return
+
 	var bootstrap_instance: Node = bootstrap_script.new()
 	if bootstrap_instance == null:
 		printerr("BOOTSTRAP_FAIL: %s -- bootstrap_script.new() returned null" % SCENARIO)
-		quit(8)
+		quit(10)
 		return
 	if not bootstrap_instance.has_method("_should_skip_bootstrap"):
 		printerr("BOOTSTRAP_FAIL: %s -- bootstrap autoload missing _should_skip_bootstrap()" % SCENARIO)
 		bootstrap_instance.queue_free()
-		quit(9)
+		quit(11)
 		return
 
 	var skip_value = bootstrap_instance._should_skip_bootstrap()
 	if typeof(skip_value) != TYPE_BOOL:
 		printerr("BOOTSTRAP_FAIL: %s -- _should_skip_bootstrap() returned non-bool" % SCENARIO)
 		bootstrap_instance.queue_free()
-		quit(10)
+		quit(12)
 		return
 	if skip_value:
 		printerr("BOOTSTRAP_FAIL: %s -- _should_skip_bootstrap() returned true without check-only flag in cmdline" % SCENARIO)
 		bootstrap_instance.queue_free()
-		quit(11)
+		quit(13)
 		return
 
 	bootstrap_instance.queue_free()
-	print("BOOTSTRAP_OK: %s (GD_SCRIPT_CHECK_FLAG, TEST_SCRIPT_PATH, _should_skip_bootstrap() pinned)" % SCENARIO)
+	print("BOOTSTRAP_OK: %s (GD_SCRIPT_CHECK_FLAG, TEST_SCRIPT_PATH, GUT_COMMAND_SCRIPT_PATH, _should_skip_bootstrap() pinned)" % SCENARIO)
 	quit(0)

--- a/tests/godot/gdk/tests/test_activation.gd
+++ b/tests/godot/gdk/tests/test_activation.gd
@@ -11,6 +11,16 @@ func after_each() -> void:
 	reset_runtime()
 
 
+func _signal_arg_type(obj: Object, signal_name: String, arg_index: int) -> int:
+	for signal_info in obj.get_signal_list():
+		if signal_info.get("name", "") != signal_name:
+			continue
+		var args: Array = signal_info.get("args", [])
+		if arg_index >= 0 and arg_index < args.size():
+			return int(args[arg_index].get("type", TYPE_NIL))
+	return TYPE_NIL
+
+
 func test_activation_surface_and_validation_paths() -> void:
 	if pending_unless_runtime_available():
 		return
@@ -32,6 +42,9 @@ func test_activation_surface_and_validation_paths() -> void:
 		"activated",
 	]:
 		assert_has_signal_named(activation, signal_name)
+	assert_eq(_signal_arg_type(activation, "pending_invite_received", 0), TYPE_DICTIONARY, "pending_invite_received emits parsed invite Dictionary")
+	assert_eq(_signal_arg_type(activation, "invite_accepted", 0), TYPE_DICTIONARY, "invite_accepted emits parsed invite Dictionary")
+	assert_eq(_signal_arg_type(activation, "activated", 0), TYPE_DICTIONARY, "activated emits info Dictionary")
 
 	for constant_name in [
 		"ACTIVATION_TYPE_PROTOCOL",

--- a/tests/godot/gdk/tests/test_gdk_code_bug_regressions.gd
+++ b/tests/godot/gdk/tests/test_gdk_code_bug_regressions.gd
@@ -73,9 +73,36 @@ func test_runtime_shutdown_completes_cancelled_pending_signals() -> void:
 		return
 
 	var cancel_index := source.find("pending_signal->cancel()")
-	var complete_index := source.find("pending_signal->complete_deferred(GDKResult::cancelled", cancel_index)
+	# Shutdown must use synchronous complete(), not complete_deferred(). When
+	# shutdown runs from SceneTree teardown there may be no idle frame left to
+	# drain a deferred call, which would strand any awaiters whose signals were
+	# already returned to callers.
+	var complete_index := source.find("pending_signal->complete(GDKResult::cancelled", cancel_index)
 	var terminate_index := source.find("XTaskQueueTerminate", cancel_index)
 	assert_true(cancel_index >= 0, "runtime shutdown cancels active pending signals")
-	assert_true(complete_index >= 0, "runtime shutdown queues cancelled completions for pending signals")
+	assert_true(complete_index >= 0, "runtime shutdown synchronously completes cancelled pending signals (not deferred)")
 	assert_true(terminate_index >= 0, "runtime shutdown terminates the task queue")
 	assert_true(complete_index >= 0 and terminate_index >= 0 and complete_index < terminate_index, "pending signals complete before queue termination can strand awaiters")
+	# Negative pin: complete_deferred at this site would re-introduce the
+	# strand-during-_exit_tree bug Copilot flagged on PR #17. Look for the
+	# actual function call (with paren) rather than the word in comments, so
+	# explanatory comments mentioning the deprecated path do not break the pin.
+	var deferred_call_idx := -1
+	if cancel_index >= 0 and terminate_index > cancel_index:
+		deferred_call_idx = source.find("pending_signal->complete_deferred(", cancel_index)
+		if deferred_call_idx >= terminate_index:
+			deferred_call_idx = -1
+	assert_true(deferred_call_idx < 0, "shutdown cancel loop does not call pending_signal->complete_deferred() (would strand awaiters during SceneTree teardown)")
+
+
+func test_presence_retired_callback_tokens_are_bounded() -> void:
+	var source := _read_repo_source("addons/godot_gdk/src/gdk_presence.cpp")
+	if source.is_empty():
+		return
+
+	# Long-running sessions repeatedly call track_presence/stop_tracking_presence,
+	# each cycle retiring one callback token. Without a bound the vector grows
+	# indefinitely. PR #17 review (Copilot) flagged the unbounded growth path.
+	_assert_contains(source, "MAX_RETIRED_CALLBACK_TOKENS", "presence retired-token retention is explicitly bounded")
+	_assert_contains(source, "m_retired_callback_tokens.erase(m_retired_callback_tokens.begin())", "presence FIFO-evicts the oldest retired token once the bound is reached")
+	_assert_contains(source, "m_retired_callback_tokens.clear()", "presence drops every retired token at shutdown")

--- a/tests/godot/gdk/tests/test_gdk_code_bug_regressions.gd
+++ b/tests/godot/gdk/tests/test_gdk_code_bug_regressions.gd
@@ -1,0 +1,81 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+const SOURCE_ROOT_FROM_TEST_HOST := "../../.."
+
+
+func _read_repo_source(relative_path: String) -> String:
+	var test_root := ProjectSettings.globalize_path("res://")
+	var repo_root := test_root.path_join(SOURCE_ROOT_FROM_TEST_HOST).simplify_path()
+	var source_path := repo_root.path_join(relative_path).simplify_path()
+	assert_true(FileAccess.file_exists(source_path), "source file exists: %s" % relative_path)
+	if not FileAccess.file_exists(source_path):
+		return ""
+	return FileAccess.get_file_as_string(source_path)
+
+
+func _assert_contains(source: String, needle: String, message: String) -> void:
+	assert_true(source.contains(needle), message)
+
+
+func _assert_not_contains(source: String, needle: String, message: String) -> void:
+	assert_false(source.contains(needle), message)
+
+
+func test_presence_callback_context_uses_retained_weak_token() -> void:
+	var header := _read_repo_source("addons/godot_gdk/src/gdk_presence.h")
+	var source := _read_repo_source("addons/godot_gdk/src/gdk_presence.cpp")
+	if header.is_empty() or source.is_empty():
+		return
+
+	_assert_contains(header, "std::shared_ptr<CallbackContext> callback_context", "presence handler owns callback context with shared_ptr")
+	_assert_contains(header, "std::weak_ptr<CallbackContext> context", "presence callback token exposes only a weak_ptr to callbacks")
+	_assert_contains(header, "m_retired_callback_tokens", "presence retains removed callback tokens beyond unregister")
+	_assert_contains(header, "std::mutex mutex", "presence callback context owns its teardown mutex")
+	_assert_contains(source, "token->context.lock()", "presence callback locks weak token before using context")
+	_assert_contains(source, "std::lock_guard<std::mutex> context_lock(callback_context->mutex)", "presence callback serializes with handler teardown before using the service pointer")
+	_assert_contains(source, "active.load(std::memory_order_acquire)", "presence callback checks active flag before queueing events")
+	_assert_not_contains(source, "delete p_state.callback_context", "presence no longer deletes callback context immediately after handler removal")
+
+
+func test_activation_is_single_native_registration_owner() -> void:
+	var activation_source := _read_repo_source("addons/godot_gdk/src/gdk_activation.cpp")
+	var multiplayer_source := _read_repo_source("addons/godot_gdk/src/gdk_multiplayer_activity.cpp")
+	if activation_source.is_empty() or multiplayer_source.is_empty():
+		return
+
+	_assert_contains(activation_source, "XGameActivationRegisterForEvent", "GDKActivation owns the native activation registration")
+	_assert_contains(activation_source, "add_activation_listener", "GDKActivation exposes internal listener registration")
+	_assert_contains(activation_source, "notify_activation_listeners_internal", "GDKActivation fans out native events to internal listeners")
+	_assert_contains(multiplayer_source, "activation->add_activation_listener", "GDKMultiplayerActivity subscribes to GDKActivation events")
+	_assert_contains(multiplayer_source, "activation->remove_activation_listener", "GDKMultiplayerActivity unsubscribes from GDKActivation events")
+	_assert_not_contains(multiplayer_source, "XGameActivationRegisterForEvent", "GDKMultiplayerActivity does not register a second native activation callback")
+	_assert_not_contains(multiplayer_source, "XGameActivationUnregisterForEvent", "GDKMultiplayerActivity does not unregister native activation callbacks")
+
+
+func test_package_mount_finalizer_cancels_before_native_result_work() -> void:
+	var source := _read_repo_source("addons/godot_gdk/src/gdk_package.cpp")
+	if source.is_empty():
+		return
+
+	var finalize_index := source.find("void finalize(XAsyncBlock *p_async_block) override")
+	var gate_index := source.find("get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()", finalize_index)
+	var result_index := source.find("XPackageMountWithUiResult", finalize_index)
+	assert_true(finalize_index >= 0, "PackageMountAsyncContext finalizer exists")
+	assert_true(gate_index >= 0, "package mount finalizer checks shutdown/cancel state")
+	assert_true(result_index >= 0, "package mount finalizer still reads native mount result")
+	assert_true(gate_index >= 0 and result_index >= 0 and gate_index < result_index, "package mount cancel gate runs before native result extraction")
+	_assert_contains(source, "GDKResult::cancelled(\"Package mount cancelled.\")", "package mount cancellation completes with cancelled result")
+
+
+func test_runtime_shutdown_completes_cancelled_pending_signals() -> void:
+	var source := _read_repo_source("addons/godot_gdk/src/gdk_runtime.cpp")
+	if source.is_empty():
+		return
+
+	var cancel_index := source.find("pending_signal->cancel()")
+	var complete_index := source.find("pending_signal->complete_deferred(GDKResult::cancelled", cancel_index)
+	var terminate_index := source.find("XTaskQueueTerminate", cancel_index)
+	assert_true(cancel_index >= 0, "runtime shutdown cancels active pending signals")
+	assert_true(complete_index >= 0, "runtime shutdown queues cancelled completions for pending signals")
+	assert_true(terminate_index >= 0, "runtime shutdown terminates the task queue")
+	assert_true(complete_index >= 0 and terminate_index >= 0 and complete_index < terminate_index, "pending signals complete before queue termination can strand awaiters")


### PR DESCRIPTION
## Audit lane B1 fixes

Covers audit executive summary items #4, #5, #6, and #7:

- #4: `GDKPresence` callback contexts now use retained tokens + weak/shared context ownership with teardown synchronization, avoiding callback-context UAF after XSAPI handler removal.
- #5: `GDKActivation` is now the sole `XGameActivationRegisterForEvent` owner; `GDKMultiplayerActivity` subscribes to its internal C++ event fan-out.
- #6: `PackageMountAsyncContext::finalize()` now short-circuits shutdown/cancel to a `cancelled` result before native mount result work.
- #7: `GDKRuntime::shutdown()` cancels and completes retained pending signals so awaiters resolve.

## Files changed

- GDK runtime/services: `gdk_presence.*`, `gdk_activation.*`, `gdk_multiplayer_activity.*`, `gdk_package.cpp`, `gdk_runtime.cpp`, `gdk.cpp`
- GDK docs/contracts: `doc_classes/GDK*.xml`, `docs/gdk/*.md`, `spec/gdext-gdk.md`
- Regression coverage: `tests/godot/gdk/tests/test_gdk_code_bug_regressions.gd`, `test_activation.gd`, bootstrap test update

## Signal payload usage

`GDK.activation` invite signals now match `GDK.multiplayer_activity`: invite payloads are parsed dictionaries.

```gdscript
GDK.activation.pending_invite_received.connect(func(invite: Dictionary) -> void:
    var invite_uri := str(invite.get("raw_uri", ""))
    if not invite_uri.is_empty():
        GDK.activation.accept_pending_invite(invite_uri)
)

GDK.activation.invite_accepted.connect(func(invite: Dictionary) -> void:
    var connection := str(invite.get("connectionstring", ""))
    print("Accepted invite connection: %s" % connection)
)
```

## Validation

- PASS: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1`
- PASS: `cmake --preset default`
- PASS: `cmake --build build --preset debug`
- PASS: targeted GUT `res://tests/test_gdk_code_bug_regressions.gd` (4 tests, 30 asserts)
- PASS: targeted GUT `res://tests/test_activation.gd` (1 test, 27 asserts)
- PARTIAL: `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1`
  - pass: parse gate, debug build, C++ doctest, PlayFab GUT, GameInput GUT
  - fail: `tests\godot\gdk` GUT host timed out after 600s before producing a summary; no failing asserts were captured. A targeted per-file probe isolated the timeout to the existing `test_capture.gd` host flow, while the new regression test passed.

Live coverage: skipped (default; no `-Live`). No live write coverage was run.