### PR TITLE
pk-docs: backfill editor-menu coverage + reconcile CLI flag tables + drop dock-rewrite spec claim (audit D4)

### DIFF
--- a/.github/instructions/godot-gdk-packaging.instructions.md
+++ b/.github/instructions/godot-gdk-packaging.instructions.md
@@ -89,8 +89,8 @@ collapses every source into one flat dict with precedence:
 
 If you add a new CLI flag whose key differs from the resolver field name,
 add the kebab -> snake mapping to `_CLI_KEY_REMAP`. Do not rename
-existing CLI keys without updating the docs and the dock alike — they
-were chosen to match dock field names verbatim.
+existing CLI keys without updating the docs and editor UI alike — they
+were chosen to match editor field names verbatim.
 
 ## Where to put new behaviour
 
@@ -120,17 +120,14 @@ shortcuts.
 
 ## Sample mirrors
 
-`addons/godot_gdk_packaging/` is mirrored into the GDK test host
-via `godot_addon_sync_directory` in the root CMakeLists. (Sample
-mirror targets will return when PR 3 of the tutorial-driven
-sample revamp adds `sample/tutorial_app/`.) The sync uses
-`copy_if_different` — **it does not delete stale mirror files.**
-When you remove or rename a file in `addons/godot_gdk_packaging/`,
-run `cmake --build build --preset debug` once, then manually
-delete the stale mirror files under
-`tests/godot/gdk/addons/godot_gdk_packaging/` (and, once
-samples land, under each `sample/*/addons/godot_gdk_packaging/`)
-before committing.
+`addons/godot_gdk_packaging/` is mirrored into the GDK test host and
+`sample/tutorial_app/` via `godot_addon_sync_directory` in the root
+CMakeLists. The sync uses `copy_if_different` — **it does not delete
+stale mirror files.** When you remove or rename a file in
+`addons/godot_gdk_packaging/`, run `cmake --build build --preset debug`
+once, then manually delete the stale mirror files under
+`tests/godot/gdk/addons/godot_gdk_packaging/` and
+`sample/tutorial_app/addons/godot_gdk_packaging/` before committing.
 
 ## Tests
 
@@ -148,8 +145,8 @@ before committing.
   precedence chain + key remap + encrypt key:<path> split.
 - `tests/godot/gdk/tests/packaging/test_packaging_content_preparer.gd` —
   content-prep XML helpers and runtime DLL refresh behavior.
-- `tests/godot/gdk/tests/packaging/test_packaging_panel_logic.gd` — dock
-  presenter helper behavior.
+- `tests/godot/gdk/tests/packaging/test_packaging_panel_logic.gd` — editor
+  panel helper behavior.
 - `tests/godot/gdk/tests/packaging/test_packaging_plugin_lifecycle.gd` —
   editor plugin enter/exit lifecycle.
 - `tests/godot/gdk/tests/packaging/test_packaging_result.gd` — result
@@ -174,8 +171,8 @@ them here.
 ## Anti-patterns specific to this addon
 
 - **No new top-level singleton.** This addon never registers an autoload.
-  All entry points are explicit (the dock for editor mode; `run.gd` for
-  headless mode).
+  All entry points are explicit (the `GDK` menu/dialogs for editor mode;
+  `run.gd` for headless mode).
 - **No verb-side IO in `packaging_cli.gd`.** It is pure. Coercion and
   schema enforcement only; reading files belongs in
   `packaging_config.gd`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the **first step** in our Godot for XBOX on PC integration journey. We p
 
 ## Addons
 
