### PR TITLE
pk-xml-rewrite: harden MicrosoftGame.config XML rewrites + truthful stderr/dll-refresh

### DIFF
--- a/.github/instructions/godot-gdk-packaging.instructions.md
+++ b/.github/instructions/godot-gdk-packaging.instructions.md
@@ -156,6 +156,8 @@ before committing.
   builder shape, exit-code constants, JSON round trip.
 - `tests/godot/gdk/tests/packaging/test_tutorial_wizard_state.gd` — tutorial
   wizard state transitions.
+- `tests/godot/gdk/tests/packaging/test_wdapp_manager.gd` — wdapp
+  install/uninstall verb wiring + cancellation/early-return guards.
 
 GUT base class for packaging tests: just `extends GutTest`. The shared
 service bases (`gdk_test_base.gd`, …) are for runtime addons; do not use

--- a/.github/instructions/godot-gdk-packaging.instructions.md
+++ b/.github/instructions/godot-gdk-packaging.instructions.md
@@ -134,20 +134,28 @@ before committing.
 
 ## Tests
 
+- `tests/godot/gdk/tests/packaging/test_config_import_plugin.gd` — import
+  plugin file classification.
+- `tests/godot/gdk/tests/packaging/test_game_config_xml_rewriting.gd` —
+  MicrosoftGame.config logo rewriting and encryption-key safety pins.
+- `tests/godot/gdk/tests/packaging/test_gdk_toolchain.gd` — GDK discovery,
+  execute_tool result shape, and stdout/stderr capture.
 - `tests/godot/gdk/tests/packaging/test_packaging_cli.gd` — argv parsing
   and verb-flag matrix.
 - `tests/godot/gdk/tests/packaging/test_gdkpkg_forwarder.gd` — shell
   forwarder argument-preservation regressions.
 - `tests/godot/gdk/tests/packaging/test_packaging_config_resolver.gd` —
   precedence chain + key remap + encrypt key:<path> split.
+- `tests/godot/gdk/tests/packaging/test_packaging_content_preparer.gd` —
+  content-prep XML helpers and runtime DLL refresh behavior.
+- `tests/godot/gdk/tests/packaging/test_packaging_panel_logic.gd` — dock
+  presenter helper behavior.
+- `tests/godot/gdk/tests/packaging/test_packaging_plugin_lifecycle.gd` —
+  editor plugin enter/exit lifecycle.
 - `tests/godot/gdk/tests/packaging/test_packaging_result.gd` — result
   builder shape, exit-code constants, JSON round trip.
-- Pre-existing helper suites (`test_packaging.gd`,
-  `test_packaging_panel_logic.gd`, `test_packaging_content_preparer.gd`,
-  `test_gdk_toolchain.gd`, `test_packaging_settings_store.gd`,
-  `test_export_preset_catalog.gd`, `test_game_config_manager.gd`,
-  `test_makepkg_executor.gd`, `test_wdapp_manager.gd`) — preserved as-is,
-  preloads updated to `core/`.
+- `tests/godot/gdk/tests/packaging/test_tutorial_wizard_state.gd` — tutorial
+  wizard state transitions.
 
 GUT base class for packaging tests: just `extends GutTest`. The shared
 service bases (`gdk_test_base.gd`, …) are for runtime addons; do not use

--- a/addons/godot_gdk_packaging/core/game_config_manager.gd
+++ b/addons/godot_gdk_packaging/core/game_config_manager.gd
@@ -339,9 +339,9 @@ func relocate_logos_to_storelogos() -> int:
 		"splash_screen": "SplashScreenImage",
 	}
 
-	# Build a mapping of root files that need to move
+	# Build a mapping of root files that need to move.
 	var files_to_move: Dictionary = {}  # src_abs -> dest_filename
-	var path_replacements: Dictionary = {}  # old_config_value -> new_config_value
+	var logo_attr_replacements: Dictionary = {}  # ShellVisuals attr -> { old, new }
 
 	for key: String in config_logos:
 		var rel_path: String = info.get(key, "")
@@ -355,15 +355,17 @@ func relocate_logos_to_storelogos() -> int:
 		if not FileAccess.file_exists(src_abs):
 			continue
 		var dest_filename: String = normalized.get_file()
+		var attr_name: String = config_logos[key]
 		files_to_move[src_abs] = dest_filename
-		path_replacements[rel_path] = "storelogos\\" + dest_filename
+		logo_attr_replacements[attr_name] = {"old": rel_path, "new": "storelogos\\" + dest_filename}
 
 	# Also check for standard GameConfigEditor output names at root
 	for filename: String in logo_files:
 		var src_abs: String = project_dir.path_join(filename)
 		if FileAccess.file_exists(src_abs) and not files_to_move.has(src_abs):
+			var attr_name: String = logo_files[filename]
 			files_to_move[src_abs] = filename
-			path_replacements[filename] = "storelogos\\" + filename
+			logo_attr_replacements[attr_name] = {"old": filename, "new": "storelogos\\" + filename}
 
 	if files_to_move.is_empty():
 		return 0
@@ -385,15 +387,13 @@ func relocate_logos_to_storelogos() -> int:
 			push_warning("[GDK Packaging] Failed to move " + src_abs.get_file() + ": " + error_string(err))
 
 	# Update MicrosoftGame.config with new paths
-	if moved > 0 and not path_replacements.is_empty():
+	if moved > 0 and not logo_attr_replacements.is_empty():
 		var config_path: String = get_config_path()
 		var file: FileAccess = FileAccess.open(config_path, FileAccess.READ)
 		if file != null:
 			var content: String = file.get_as_text()
 			file.close()
-			for old_val: String in path_replacements:
-				var new_val: String = path_replacements[old_val]
-				content = content.replace('"' + old_val + '"', '"' + new_val + '"')
+			content = _replace_shell_visuals_logo_attributes(content, logo_attr_replacements)
 			file = FileAccess.open(config_path, FileAccess.WRITE)
 			if file != null:
 				file.store_string(content)
@@ -410,6 +410,79 @@ func relocate_logos_to_storelogos() -> int:
 ## Escapes special characters for safe use in XML attribute values.
 static func _escape_xml_attr(value: String) -> String:
 	return value.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+static func _replace_shell_visuals_logo_attributes(content: String, attr_replacements: Dictionary) -> String:
+	var shell_visuals: RegEx = RegEx.new()
+	shell_visuals.compile('(?s)<ShellVisuals\\b[^>]*>')
+	var shell_match: RegExMatch = shell_visuals.search(content)
+	if shell_match == null:
+		return content
+
+	var patched: String = ""
+	var cursor: int = 0
+	while shell_match != null:
+		patched += content.substr(cursor, shell_match.get_start() - cursor)
+		patched += _replace_logo_attrs_in_tag(shell_match.get_string(), attr_replacements)
+		cursor = shell_match.get_end()
+		shell_match = shell_visuals.search(content, cursor)
+	return patched + content.substr(cursor)
+
+
+static func _replace_logo_attrs_in_tag(tag: String, attr_replacements: Dictionary) -> String:
+	var patched: String = tag
+	for attr_name: String in attr_replacements:
+		var replacement: Dictionary = attr_replacements[attr_name]
+		patched = _replace_xml_attribute_value(
+			patched,
+			attr_name,
+			str(replacement.get("old", "")),
+			str(replacement.get("new", "")))
+	return patched
+
+
+static func _replace_xml_attribute_value(tag: String, attr_name: String,
+		expected_old_value: String, new_value: String) -> String:
+	if expected_old_value.is_empty():
+		return tag
+	var attr_regex: RegEx = RegEx.new()
+	attr_regex.compile('(\\b' + attr_name + '\\s*=\\s*")[^"]*(")')
+	var attr_match: RegExMatch = attr_regex.search(tag)
+	if attr_match == null:
+		return tag
+
+	var escaped_old: String = _escape_xml_attr(expected_old_value)
+	var escaped_new: String = _escape_xml_attr(new_value)
+	var patched: String = ""
+	var cursor: int = 0
+	while attr_match != null:
+		var original: String = attr_match.get_string()
+		var prefix: String = attr_match.get_string(1)
+		var suffix: String = attr_match.get_string(2)
+		var current_value: String = original.substr(prefix.length(),
+			original.length() - prefix.length() - suffix.length())
+		patched += tag.substr(cursor, attr_match.get_start() - cursor)
+		if current_value == expected_old_value or current_value == escaped_old:
+			patched += prefix + escaped_new + suffix
+		else:
+			patched += original
+		cursor = attr_match.get_end()
+		attr_match = attr_regex.search(tag, cursor)
+	return patched + tag.substr(cursor)
+
+
+static func _find_shell_visuals_attr(content: String, attr_name: String) -> String:
+	var shell_visuals: RegEx = RegEx.new()
+	shell_visuals.compile('(?s)<ShellVisuals\\b[^>]*>')
+	var shell_match: RegExMatch = shell_visuals.search(content)
+	while shell_match != null:
+		var attr_regex: RegEx = RegEx.new()
+		attr_regex.compile('\\b' + attr_name + '\\s*=\\s*"([^"]*)"')
+		var attr_match: RegExMatch = attr_regex.search(shell_match.get_string())
+		if attr_match != null:
+			return attr_match.get_string(1)
+		shell_match = shell_visuals.search(content, shell_match.get_end())
+	return ""
 
 
 ## Strips characters disallowed in MicrosoftGame.config Identity/@Name (spaces
@@ -461,22 +534,16 @@ func _rewrite_config_paths_to_storelogos() -> void:
 		"SplashScreenImage",
 	]
 
-	var changed: bool = false
+	var logo_attr_replacements: Dictionary = {}
 	for attr: String in logo_attrs:
-		# Match attr="something.png" where something.png doesn't already start with storelogos
-		var regex: RegEx = RegEx.new()
-		regex.compile(attr + '="(?!storelogos[/\\\\])([^"]+)"')
-		var result: RegExMatch = regex.search(content)
-		if result:
-			var old_path: String = result.get_string(1)
-			var filename: String = old_path.replace("\\", "/").get_file()
-			var new_path: String = "storelogos\\" + filename
-			content = content.replace(
-				attr + '="' + old_path + '"',
-				attr + '="' + new_path + '"')
-			changed = true
+		var old_path: String = _find_shell_visuals_attr(content, attr)
+		if old_path.is_empty() or old_path.replace("/", "\\").begins_with("storelogos\\"):
+			continue
+		var filename: String = old_path.replace("\\", "/").get_file()
+		logo_attr_replacements[attr] = {"old": old_path, "new": "storelogos\\" + filename}
 
-	if changed:
+	if not logo_attr_replacements.is_empty():
+		content = _replace_shell_visuals_logo_attributes(content, logo_attr_replacements)
 		file = FileAccess.open(config_path, FileAccess.WRITE)
 		if file != null:
 			file.store_string(content)