-The addons are designed to be dropped into any Godot 4.5+ project — most developers will consume them as a prebuilt addon zip. This repository is where the addons are authored, built, tested, and (once the tutorial-driven sample revamp's PR 3 lands) demonstrated through a small set of tutorial sample projects. Sample projects are temporarily absent while that revamp lands; follow the [tutorials](docs/tutorials/README.md) in your own project in the meantime.
+The addons are designed to be dropped into any Godot 4.5+ project — most developers will consume them as a prebuilt addon zip. This repository is where the addons are authored, built, tested, and demonstrated through the tutorial sample projects under `sample/tutorial_app/` and `sample/tutorial_gameinput/`.
 
 | Addon | Description |
 |-------|-------------|
@@ -49,7 +49,7 @@ Per-addon documentation:
 - [`godot_gdk`](docs/gdk/plugin.md) — runtime, services, async system, build, editor tooling
 - [`godot_playfab`](docs/playfab/plugin.md) — runtime configuration, user sessions, Game Saves, leaderboards, client services
 - [`godot_gameinput`](docs/gameinput/plugin.md) — devices, polling, vibration, action bridge
-- [`godot_gdk_packaging`](docs/packaging/plugin.md) — Create Game Config, Sandbox dialog, export platform, Package Manager
+- [`godot_gdk_packaging`](docs/packaging/plugin.md) — headless packaging runner; see also the [editor `GDK` menu](docs/packaging/editor-menu.md)
 
 Platform setup:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,9 +109,11 @@ docs/
 
 ## Packaging addon (`godot_gdk_packaging`)
 
-- [**Packaging Plugin**](packaging/plugin.md) — editor tooling for PC
-  packaging: Create Game Config, Sandbox dialog, export platform, and
-  the Package Manager (install/uninstall/run loose builds)
+- [**Packaging Plugin**](packaging/plugin.md) — headless runner and CLI
+  reference for PC packaging verbs
+- [**Editor `GDK` menu**](packaging/editor-menu.md) — Create/Edit
+  MicrosoftGame.config, sandbox switching, Package Manager, and documentation
+  shortcuts
 
 ## Platform setup
 

--- a/docs/packaging/editor-menu.md
+++ b/docs/packaging/editor-menu.md
@@ -1,0 +1,263 @@
+# Godot GDK Packaging — Editor `GDK` Menu
+
+The `godot_gdk_packaging` addon adds a top-level **GDK** menu to the
+Godot editor. The menu is editor tooling only: it does not add a runtime
+autoload or engine singleton, and it is separate from the headless
+`gdkpkg` runner documented in [Packaging Plugin](plugin.md).
+
+The menu is assembled by
+`addons\godot_gdk_packaging\editor\gdk_packaging_plugin.gd`. It contains
+11 user-visible entries:
+
+1. Getting Started
+2. Create MicrosoftGame.config / Edit MicrosoftGame.config
+3. Change Sandbox…
+4. Package Manager…
+5. PC Packaging Overview
+6. makepkg Reference
+7. GameConfigEditor Reference
+8. Achievements Guide
+9. PlayFab Game Manager
+10. PlayFab IDs from Xbox Live
+11. PlayFab + GDK Quickstart
+
+## Prerequisites shared by all menu entries
+
+- Enable the `godot_gdk_packaging` addon in the Godot editor.
+- Open the project whose packaging state you want to inspect or change.
+- Install the Microsoft GDK when you want to run local tools such as
+  `GameConfigEditor.exe`, `XblPCSandbox.exe`, `wdapp.exe`, or `makepkg.exe`.
+  The addon discovers the GDK from `GDK_BIN` first, then from the default
+  `C:\Program Files (x86)\Microsoft GDK\bin` location.
+
+Documentation links also require network access and whatever Microsoft,
+Partner Center, or PlayFab account permissions the linked site requires.
+
+## Menu entries
+
+### Getting Started
+
+**What it does:** Opens the in-editor tutorial wizard. The wizard walks
+through the packaging workflow at a high level: MicrosoftGame.config,
+sandboxes, export and package steps, installing and launching builds,
+achievements, and PlayFab setup.
+
+**When to use it:** Use this first when enabling the addon in a project, or
+when you need a quick reminder of the packaging workflow without leaving the
+editor.
+
+**Required prerequisites:** The addon must be enabled and the Godot editor
+must have a base editor window. The wizard itself does not require the GDK to
+be installed because it is informational.
+
+**Expected output / side effects:** A modal wizard window opens. Navigating or
+closing it does not change project files or machine state.
+
+**Deeper docs:** Continue with [Packaging Plugin](plugin.md) for the headless
+commands that perform the build and packaging work.
+
+### Create MicrosoftGame.config / Edit MicrosoftGame.config
+
+**What it does:** The label changes based on whether the project already has a
+MicrosoftGame.config. When the file is missing, the menu creates a starter
+`MicrosoftGame.config`, creates placeholder images under `storelogos\`, asks
+Godot's file system to rescan, then launches `GameConfigEditor.exe`. When the
+file already exists, it launches `GameConfigEditor.exe` against the current
+config.
+
+**When to use it:** Use it when bootstrapping a GDK project identity, editing
+store logos, or updating the executable, identity, product, or Xbox Live fields
+inside the config.
+
+**Required prerequisites:** Install the Microsoft GDK so
+`GameConfigEditor.exe` is available. The project directory must be writable
+when creating the initial template. Partner Center sign-in is not required just
+to create or edit the local file, but store association and Xbox Live IDs must
+come from your Partner Center title when you are preparing a real package.
+
+**Expected output / side effects:** Template creation writes
+`MicrosoftGame.config` and a `storelogos\` folder in the project if they do not
+exist. Editing through GameConfigEditor may rewrite the config and logo files.
+If the editor executable is missing or fails to launch, the Godot output panel
+shows an error.
+
+**Deeper docs:** See [Packaging Plugin](plugin.md#verbs) for the
+`config_template` and `config_editor` headless verbs, and Microsoft's
+GameConfigEditor documentation from the **GameConfigEditor Reference** menu
+entry.
+
+### Change Sandbox…
+
+**What it does:** Opens the GDK Sandbox Switcher dialog. The dialog reads the
+current PC sandbox with `XblPCSandbox.exe /get`, can switch to a target
+sandbox with `/set <sandbox-id> /noApps`, and can switch back to RETAIL with
+`/retail /noApps`.
+
+**When to use it:** Use it before testing Xbox Live services with development
+sandboxes, or before returning the PC to retail Xbox Live services.
+
+**Required prerequisites:** Install the Microsoft GDK so
+`XblPCSandbox.exe` is available. Switching sandboxes is machine-wide and
+requires administrator privileges. You also need the target sandbox ID from a
+Partner Center title that your developer account can access.
+
+**Expected output / side effects:** The dialog displays the current sandbox,
+confirms any switch, and reports success or failure. A successful switch changes
+the PC's machine-wide Xbox sandbox for every user, Xbox tool, and Xbox-aware
+app on the machine. Switch back to RETAIL before using retail Xbox Live
+services.
+
+**Deeper docs:** See [Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
+for account and sandbox setup. The headless equivalent is the `sandbox` verb in
+[Packaging Plugin](plugin.md#verbs).
+
+### Package Manager…
+
+**What it does:** Opens a machine-wide package manager backed by `wdapp.exe`.
+It lists registered packages and AUMIDs, installs a selected `.msixvc`,
+uninstalls the selected package, refreshes the package list, and can open
+Godot's standard **Project > Export…** dialog to build a new package.
+
+**When to use it:** Use it when validating what packages are installed on your
+PC, installing a package built elsewhere, removing stale packages, or jumping to
+Godot's export dialog before a packaging pass.
+
+**Required prerequisites:** Install the Microsoft GDK so `wdapp.exe` is
+available. Installing requires a built `.msixvc` package. Uninstalling requires
+selecting a package from the list. Exporting requires a configured Godot export
+preset for your project.
+
+**Expected output / side effects:** The dialog refreshes asynchronously while
+`wdapp` runs. Installing or uninstalling changes the machine-wide registered
+package state, not just the current project. Opening **Project > Export…** does
+not build by itself; the export dialog owns that workflow.
+
+**Deeper docs:** See the `install`, `uninstall`, `register_loose`, `launch`,
+and `terminate` verbs in [Packaging Plugin](plugin.md#verbs), plus the
+**PC Packaging Overview** and **makepkg Reference** menu links.
+
+### PC Packaging Overview
+
+**What it does:** Opens Microsoft's PC packaging getting-started documentation
+in the system browser.
+
+**When to use it:** Use it when you need the Microsoft overview for PC package
+layout, packaging terms, or the broader flow around building MSIXVC packages.
+
+**Required prerequisites:** Network access. Running the documented steps later
+requires the Microsoft GDK and an appropriately configured title.
+
+**Expected output / side effects:** The browser opens a Microsoft Learn page.
+No project files or machine packaging state change.
+
+**Deeper docs:** Pair it with [Packaging Plugin](plugin.md) for this addon's
+headless command reference.
+
+### makepkg Reference
+
+**What it does:** Opens Microsoft's `makepkg.exe` package-creation reference in
+the system browser.
+
+**When to use it:** Use it when troubleshooting `genmap`, `pack`, or
+`validate`, or when you need to understand the flags the addon passes through
+to `makepkg.exe`.
+
+**Required prerequisites:** Network access. To run `makepkg.exe` locally, the
+Microsoft GDK must be installed.
+
+**Expected output / side effects:** The browser opens a Microsoft Learn page.
+No local files change.
+
+**Deeper docs:** See the `pack`, `genmap`, and `validate` verb descriptions in
+[Packaging Plugin](plugin.md#verbs).
+
+### GameConfigEditor Reference
+
+**What it does:** Opens Microsoft's GameConfigEditor documentation in the
+system browser.
+
+**When to use it:** Use it when editing MicrosoftGame.config fields, store
+logos, identity values, or store association details.
+
+**Required prerequisites:** Network access. To launch GameConfigEditor from the
+addon, the Microsoft GDK must be installed.
+
+**Expected output / side effects:** The browser opens a Microsoft Learn page.
+No local files change until you separately run GameConfigEditor and save a
+config.
+
+**Deeper docs:** See **Create MicrosoftGame.config / Edit MicrosoftGame.config**
+on this page and the `config_template` / `config_editor` verbs in
+[Packaging Plugin](plugin.md#verbs).
+
+### Achievements Guide
+
+**What it does:** Opens Microsoft's PC end-to-end achievements guide in the
+system browser.
+
+**When to use it:** Use it when configuring achievements for a Partner Center
+title, publishing them to a development sandbox, or validating achievement
+unlock flows with test accounts.
+
+**Required prerequisites:** Network access. Following the guide requires a
+Partner Center title, access to Xbox Live configuration for that title, a
+development sandbox, and a matching test account.
+
+**Expected output / side effects:** The browser opens a Microsoft Learn page.
+No local project files change.
+
+**Deeper docs:** See [Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
+for the local sandbox and test-account prerequisites.
+
+### PlayFab Game Manager
+
+**What it does:** Opens the PlayFab Game Manager sign-in page in the system
+browser.
+
+**When to use it:** Use it to manage PlayFab title settings, API keys,
+statistics, leaderboards, multiplayer feature switches, and test data needed by
+PlayFab-backed samples or tutorials.
+
+**Required prerequisites:** Network access and a PlayFab account with access to
+the target title.
+
+**Expected output / side effects:** The browser opens PlayFab Game Manager.
+Changes happen only if you modify title data in the portal.
+
+**Deeper docs:** See [PlayFab title prerequisites](../playfab/prerequisites.md)
+for the title configuration expected by this repository's PlayFab tutorials.
+
+### PlayFab IDs from Xbox Live
+
+**What it does:** Opens the PlayFab REST API documentation for mapping Xbox Live
+IDs to PlayFab IDs.
+
+**When to use it:** Use it when reconciling Xbox identities with PlayFab player
+records or debugging cross-service account linking.
+
+**Required prerequisites:** Network access. Calling the documented API requires
+PlayFab credentials and the appropriate Xbox Live identity data.
+
+**Expected output / side effects:** The browser opens a Microsoft Learn API
+reference. No local files change.
+
+**Deeper docs:** See [PlayFab title prerequisites](../playfab/prerequisites.md)
+and the PlayFab user-session docs in [PlayFab Plugin](../playfab/plugin.md).
+
+### PlayFab + GDK Quickstart
+
+**What it does:** Opens the PlayFab SDK for GDK quickstart in the system
+browser.
+
+**When to use it:** Use it when you need Microsoft's native PlayFab + GDK
+integration context while comparing this repository's Godot addon layer to the
+underlying platform SDK guidance.
+
+**Required prerequisites:** Network access. Running native GDK SDK samples also
+requires the Microsoft GDK and a PlayFab title.
+
+**Expected output / side effects:** The browser opens Microsoft Learn. No local
+project files or machine state change.
+
+**Deeper docs:** See [PlayFab Plugin](../playfab/plugin.md) for this repo's
+Godot-facing PlayFab surface.

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -4,10 +4,11 @@
 Godot — Microsoft Game Config, makepkg (genmap / pack / validate), wdapp
 (register / install / launch / terminate / uninstall), XblPCSandbox, and
 the GameConfigEditor / Store Association wizard. It works as a **headless**
-runner you can drive from scripts and CI, with a small editor menu for
-Game Config and documentation shortcuts.
+runner you can drive from scripts and CI, with a top-level editor `GDK` menu
+for Game Config, sandbox/package management, and documentation shortcuts.
 
-This page is the headless-surface reference.
+This page is the headless-surface reference. For editor UI coverage, see
+[Godot GDK Packaging — Editor `GDK` Menu](editor-menu.md).
 
 ## Invocation
 
@@ -52,8 +53,10 @@ Godot discovery order in the forwarders:
 1. `GODOT_CONSOLE` env var (full path to a console-enabled Godot binary)
 2. `GODOT_BIN` env var
 3. `GODOT` env var
-4. Repo-local `sample\Godot*_console.exe` (highest version wins; for dev hosts)
-5. `where godot` / `which godot`
+4. Repo-local `sample\Godot*_console.exe` / `sample\Godot*.exe` candidates
+5. Current-working-directory `Godot*_console.exe` / `Godot*.exe` candidates
+6. `where godot` / `where godot4` on Windows, or `which godot` / `which godot4`
+   on POSIX shells
 
 Both forwarders accept `--path <project_dir>` to override the project
 root (otherwise the current working directory is used). Pass `--godot
@@ -67,42 +70,22 @@ The runner dispatches one verb per invocation. Common runner flags accepted
 on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 `--verbose` (`-v`).
 
-| Verb               | Required flags                       | Description                                                       |
-|--------------------|--------------------------------------|-------------------------------------------------------------------|
-| `pack`             | `--source-dir`, `--output-dir`       | makepkg pack. Auto-genmap when `--map-file` is omitted.           |
-| `genmap`           | `--source-dir`, `--map-file`         | makepkg genmap.                                                   |
-| `validate`         | `--source-dir`, `--map-file`         | makepkg validate; optional `--output-dir` selects `/pd`.          |
-| `prepare_content`  | `--content-dir`                      | Copies MicrosoftGame.config + logos into a content directory.     |
-| `export`           | `--preset`, `--output-dir`           | Godot Windows-Desktop export; `--release`; optional `--no-prepare`. |
-| `register_loose`   | `--content-dir`                      | wdapp register (loose-files build).                               |
-| `install`          | `--package`                          | wdapp install on an .msixvc file.                                 |
-| `uninstall`        | `--package-name`                     | wdapp uninstall by package full name.                             |
-| `launch`           | `--package-name` or `--aumid`        | wdapp launch. Resolves AUMID from PFN when needed.                |
-| `terminate`        | `--package-name`                     | wdapp terminate; taskkill fallback is limited to the build's config-named `.exe`. |
-| `sandbox`          | `--action {get,set,retail}`          | `set` additionally requires `--sandbox-id`.                       |
-| `config_template`  | (none)                               | Writes a starter MicrosoftGame.config; optional `--output`, `--overwrite`. |
-| `config_editor`    | (none)                               | Detached GameConfigEditor.exe launch on the current config.       |
-| `store_wizard`     | (none)                               | Detached GameConfigEditor.exe `/StoreAssociation`.                |
-
-`pack`-specific flags:
-
-| Flag              | Default  | Description                                                            |
-|-------------------|----------|------------------------------------------------------------------------|
-| `--content-id`    | `product_id` | Override the `/contentid` value.                                   |
-| `--product-id`    |          | Override the `/productid` value (otherwise MicrosoftGame.config wins).|
-| `--encrypt`       | `none`   | `none`, `license`, or `key:<ekb-path>`.                                |
-| `--encrypt-key`   |          | EKB path (required when `--encrypt=key`).                              |
-| `--updcompat`     | `3`      | makepkg `/updcompat` level (1, 2, or 3).                               |
-| `--no-prepare`    | off      | Skip the content-prep step before pack.                                |
-
-Additional verb-specific flags:
-
-- `validate --output-dir <dir>` chooses the makepkg validation output `/pd`
-  directory (otherwise a `validate-out` sibling is created).
-- `export --no-prepare` skips the post-export content preparation step.
-- `config_template --output <path>` writes the template at that path;
-  `--overwrite` replaces that same resolved output file when it already
-  exists.
+| Verb               | Required flags                 | Optional flags                                                                 | Description                                                       |
+|--------------------|--------------------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `pack`             | `--source-dir`, `--output-dir` | `--map-file`, `--content-id`, `--product-id`, `--encrypt`, `--encrypt-key`, `--updcompat`, `--no-prepare` | makepkg pack. Auto-generates a map file when `--map-file` is omitted; `--no-prepare` only skips content prep. |
+| `genmap`           | `--source-dir`, `--map-file`   | (none)                                                                          | makepkg genmap.                                                   |
+| `validate`         | `--source-dir`, `--map-file`   | `--output-dir`                                                                  | makepkg validate; `--output-dir` selects `/pd`, otherwise a `validate-out` sibling is created. |
+| `prepare_content`  | `--content-dir`                | (none)                                                                          | Copies MicrosoftGame.config + logos into a content directory.     |
+| `export`           | `--preset`, `--output-dir`     | `--release`, `--no-prepare`                                                     | Godot Windows-Desktop export; `--no-prepare` skips post-export content preparation. |
+| `register_loose`   | `--content-dir`                | (none)                                                                          | wdapp register (loose-files build).                               |
+| `install`          | `--package`                    | (none)                                                                          | wdapp install on an .msixvc file.                                 |
+| `uninstall`        | `--package-name`               | (none)                                                                          | wdapp uninstall by package full name.                             |
+| `launch`           | `--package-name`               | `--aumid`                                                                       | wdapp launch. The CLI parser requires `--package-name`; `--aumid` overrides the AUMID resolved from `wdapp list`. |
+| `terminate`        | `--package-name`               | (none)                                                                          | wdapp terminate; taskkill fallback is limited to the build's config-named `.exe`. |
+| `sandbox`          | (none)                         | `--action {get,set,retail}`, `--sandbox-id`                                     | Defaults to `get`; `--action set` also requires `--sandbox-id`.   |
+| `config_template`  | (none)                         | `--output`, `--overwrite`                                                       | Writes a starter MicrosoftGame.config; `--output` redirects the template path (relative paths resolve under the project root) and `--overwrite` replaces that same file. |
+| `config_editor`    | (none)                         | (none)                                                                          | Detached GameConfigEditor.exe launch on the current config.       |
+| `store_wizard`     | (none)                         | (none)                                                                          | Detached GameConfigEditor.exe `/StoreAssociation`.                |
 
 `--encrypt=key` without a non-empty `--encrypt-key` fails with `EXIT_CONFIG`;
 the pack verb never silently downgrades a key-encrypted build to unencrypted.
@@ -145,8 +128,13 @@ are reported in `stderr` instead of being merged into `stdout`.
 (highest precedence wins):
 
 1. **CLI flags** (kebab-case). E.g. `--source-dir C:\Build\content`.
-2. **`res://.gdk_packaging.cfg`** — written by the dock. Empty strings
-   here do not blow away values from lower layers.
+2. **`res://.gdk_packaging.cfg`** — persisted editor settings. Empty strings
+   here do not blow away values from lower layers. The settings file contains:
+   - `[packaging]`: `source_dir`, `map_file`, `auto_genmap`, `output_dir`,
+     `content_id`, `product_id`, `encrypt_option`, `encrypt_key`,
+     `updcompat_option`
+   - `[sandbox]`: `sandbox_id`, `test_account`
+   - `[export]`: `preset_name`, `clean_build`
 3. **`MicrosoftGame.config`** at `<project>\MicrosoftGame.config` (override
    with the runner's `--config <path>` flag) — provides `product_id`,
    identity fields, and the executable name.
@@ -162,6 +150,12 @@ Derived rules:
 - `--config <path>` is honored by the resolver and by content preparation, so
   `prepare_content`, `pack`, and post-export prep stage the selected config
   instead of implicitly reading `res://MicrosoftGame.config`.
+- `config_template --output <path>` writes to that path; relative paths are
+  resolved under the project root, and `--overwrite` removes and recreates that
+  same resolved file.
+- `auto_genmap`, `test_account`, and `clean_build` are persisted editor UI
+  state. They are listed here for completeness, but the headless resolver does
+  not treat them as CLI-equivalent overrides.
 
 ## Content-directory safety
 
@@ -229,6 +223,8 @@ addons\godot_gdk_packaging\gdkpkg.cmd terminate --package-name MyPublisher.MyGam
 
 ## See also
 
+- [Godot GDK Packaging — Editor `GDK` Menu](editor-menu.md) — what each
+  editor menu item does and what prerequisites it needs.
 - `.github\instructions\godot-gdk-packaging.instructions.md` — repo-wide
   rules for contributors editing the addon.
 - `docs\gdk\editor-tools.md` — broader editor-tooling notes.

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -55,8 +55,9 @@ Godot discovery order in the forwarders:
 3. `GODOT` env var
 4. Repo-local `sample\Godot*_console.exe` / `sample\Godot*.exe` candidates
 5. Current-working-directory `Godot*_console.exe` / `Godot*.exe` candidates
-6. `where godot` / `where godot4` on Windows, or `which godot` / `which godot4`
-   on POSIX shells
+6. `where godot` / `where godot4` on Windows, or `command -v godot` /
+   `command -v godot4` on POSIX shells (`gdkpkg.sh` uses `command -v` for
+   PATH lookup, not `which`)
 
 Both forwarders accept `--path <project_dir>` to override the project
 root (otherwise the current working directory is used). Pass `--godot

--- a/spec/gdext-packaging.md
+++ b/spec/gdext-packaging.md
@@ -1,7 +1,7 @@
 # `godot_gdk_packaging` — Headless Packaging Surface
 
-Status: **Phase 1 in flight** (this PR ships the headless workflow layer; the
-dock UI stays on the existing helpers and is rewired in a follow-on PR).
+Status: **Headless workflow implemented**. The editor plugin exposes a
+top-level `GDK` menu and modal dialogs; it does not register an editor dock.
 
 ## Overview
 
@@ -10,11 +10,10 @@ Microsoft Game Config, makepkg.exe (genmap / pack / validate), wdapp.exe
 (register / install / launch / terminate / uninstall), XblPCSandbox.exe, and
 the GameConfigEditor / Store Association wizard launches.
 
-Up to this point all of it was reachable only from the editor dock under
-`editor\packaging_tabs\`. This spec defines a headless-first surface so
-automation (`tools\run_all_tests.ps1`, sample-export CI, cloud agents) can
-drive every verb without a human at the dock, and so the dock (in Phase 2)
-can be rewritten as a thin presenter over the same service.
+Editor access is through the top-level `GDK` menu and modal dialogs under
+`editor\`. This spec defines a headless-first surface so automation
+(`tools\run_all_tests.ps1`, sample-export CI, cloud agents) can drive every
+verb without a human clicking through editor UI.
 
 The headless surface is intentionally **GDScript-only** and lives entirely
 under `addons\godot_gdk_packaging\`. There is no new PowerShell wrapper
@@ -39,11 +38,11 @@ addons\godot_gdk_packaging\
     wdapp_manager.gd                     # wraps wdapp register/install/launch/terminate/uninstall
     packaging_settings_store.gd          # reads/writes res://.gdk_packaging.cfg
     export_preset_catalog.gd             # enumerates Windows export presets
-    packaging_panel_logic.gd             # dock helpers (still editor-shaped)
+    packaging_panel_logic.gd             # editor panel helpers (not an active dock)
   editor\                                # UI-only — preloads from core\
-    gdk_packaging_plugin.gd              # EditorPlugin entry
-    packaging_panel.gd                   # dock root
-    packaging_tabs\*.gd                  # tab views
+    gdk_packaging_plugin.gd              # EditorPlugin entry; top-level GDK menu
+    packaging_panel.gd                   # legacy panel root (not registered)
+    packaging_tabs\*.gd                  # legacy tab views (not registered)
     gdk_tutorial_wizard.gd, tutorial_wizard_state.gd
     gdk_sandbox_dialog.gd                # GDK Sandbox Switcher popup
     gdk_package_manager_dialog.gd        # machine-wide Package Manager popup
@@ -71,9 +70,12 @@ Layer summary:
   prints a one-line summary plus a `PACKAGING_RESULT_JSON:` line (unless
   `--no-json` is supplied), then `quit(exit_code)`.
 - `gdkpkg.cmd` / `gdkpkg.sh` locate Godot via env vars
-  (`GODOT_CONSOLE` -> `GODOT_BIN` -> `GODOT`), fall back to the repo-local
-  `sample\Godot*_console.exe` for dev use, then `where godot` / `which godot`.
-  They forward all remaining args using form A (`-s ...`) so they work even
+  (`GODOT_CONSOLE` -> `GODOT_BIN` -> `GODOT`), fall back to repo-local
+  `sample\Godot*_console.exe` / `sample\Godot*.exe` candidates, then the
+  current working directory's `Godot*_console.exe` / `Godot*.exe` candidates,
+  then `where godot` / `where godot4` on Windows or `which godot` /
+  `which godot4` on POSIX shells. They forward all remaining args using form
+  A (`-s ...`) so they work even
   before a `--import` pass has populated the class registry. The forwarders
   preserve argument boundaries for paths with spaces; `gdkpkg.sh` uses Bash
   arrays and `gdkpkg.cmd` invokes Godot through a PowerShell argument array.
@@ -195,9 +197,11 @@ logo bytes are written to the staging directory.
 
 ## Plan
 
-Headless first. UI rewire is a separate PR.
+Headless workflows are the supported automation contract. Editor access stays
+explicit through the top-level `GDK` menu and modal dialogs; this spec does not
+plan a separate editor-panel rewrite.
 
-### Phase 1 — headless workflows (this PR)
+### Shipped — headless workflows
 
 1. Move 8 headless-safe helpers from `editor\` to `core\`; update preloads.
 2. Add `core\packaging_result.gd` (typed dict + exit-code constants).
@@ -206,47 +210,32 @@ Headless first. UI rewire is a separate PR.
 5. Add `core\packaging_service.gd` (verb facade; one method per verb).
 6. Add `addons\godot_gdk_packaging\run.gd` (`class_name GdkPackagingRunner`).
 7. Add `gdkpkg.cmd` / `gdkpkg.sh` shell forwarders.
-8. GUT coverage under `tests\godot\gdk\tests\packaging\` for the CLI parser,
-   config resolver, and result builder plus the pre-existing helper suites
-   updated to the new `core\` paths.
-9. Spec (this file), user-facing reference (`docs\packaging\plugin.md`),
-   and path-scoped instructions
-   (`.github\instructions\godot-gdk-packaging.instructions.md`).
+8. Add GUT coverage under `tests\godot\gdk\tests\packaging\` for the CLI
+   parser, config resolver, and result builder plus the helper suites that
+   target the moved `core\` paths.
+9. Keep the spec, user-facing reference (`docs\packaging\plugin.md`), editor
+   menu reference (`docs\packaging\editor-menu.md`), and path-scoped
+   instructions aligned with the live implementation.
 
-### Phase 2 — dock rewrite (separate PR)
+### Future — service hardening and editor UX
 
-12. Migrate each `editor\packaging_tabs\*.gd` tab to call `PackagingService`
-    instead of the helpers directly. Each tab becomes a thin presenter
-    (collect input -> call service -> render result).
-13. Consolidate the duplicated orchestration in
-    `_on_export_and_package` / `_post_export_prepare` / the menu handler in
-    `gdk_packaging_plugin.gd` to a single `service.run_export` call.
-14. UX pass: tab layout, button placement, refresh behaviour, dialog
-    ergonomics. Audit what's left in `packaging_panel_logic.gd` and
-    promote anything truly headless-safe back into `core\` if needed.
-
-### Phase 3 — wider integrations (separate PRs)
-
-15. Optional: a thin `tools\run_packaging.ps1` if usage patterns demand it
-    (skipped for now per user preference).
-16. Re-evaluate orchestrator coverage of the headless runner against the
-    real GDK toolchain (gated on `is_gdk_available()`).
+10. Add targeted service and runner coverage for behaviours that require the
+    real GDK toolchain, gated on `is_gdk_available()`.
+11. Keep editor entry points menu/dialog based unless a future design explicitly
+    changes the editor model.
+12. Optional: add a thin `tools\run_packaging.ps1` only if usage patterns demand
+    it; the addon-local forwarders remain the supported wrapper today.
 
 ## Progress
 
-- **Phase 1**: implemented in branch `packaging-headless-revamp`. All eight
-  pre-existing source modules moved into `core\`; new `packaging_result.gd`,
-  `packaging_cli.gd`, `packaging_config.gd`, `packaging_service.gd`,
-  `run.gd`, `gdkpkg.cmd`, and `gdkpkg.sh` ship with the PR. GUT coverage
-  under `tests\godot\gdk\tests\packaging\` covers the resolver, CLI parser,
-  and result builder; pre-existing helper suites for the moved modules were
-  preserved and re-pointed at `core\`. Verb-level service coverage is
-  intentionally not shipped in this PR — the dock UI is the only consumer
-  driving the service end-to-end until Phase 2 (and that work will land
-  alongside its own coverage strategy against the real toolchain).
-  Spec, `docs\packaging\plugin.md`, and
-  `.github\instructions\godot-gdk-packaging.instructions.md` land in the
-  same PR.
+- **Headless workflow**: shipped in branch `packaging-headless-revamp`. All
+  eight pre-existing source modules moved into `core\`; new
+  `packaging_result.gd`, `packaging_cli.gd`, `packaging_config.gd`,
+  `packaging_service.gd`, `run.gd`, `gdkpkg.cmd`, and `gdkpkg.sh` shipped with
+  that work. GUT coverage under `tests\godot\gdk\tests\packaging\` covers the
+  resolver, CLI parser, result builder, and helper suites for the moved
+  `core\` paths. Verb-level service coverage continues to expand alongside
+  real-toolchain validation.
 - **Known orchestrator flake (not blocking)**: `tools\run_all_tests.ps1`
   occasionally crashes the `tests\godot\gdk` GUT host with signal 11 after
   ~194/205 passing tests and 0 failures. The backtrace points at
@@ -256,6 +245,5 @@ Headless first. UI rewire is a separate PR.
   changes stashed. Direct GUT invocations and isolated host runs are clean;
   re-running the orchestrator typically passes on retry. Tracking
   separately; do not gate packaging work on this flake.
-- **Phase 2**: not started. Dock still imports helpers directly; behaviour
-  unchanged.
-- **Phase 3**: not started.
+- **Editor UX / service hardening**: ongoing. The current editor surface is the
+  top-level `GDK` menu plus dialogs; no dock is registered.

--- a/spec/gdext-packaging.md
+++ b/spec/gdext-packaging.md
@@ -73,8 +73,9 @@ Layer summary:
   (`GODOT_CONSOLE` -> `GODOT_BIN` -> `GODOT`), fall back to repo-local
   `sample\Godot*_console.exe` / `sample\Godot*.exe` candidates, then the
   current working directory's `Godot*_console.exe` / `Godot*.exe` candidates,
-  then `where godot` / `where godot4` on Windows or `which godot` /
-  `which godot4` on POSIX shells. They forward all remaining args using form
+  then `where godot` / `where godot4` on Windows or `command -v godot` /
+  `command -v godot4` on POSIX shells (`gdkpkg.sh` uses `command -v`, not
+  `which`, for PATH lookup). They forward all remaining args using form
   A (`-s ...`) so they work even
   before a `--import` pass has populated the class registry. The forwarders
   preserve argument boundaries for paths with spaces; `gdkpkg.sh` uses Bash


### PR DESCRIPTION
## Summary

Docs-only audit D4 sweep for `godot_gdk_packaging`.

- Added `docs/packaging/editor-menu.md` with full coverage for all 11 live editor `GDK` menu entries.
- Reconciled the headless CLI verb table, `--config`, `config_template --output`, forwarder discovery, and settings precedence docs with live code.
- Removed stale dock-rewrite/sample-returning language from the packaging spec and path-scoped instructions.

## Audit sign-off / evidence

- [x] **HIGH D-03/D-06/D-07/D-08 — editor menu coverage.** The live menu inventory is built in `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:83-95`, with dispatch in `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:151-186`. The new user doc inventories the same 11 entries at `docs/packaging/editor-menu.md:8-22` and documents each entry's purpose, usage timing, prerequisites, side effects, and deeper docs at `docs/packaging/editor-menu.md:38-263`.

  | Menu item documented | Implementation file(s) |
  | --- | --- |
  | Getting Started | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:83,153-156`; `addons/godot_gdk_packaging/editor/gdk_tutorial_wizard.gd` |
  | Create/Edit MicrosoftGame.config | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:85,158-159,217-235`; `addons/godot_gdk_packaging/core/game_config_manager.gd` |
  | Change Sandbox… | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:86,161-162`; `addons/godot_gdk_packaging/editor/gdk_sandbox_dialog.gd` |
  | Package Manager… | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:87,164-165`; `addons/godot_gdk_packaging/editor/gdk_package_manager_dialog.gd` |
  | PC Packaging Overview | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:89,167-168` |
  | makepkg Reference | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:90,170-171` |
  | GameConfigEditor Reference | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:91,173-174` |
  | Achievements Guide | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:92,176-177` |
  | PlayFab Game Manager | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:93,179-180` |
  | PlayFab IDs from Xbox Live | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:94,182-183` |
  | PlayFab + GDK Quickstart | `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:95,185-186` |

- [x] **HIGH D-01 — `--config <path>` behavior.** Already resolved in merged code: `run.gd` pulls the parsed `config` option and passes it as `config_path_override` at `addons/godot_gdk_packaging/run.gd:55-57`; the resolver uses that override before falling back to `MicrosoftGame.config` at `addons/godot_gdk_packaging/core/packaging_config.gd:141-148`. Docs now describe the honored behavior at `docs/packaging/plugin.md:150-152`.
- [x] **HIGH D-02 — `config_template --output <path>` behavior.** Already resolved in merged code: `run_config_template()` resolves `output`, normalizes it with `to_filesystem_path()`, deletes that same resolved file when `--overwrite` is set, and passes `output` into `create_template()` at `addons/godot_gdk_packaging/core/packaging_service.gd:489-511`; `to_filesystem_path()` and `create_template()` write to that resolved target at `addons/godot_gdk_packaging/core/game_config_manager.gd:40-47`, `addons/godot_gdk_packaging/core/game_config_manager.gd:166-174`, and `addons/godot_gdk_packaging/core/game_config_manager.gd:206-224`. Docs now state this at `docs/packaging/plugin.md:86` and `docs/packaging/plugin.md:153-155`.
- [x] **MED D-04 — omitted verb flags.** `run.gd` delegates argv parsing to `PackagingCli.parse()` at `addons/godot_gdk_packaging/run.gd:31-32`; the parser schema includes `validate --output-dir` at `addons/godot_gdk_packaging/core/packaging_cli.gd:80-88`, `export --no-prepare` at `addons/godot_gdk_packaging/core/packaging_cli.gd:100-110`, and `config_template --output` at `addons/godot_gdk_packaging/core/packaging_cli.gd:167-171`. The user-facing table now lists these flags at `docs/packaging/plugin.md:77`, `docs/packaging/plugin.md:79`, and `docs/packaging/plugin.md:86`.
- [x] **MED D-05 — forwarder discovery.** Verified CWD probes and `godot4` discovery in `addons/godot_gdk_packaging/gdkpkg.cmd:63-72` and `addons/godot_gdk_packaging/gdkpkg.sh:73-88`; docs now list them at `docs/packaging/plugin.md:53-59` and `spec/gdext-packaging.md:72-78`.
- [x] **MED D-09/D-10 — stale dock rewrite spec claim.** Verified the live plugin registers a top-level `GDK` menu at `addons/godot_gdk_packaging/editor/gdk_packaging_plugin.gd:78-102` and `rg add_control_to_dock addons/godot_gdk_packaging` returns no matches. The spec now states menu/dialog editor access and no registered dock at `spec/gdext-packaging.md:3-16`, with the stale plan replaced at `spec/gdext-packaging.md:198-227` and progress updated at `spec/gdext-packaging.md:248-249`.
- [x] **LOW D-11 — stale `sample/tutorial_app/` parenthetical.** Updated the path-scoped instructions to describe the current mirrors into `tests/godot/gdk` and `sample/tutorial_app` at `.github/instructions/godot-gdk-packaging.instructions.md:123-130`.
- [x] **LOW D-12/D-13/D-14 — settings precedence docs.** Verified all persisted keys in `addons/godot_gdk_packaging/core/packaging_settings_store.gd:5-24`, including `auto_genmap`, `test_account`, and `clean_build`; docs now list every key without dock-shaped wording at `docs/packaging/plugin.md:130-158`.

## Validation

- `git diff public/main...HEAD --check`
- No `.gd` files changed; parse gate not required.
- No addon source code changed.
- No test changes.
- Live tests skipped (docs-only); `-AllowLiveWrites` not used.