--- a/addons/godot_gdk_packaging/core/gdk_toolchain.gd
+++ b/addons/godot_gdk_packaging/core/gdk_toolchain.gd
@@ -50,19 +50,46 @@ func execute_tool(exe_path: String, args: PackedStringArray) -> Dictionary:
 	if not FileAccess.file_exists(exe_path):
 		return { "exit_code": -1, "stdout": "", "stderr": "Tool not found: " + exe_path }
 
-	var output: Array = []
-	# read_stderr=false: Godot merges stderr into stdout in output[0]
-	var exit_code: int = OS.execute(exe_path, args, output, true, false)
+	var pipes: Dictionary = OS.execute_with_pipe(exe_path, args, false)
+	if pipes.is_empty():
+		return { "exit_code": -1, "stdout": "", "stderr": "Failed to execute tool: " + exe_path }
 
+	var pid: int = int(pipes.get("pid", -1))
+	var stdout_pipe: FileAccess = pipes.get("stdio", null) as FileAccess
+	var stderr_pipe: FileAccess = pipes.get("stderr", null) as FileAccess
 	var stdout_text: String = ""
-	if output.size() > 0:
-		stdout_text = str(output[0])
+	var stderr_text: String = ""
+
+	while pid >= 0 and OS.is_process_running(pid):
+		stdout_text += _drain_pipe_text(stdout_pipe)
+		stderr_text += _drain_pipe_text(stderr_pipe)
+		OS.delay_msec(10)
+	stdout_text += _drain_pipe_text(stdout_pipe)
+	stderr_text += _drain_pipe_text(stderr_pipe)
+
+	var exit_code: int = OS.get_process_exit_code(pid) if pid >= 0 else -1
+	if stdout_pipe != null:
+		stdout_pipe.close()
+	if stderr_pipe != null:
+		stderr_pipe.close()
 
 	return {
 		"exit_code": exit_code,
 		"stdout": stdout_text,
-		"stderr": ""  # stderr is merged into stdout by OS.execute
+		"stderr": stderr_text
 	}
+
+
+static func _drain_pipe_text(pipe: FileAccess) -> String:
+	if pipe == null or not pipe.is_open():
+		return ""
+	var bytes: PackedByteArray = PackedByteArray()
+	while true:
+		var chunk: PackedByteArray = pipe.get_buffer(4096)
+		if chunk.is_empty():
+			break
+		bytes.append_array(chunk)
+	return bytes.get_string_from_utf8()
 
 
 ## Launches an executable as a detached process (fire-and-forget).

--- a/addons/godot_gdk_packaging/core/packaging_content_preparer.gd
+++ b/addons/godot_gdk_packaging/core/packaging_content_preparer.gd
@@ -126,7 +126,7 @@ func _copy_addon_runtime_dlls(content_dir: String, logger: Callable) -> int:
 						if not bin.current_is_dir() and fname.ends_with(".dll") and skip_re.search(fname) == null:
 							var src: String = bin_dir.path_join(fname)
 							var dest: String = content_dir.path_join(fname)
-							if not FileAccess.file_exists(dest):
+							if _should_copy_runtime_dll(src, dest):
 								if copy_dir.copy(src, dest) == OK:
 									copied += 1
 									_call_logger(logger, "Copied runtime DLL: addons/%s/bin/%s" % [addon_name, fname])
@@ -140,32 +140,79 @@ func _copy_addon_runtime_dlls(content_dir: String, logger: Callable) -> int:
 
 
 static func inject_vc14_dependency(content: String) -> String:
-	if content.contains('<KnownDependency Name="VC14"/>') or not content.contains("</Game>"):
+	if not content.contains("</Game>"):
 		return content
 
-	var dep_inner: String = '    <DependencyList>\n      <KnownDependency Name="VC14"/>\n    </DependencyList>\n'
+	var dep_entry: String = '      <KnownDependency Name="VC14"/>\n'
 	var existing_dr: RegEx = RegEx.new()
-	# Match an existing <DesktopRegistration>...</DesktopRegistration> block (non-greedy, DOTALL so
-	# it can span newlines). If found, merge the DependencyList into it instead of appending a new
-	# DesktopRegistration block — GDK rejects configs with more than one DesktopRegistration.
-	existing_dr.compile('(?s)<DesktopRegistration>(.*?)</DesktopRegistration>')
-	var match: RegExMatch = existing_dr.search(content)
-	if match:
-		var inner: String = match.get_string(1)
-		var trimmed: String = inner.strip_edges(false, true)
-		var merged: String = "<DesktopRegistration>%s\n%s  </DesktopRegistration>" % [trimmed, dep_inner]
-		return content.substr(0, match.get_start()) + merged + content.substr(match.get_end())
+	existing_dr.compile('(?s)(<DesktopRegistration\\b[^>]*>)(.*?)(</DesktopRegistration>)')
+	var desktop_match: RegExMatch = existing_dr.search(content)
+	if desktop_match:
+		var inner: String = desktop_match.get_string(2)
+		var dependency_list: RegEx = RegEx.new()
+		dependency_list.compile('(?s)(<DependencyList\\b[^>]*>)(.*?)(</DependencyList>)')
+		var list_match: RegExMatch = dependency_list.search(inner)
+		var new_inner: String = inner
+		if list_match:
+			if _dependency_list_has_name(list_match.get_string(), "VC14"):
+				return content
+			var list_body: String = list_match.get_string(2).strip_edges(false, true)
+			if list_body.is_empty():
+				list_body = "\n"
+			elif not list_body.ends_with("\n"):
+				list_body += "\n"
+			var merged_list: String = list_match.get_string(1) + list_body + dep_entry + "    " + list_match.get_string(3)
+			new_inner = inner.substr(0, list_match.get_start()) + merged_list + inner.substr(list_match.get_end())
+		else:
+			new_inner = inner.strip_edges(false, true)
+			if new_inner.is_empty():
+				new_inner = "\n"
+			elif not new_inner.ends_with("\n"):
+				new_inner += "\n"
+			new_inner += '    <DependencyList>\n' + dep_entry + '    </DependencyList>\n  '
+		var merged_desktop: String = desktop_match.get_string(1) + new_inner + desktop_match.get_string(3)
+		return content.substr(0, desktop_match.get_start()) + merged_desktop + content.substr(desktop_match.get_end())
 
-	var dep_xml: String = '  <DesktopRegistration>\n' + dep_inner + '  </DesktopRegistration>\n'
+	var dep_xml: String = '  <DesktopRegistration>\n    <DependencyList>\n' + dep_entry + '    </DependencyList>\n  </DesktopRegistration>\n'
 	return content.replace("</Game>", dep_xml + "</Game>")
 
 
 static func patch_executable_name(content: String, executable_name: String) -> String:
 	var regex: RegEx = RegEx.new()
-	regex.compile('Executable Name="[^"]*"')
-	if regex.search(content):
-		return regex.sub(content, 'Executable Name="%s"' % executable_name)
-	return content
+	regex.compile('(<Executable\\b[^>]*\\bName=")[^"]*(")')
+	var executable_match: RegExMatch = regex.search(content)
+	if executable_match == null:
+		return content
+
+	var escaped_name: String = GameConfigManagerScript._escape_xml_attr(executable_name)
+	var patched: String = ""
+	var cursor: int = 0
+	while executable_match != null:
+		patched += content.substr(cursor, executable_match.get_start() - cursor)
+		patched += executable_match.get_string(1) + escaped_name + executable_match.get_string(2)
+		cursor = executable_match.get_end()
+		executable_match = regex.search(content, cursor)
+	return patched + content.substr(cursor)
+
+
+static func _should_copy_runtime_dll(src_path: String, dest_path: String) -> bool:
+	if not FileAccess.file_exists(dest_path):
+		return true
+	var src_hash: String = FileAccess.get_sha256(src_path)
+	var dest_hash: String = FileAccess.get_sha256(dest_path)
+	if not src_hash.is_empty() and not dest_hash.is_empty():
+		return src_hash != dest_hash
+	var src_time: int = FileAccess.get_modified_time(src_path)
+	var dest_time: int = FileAccess.get_modified_time(dest_path)
+	if src_time <= 0 or dest_time <= 0:
+		return true
+	return src_time > dest_time
+
+
+static func _dependency_list_has_name(dependency_list_xml: String, dependency_name: String) -> bool:
+	var regex: RegEx = RegEx.new()
+	regex.compile("\\bName\\s*=\\s*[\"']" + dependency_name + "[\"']")
+	return regex.search(dependency_list_xml) != null
 
 
 func _find_primary_executable(content_dir: String) -> String:

--- a/addons/godot_gdk_packaging/core/packaging_service.gd
+++ b/addons/godot_gdk_packaging/core/packaging_service.gd
@@ -50,6 +50,10 @@ func run_pack(resolved: Dictionary) -> Dictionary:
 	var missing: String = _missing_required(resolved, ["source_dir", "output_dir"])
 	if not missing.is_empty():
 		return PackagingResult.fail(verb, missing, PackagingResult.EXIT_USAGE)
+	if _encrypt_key_missing(resolved):
+		var message: String = "--encrypt=key requires --encrypt-key to point at an EKB file"
+		push_error("[GDK Packaging] " + message)
+		return PackagingResult.fail(verb, message, PackagingResult.EXIT_CONFIG)
 	if not _toolchain.is_gdk_available():
 		return PackagingResult.fail(verb, "GDK tools not found (set GDK_BIN or install the GDK)",
 			PackagingResult.EXIT_CONFIG)
@@ -588,3 +592,12 @@ static func _missing_required(resolved: Dictionary, keys: Array) -> String:
 	if missing.is_empty():
 		return ""
 	return "Missing required value(s): %s" % ", ".join(missing)
+
+
+static func _encrypt_key_missing(resolved: Dictionary) -> bool:
+	if str(resolved.get("encrypt", "none")) != "key":
+		return false
+	var raw_key: Variant = resolved.get("encrypt_key", "")
+	if raw_key == null:
+		return true
+	return str(raw_key).strip_edges().is_empty()

--- a/addons/godot_gdk_packaging/core/wdapp_manager.gd
+++ b/addons/godot_gdk_packaging/core/wdapp_manager.gd
@@ -214,6 +214,7 @@ func _notification(what: int) -> void:
 		return
 	_disposed = true
 	if _thread != null and _thread.is_started():
+		push_warning("[GDK Packaging] Waiting for in-flight wdapp operation to finish before shutdown...")
 		_thread.wait_to_finish()
 		_thread = null
 	_busy = false

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -93,6 +93,9 @@ on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 | `--encrypt`       | `none`   | `none`, `license`, or `key:<ekb-path>`.                                |
 | `--encrypt-key`   |          | EKB path (required when `--encrypt=key`).                              |
 | `--updcompat`     | `3`      | makepkg `/updcompat` level (1, 2, or 3).                               |
+
+`--encrypt=key` without a non-empty `--encrypt-key` fails with `EXIT_CONFIG`;
+the pack verb never silently downgrades a key-encrypted build to unencrypted.
 | `--no-prepare`    | off      | Skip the content-prep step before pack.                                |
 
 Per-verb help is always reachable as `<verb> --help`:
@@ -113,7 +116,8 @@ PACKAGING_RESULT_JSON:{"verb":"pack","exit_code":0,"ok":true,"message":"...","de
 ```
 
 Pass `--no-json` to suppress the marker line for terminal use. The
-process exit code mirrors the `exit_code` field.
+process exit code mirrors the `exit_code` field. Underlying tool diagnostics
+are reported in `stderr` instead of being merged into `stdout`.
 
 ### Exit-code reference
 

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -93,10 +93,10 @@ on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 | `--encrypt`       | `none`   | `none`, `license`, or `key:<ekb-path>`.                                |
 | `--encrypt-key`   |          | EKB path (required when `--encrypt=key`).                              |
 | `--updcompat`     | `3`      | makepkg `/updcompat` level (1, 2, or 3).                               |
+| `--no-prepare`    | off      | Skip the content-prep step before pack.                                |
 
 `--encrypt=key` without a non-empty `--encrypt-key` fails with `EXIT_CONFIG`;
 the pack verb never silently downgrades a key-encrypted build to unencrypted.
-| `--no-prepare`    | off      | Skip the content-prep step before pack.                                |
 
 Per-verb help is always reachable as `<verb> --help`:
 

--- a/spec/gdext-packaging.md
+++ b/spec/gdext-packaging.md
@@ -89,8 +89,8 @@ Every verb returns a `PackagingResult` dictionary:
     "ok":          true,       # exit_code == 0
     "message":     "Packed ... -> ...",
     "details":     {...},      # verb-specific (artifact paths, parsed config, etc.)
-    "stdout":      "...",      # forwarded from underlying tool, may be ""
-    "stderr":      "...",      # forwarded from underlying tool, may be ""
+    "stdout":      "...",      # forwarded from underlying tool stdout, may be ""
+    "stderr":      "...",      # forwarded from underlying tool stderr, may be ""
     "duration_ms": 1234
 }
 ```
@@ -176,7 +176,9 @@ Derived rules:
 - `content_id` falls back to `product_id` if neither CLI nor settings file
   supplied one.
 - `--encrypt=key:<ekb>` is split into `encrypt="key"` + `encrypt_key="<ekb>"`
-  unless `--encrypt-key` is also passed (CLI wins).
+  unless `--encrypt-key` is also passed (CLI wins). A resolved `encrypt="key"`
+  with no non-empty `encrypt_key` fails with `EXIT_CONFIG`; the service never
+  silently drops the requested encryption mode.
 
 ## Plan
 

--- a/tests/godot/gdk/tests/packaging/test_game_config_xml_rewriting.gd
+++ b/tests/godot/gdk/tests/packaging/test_game_config_xml_rewriting.gd
@@ -1,0 +1,124 @@
+extends GutTest
+## XML rewrite safety coverage for MicrosoftGame.config packaging helpers.
+
+const GameConfigManagerScript = preload("res://addons/godot_gdk_packaging/core/game_config_manager.gd")
+const PackagingResult = preload("res://addons/godot_gdk_packaging/core/packaging_result.gd")
+const PackagingServiceScript = preload("res://addons/godot_gdk_packaging/core/packaging_service.gd")
+
+const _CONFIG_FILE := "MicrosoftGame.config"
+const _ROOT_LOGO := "Logo.png"
+
+
+class FakeToolchain:
+	extends RefCounted
+
+	func is_gdk_available() -> bool:
+		return false
+
+	func get_makepkg_path() -> String:
+		return ""
+
+	func get_game_config_editor_path() -> String:
+		return ""
+
+	func get_sandbox_path() -> String:
+		return ""
+
+	func get_dev_account_path() -> String:
+		return ""
+
+	func get_gdk_version() -> String:
+		return ""
+
+	func get_bin_dir() -> String:
+		return ""
+
+	func execute_tool(_exe_path: String, _args: PackedStringArray) -> Dictionary:
+		return {"exit_code": 0, "stdout": "", "stderr": ""}
+
+	func launch_detached(_exe_path: String, _args: PackedStringArray) -> int:
+		return -1
+
+
+func before_each() -> void:
+	_cleanup_project_artifacts()
+
+
+func after_each() -> void:
+	_cleanup_project_artifacts()
+
+
+func test_relocate_logos_updates_only_logo_attributes() -> void:
+	var config := ""
+	config += '<?xml version="1.0" encoding="utf-8"?>\n'
+	config += '<Game configVersion="1">\n'
+	config += '  <ShellVisuals DefaultDisplayName="Logo.png"\n'
+	config += '                PublisherDisplayName="Logo.png"\n'
+	config += '                Square150x150Logo="Logo.png"\n'
+	config += '                Description="assets\\Logo.png" />\n'
+	config += '</Game>\n'
+	_write_text(_project_path(_CONFIG_FILE), config)
+	_write_text(_project_path(_ROOT_LOGO), "fake-png")
+
+	var manager = GameConfigManagerScript.new(FakeToolchain.new())
+	var moved: int = manager.relocate_logos_to_storelogos()
+
+	assert_eq(moved, 1, "root logo moved once")
+	var rewritten: String = _read_text(_project_path(_CONFIG_FILE))
+	assert_string_contains(rewritten, 'Square150x150Logo="storelogos\\Logo.png"', "logo attr rewritten")
+	assert_string_contains(rewritten, 'DefaultDisplayName="Logo.png"', "same value in non-logo attr preserved")
+	assert_string_contains(rewritten, 'PublisherDisplayName="Logo.png"', "unrelated attr not rewritten")
+	assert_string_contains(rewritten, 'Description="assets\\Logo.png"', "substring in unrelated attr preserved")
+	assert_false(FileAccess.file_exists(_project_path(_ROOT_LOGO)), "root logo removed")
+	assert_true(FileAccess.file_exists(_project_path("storelogos").path_join(_ROOT_LOGO)), "logo moved into storelogos")
+
+
+func test_pack_encrypt_key_without_key_returns_config_error() -> void:
+	var service = PackagingServiceScript.new(FakeToolchain.new())
+	var result: Dictionary = service.run_pack({
+		"source_dir": "C:\\does-not-need-to-exist",
+		"output_dir": "C:\\does-not-need-to-exist",
+		"encrypt": "key",
+		"encrypt_key": "",
+	})
+
+	assert_false(bool(result.get("ok", true)), "pack fails before producing an unencrypted package")
+	assert_eq(int(result.get("exit_code", -1)), PackagingResult.EXIT_CONFIG, "missing key is a config error")
+	assert_string_contains(str(result.get("message", "")), "--encrypt=key requires --encrypt-key", "error explains missing key")
+	assert_push_error("--encrypt=key requires --encrypt-key", "push_error emitted for editor callers")
+
+
+func _project_path(relative_path: String) -> String:
+	return ProjectSettings.globalize_path("res://").path_join(relative_path)
+
+
+func _write_text(path: String, text: String) -> void:
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "fixture file opened for writing: %s" % path)
+	if file == null:
+		return
+	file.store_string(text)
+	file.close()
+
+
+func _read_text(path: String) -> String:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var text: String = file.get_as_text()
+	file.close()
+	return text
+
+
+func _cleanup_project_artifacts() -> void:
+	for path: String in [
+		_project_path(_CONFIG_FILE),
+		_project_path(_ROOT_LOGO),
+		_project_path("storelogos").path_join(_ROOT_LOGO),
+	]:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(path)
+	var storelogos_dir: String = _project_path("storelogos")
+	if DirAccess.dir_exists_absolute(storelogos_dir):
+		if DirAccess.get_files_at(storelogos_dir).is_empty() and DirAccess.get_directories_at(storelogos_dir).is_empty():
+			DirAccess.remove_absolute(storelogos_dir)

--- a/tests/godot/gdk/tests/packaging/test_gdk_toolchain.gd
+++ b/tests/godot/gdk/tests/packaging/test_gdk_toolchain.gd
@@ -65,6 +65,29 @@ func test_execute_tool_result_dict_shape() -> void:
 	assert_eq(typeof(result["stderr"]), TYPE_STRING, "stderr is String")
 
 
+func test_execute_tool_captures_stderr_separately() -> void:
+	var shell_path: String = ""
+	var args: PackedStringArray = PackedStringArray()
+	if OS.get_name() == "Windows":
+		shell_path = OS.get_environment("ComSpec")
+		if shell_path.is_empty():
+			shell_path = "C:\\Windows\\System32\\cmd.exe"
+		args = PackedStringArray(["/C", "echo tool_stdout && echo tool_stderr 1>&2"])
+	else:
+		shell_path = "/bin/sh"
+		args = PackedStringArray(["-c", "printf 'tool_stdout\\n'; printf 'tool_stderr\\n' >&2"])
+	if not FileAccess.file_exists(shell_path):
+		pending("No shell executable available for stderr capture test")
+		return
+
+	var tc = GDKToolchainScript.new()
+	var result: Dictionary = tc.execute_tool(shell_path, args)
+	assert_eq(int(result.get("exit_code", -1)), 0, "shell command exits cleanly")
+	assert_string_contains(str(result.get("stdout", "")), "tool_stdout", "stdout captured")
+	assert_string_contains(str(result.get("stderr", "")), "tool_stderr", "stderr captured")
+	assert_false(str(result.get("stdout", "")).contains("tool_stderr"), "stderr is not merged into stdout")
+
+
 # ── launch_detached — missing executable soft-fail ────────────────────────
 
 func test_launch_detached_missing_exe_returns_negative() -> void:

--- a/tests/godot/gdk/tests/packaging/test_packaging_content_preparer.gd
+++ b/tests/godot/gdk/tests/packaging/test_packaging_content_preparer.gd
@@ -5,15 +5,26 @@ extends GutTest
 ## test layer).
 ##
 ## Pinned behaviors:
-##   * `patch_executable_name` uses Godot's `RegEx` and matches the FIRST
-##     `Executable Name="…"` attribute. The replacement value is NOT XML-
-##     escaped; callers are responsible for sanitising untrusted exe names.
-##   * `inject_vc14_dependency` is idempotent: a config that already
-##     contains `<KnownDependency Name="VC14"/>` is returned unchanged.
+##   * `patch_executable_name` rewrites every `<Executable Name="…">`, XML-
+##     escapes replacement values, and treats dollar signs as literal text.
+##   * `inject_vc14_dependency` merges into an existing DesktopRegistration/
+##     DependencyList and skips duplicates by dependency Name.
 ##   * Both helpers passthrough on no-match (no `Executable Name=`,
 ##     no `</Game>` tag).
 
 const PackagingContentPreparerScript = preload("res://addons/godot_gdk_packaging/core/packaging_content_preparer.gd")
+
+const _RUNTIME_ADDON_NAME := "_copy_refresh_probe"
+const _RUNTIME_DLL := "ProbeRuntime.dll"
+const _RUNTIME_CONTENT_DIR := "user://packaging_runtime_copy"
+
+
+func before_each() -> void:
+	_cleanup_runtime_copy_fixture()
+
+
+func after_each() -> void:
+	_cleanup_runtime_copy_fixture()
 
 
 # ── patch_executable_name ─────────────────────────────────────────────────
@@ -31,28 +42,29 @@ func test_patch_executable_no_match_passthrough() -> void:
 	assert_eq(patched, input, "input returned unchanged when no Executable Name= attribute is present")
 
 
-func test_patch_executable_replaces_only_first_attribute() -> void:
-	# Pin: the underlying RegEx.sub() called without `all` replaces only the
-	# first match. Configs in practice have a single Executable, but we
-	# document the actual behavior here.
+func test_patch_executable_replaces_all_attributes() -> void:
 	var input := '<Executable Name="A.exe" /><Executable Name="B.exe" />'
 	var patched: String = PackagingContentPreparerScript.patch_executable_name(input, "C.exe")
-	assert_true(patched.contains('Name="C.exe"'), "first attribute replaced")
-	assert_true(patched.contains('Name="B.exe"'), "second attribute left intact (single replacement)")
+	assert_eq(_count_occurrences(patched, 'Name="C.exe"'), 2, "all executable names replaced")
+	assert_false(patched.contains('Name="A.exe"'), "first old name removed")
+	assert_false(patched.contains('Name="B.exe"'), "second old name removed")
 
 
-func test_patch_executable_does_not_escape_xml_special_chars() -> void:
-	# Pin: the implementation does NOT sanitise the replacement value — there
-	# is no `xml_escape` helper in the addon. A name containing `&` or `"` is
-	# inserted literally and would produce malformed XML downstream. This test
-	# documents the current behavior so any future hardening is intentional.
+func test_patch_executable_escapes_xml_special_chars() -> void:
 	var input := '<Executable Name="OldName.exe" Id="Game" />'
-	var unsafe := 'Game&Name<Special>.exe'
+	var unsafe := 'Game&Name<Special>"Quote".exe'
 	var patched: String = PackagingContentPreparerScript.patch_executable_name(input, unsafe)
 	assert_string_contains(
 		patched,
-		'Executable Name="Game&Name<Special>.exe"',
-		"unsafe characters inserted verbatim — no XML escaping is performed")
+		'Executable Name="Game&amp;Name&lt;Special&gt;&quot;Quote&quot;.exe"',
+		"replacement is safe for XML attributes")
+	assert_false(patched.contains(unsafe), "unsafe replacement was not inserted verbatim")
+
+
+func test_patch_executable_preserves_dollar_characters() -> void:
+	var input := '<Executable Name="OldName.exe" Id="Game" />'
+	var patched: String = PackagingContentPreparerScript.patch_executable_name(input, "Cash$1Game$N.exe")
+	assert_string_contains(patched, 'Executable Name="Cash$1Game$N.exe"', "dollar signs stay literal")
 
 
 func test_patch_executable_handles_realistic_config_block() -> void:
@@ -83,13 +95,34 @@ func test_inject_vc14_inserts_block_before_close_game() -> void:
 		"dependency block sits BEFORE </Game>")
 
 
-func test_inject_vc14_idempotent_when_already_present() -> void:
-	var existing := "<Game>\n  <KnownDependency Name=\"VC14\"/>\n</Game>"
+func test_inject_vc14_idempotent_when_dependency_name_already_present() -> void:
+	var existing := ""
+	existing += "<Game>\n"
+	existing += "  <DesktopRegistration>\n"
+	existing += "    <DependencyList>\n"
+	existing += "      <PackageDependency Name=\"VC14\" MinVersion=\"old\" />\n"
+	existing += "    </DependencyList>\n"
+	existing += "  </DesktopRegistration>\n"
+	existing += "</Game>"
 	var injected: String = PackagingContentPreparerScript.inject_vc14_dependency(existing)
-	assert_eq(injected, existing, "input with VC14 already present returned unchanged")
-	# And explicitly: only one occurrence after the call.
-	var occurrences := injected.split('<KnownDependency Name="VC14"/>').size() - 1
-	assert_eq(occurrences, 1, "no duplicate VC14 dependency added")
+	assert_eq(injected, existing, "input with VC14 Name already present returned unchanged")
+	assert_eq(_count_occurrences(injected, 'Name="VC14"'), 1, "no duplicate VC14 dependency added")
+
+
+func test_inject_vc14_merges_into_existing_dependency_list() -> void:
+	var input := ""
+	input += "<Game>\n"
+	input += "  <DesktopRegistration>\n"
+	input += "    <DependencyList>\n"
+	input += "      <PackageDependency Name=\"OtherRuntime\" MinVersion=\"1.0.0.0\" />\n"
+	input += "    </DependencyList>\n"
+	input += "  </DesktopRegistration>\n"
+	input += "</Game>"
+	var injected: String = PackagingContentPreparerScript.inject_vc14_dependency(input)
+	assert_string_contains(injected, '<PackageDependency Name="OtherRuntime"', "existing dependency preserved")
+	assert_string_contains(injected, '<KnownDependency Name="VC14"/>', "VC14 dependency merged")
+	assert_eq(_count_occurrences(injected, "<DependencyList"), 1, "no duplicate DependencyList added")
+	assert_eq(_count_occurrences(injected, "<DesktopRegistration"), 1, "no duplicate DesktopRegistration added")
 
 
 func test_inject_vc14_passthrough_when_no_close_game_tag() -> void:
@@ -99,14 +132,32 @@ func test_inject_vc14_passthrough_when_no_close_game_tag() -> void:
 
 
 func test_inject_vc14_runs_again_after_dependency_stripped() -> void:
-	# Sanity round-trip: inject, strip the marker, re-inject. Verifies the
-	# detection only keys on the literal `<KnownDependency Name="VC14"/>`.
 	var input := "<Game>\n</Game>\n"
 	var first: String = PackagingContentPreparerScript.inject_vc14_dependency(input)
 	var stripped := first.replace('<KnownDependency Name="VC14"/>', '<KnownDependency Name="OTHER"/>')
 	var second: String = PackagingContentPreparerScript.inject_vc14_dependency(stripped)
 	assert_string_contains(second, '<KnownDependency Name="VC14"/>', "VC14 re-injected after marker removed")
 	assert_string_contains(second, '<KnownDependency Name="OTHER"/>', "unrelated dependency preserved")
+	assert_eq(_count_occurrences(second, "<DependencyList"), 1, "VC14 merged into existing DependencyList")
+
+
+# ── runtime DLL copying ───────────────────────────────────────────────────
+
+func test_copy_addon_runtime_dlls_refreshes_stale_destination() -> void:
+	var project_dir: String = ProjectSettings.globalize_path("res://")
+	var addon_bin: String = project_dir.path_join("addons").path_join(_RUNTIME_ADDON_NAME).path_join("bin")
+	var content_dir: String = ProjectSettings.globalize_path(_RUNTIME_CONTENT_DIR)
+	DirAccess.make_dir_recursive_absolute(addon_bin)
+	DirAccess.make_dir_recursive_absolute(content_dir)
+	var src_path: String = addon_bin.path_join(_RUNTIME_DLL)
+	var dest_path: String = content_dir.path_join(_RUNTIME_DLL)
+	_write_text(src_path, "fresh-runtime")
+	_write_text(dest_path, "stale-runtime")
+
+	var preparer = PackagingContentPreparerScript.new(RefCounted.new())
+	preparer._copy_addon_runtime_dlls(content_dir, Callable())
+
+	assert_eq(_read_text(dest_path), "fresh-runtime", "stale destination DLL overwritten from source")
 
 
 # ── pipeline (typical caller order) ───────────────────────────────────────
@@ -126,3 +177,43 @@ func test_pipeline_inject_then_patch_matches_caller_order() -> void:
 	var step2: String = PackagingContentPreparerScript.patch_executable_name(step1, "RealGame.exe")
 	assert_string_contains(step2, 'Executable Name="RealGame.exe"', "exe patched after inject")
 	assert_string_contains(step2, '<KnownDependency Name="VC14"/>', "VC14 still present after patch")
+
+
+func _count_occurrences(text: String, needle: String) -> int:
+	if needle.is_empty():
+		return 0
+	return text.split(needle).size() - 1
+
+
+func _write_text(path: String, text: String) -> void:
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	assert_not_null(file, "fixture file opened for writing: %s" % path)
+	if file == null:
+		return
+	file.store_string(text)
+	file.close()
+
+
+func _read_text(path: String) -> String:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var text: String = file.get_as_text()
+	file.close()
+	return text
+
+
+func _cleanup_runtime_copy_fixture() -> void:
+	var project_dir: String = ProjectSettings.globalize_path("res://")
+	_remove_dir_recursive(project_dir.path_join("addons").path_join(_RUNTIME_ADDON_NAME))
+	_remove_dir_recursive(ProjectSettings.globalize_path(_RUNTIME_CONTENT_DIR))
+
+
+func _remove_dir_recursive(path: String) -> void:
+	if not DirAccess.dir_exists_absolute(path):
+		return
+	for filename: String in DirAccess.get_files_at(path):
+		DirAccess.remove_absolute(path.path_join(filename))
+	for dirname: String in DirAccess.get_directories_at(path):
+		_remove_dir_recursive(path.path_join(dirname))
+	DirAccess.remove_absolute(path)


### PR DESCRIPTION
**Lane D3 (Packaging XML rewriting safety sweep)** — fixes HIGH/CONSENSUS audit findings:

- `inject_vc14_dependency`: merge into existing `<DesktopRegistration>`/`<DependencyList>` instead of appending a second list.
- `patch_executable_name`: XML-escape substituted name, patch **all** `<Executable>` entries (not just the first), preserve literal `$`.
- `relocate_logos_to_storelogos`: scope rewrites to `<ShellVisuals>` logo attributes only — no more over-replacement of unrelated strings.
- Fail packaging when `encrypt="key"` is set without an `encrypt_key` value (was silently dropping encryption).
- `_copy_addon_runtime_dlls`: refresh stale DLLs (timestamp/hash-aware) instead of skipping when destination exists.
- `GDKToolchain.execute_tool`: capture stderr separately so `PackagingResult.stderr` stops always being empty.

**Tests:** new `test_game_config_xml_rewriting.gd`, plus expansions to `test_gdk_toolchain.gd` and `test_packaging_content_preparer.gd`.

**Internal mirror:** see gaming-microsoft/godot-public-gdk-ext (will be filed shortly).

**Validation:**
- `cmake --preset default` ✅
- `cmake --build build --preset debug` ✅
- Addon parse gate ✅
- Packaging GUT subset ✅ (120 tests, 118 pass, 2 pending)
- Full `run_all_tests.ps1` blocked by **pre-existing sample parse failures** (`GDKUser` typed-symbol in `sample/multiplayer_pong/logic/`) — unrelated to this PR; tracked in audit follow-up.

Authored by the D3 audit-remediation agent. Conflict in `wdapp_manager.gd:_notification` (vs PR #16) resolved by combining D1's early-return style with D3's `push_warning` diagnostic.
