### PR TITLE
gdk-docs: reconcile api-reference enums + async-system return shapes + native-runtime service set + stale sample/dock status (audit B2)

### DIFF
--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -475,8 +475,13 @@ await GDK.presence.set_presence_async(user, "InGame")
 # Query presence for a list of XUIDs
 var result = await GDK.presence.get_presence_async(["1234567890123456"])
 if result.ok:
-    var record = GDK.presence.get_cached_presence("1234567890123456")
-    print(record.gamertag, " is ", record.presence_text)
+    var record: GDKPresenceRecord = GDK.presence.get_cached_presence("1234567890123456")
+    if record != null:
+        print("%s is %s" % [record.xuid, record.get_user_state_name()])
+        for title in record.title_records:
+            var title_name = str(title.get("title_name", ""))
+            var rich_presence = str(title.get("rich_presence_string", ""))
+            print("%s: %s" % [title_name, rich_presence])
 ```
 
 ## `GDKPresenceRecord`
@@ -488,9 +493,19 @@ Script-visible wrapper around a cached Xbox presence record.
 | Property | Type | Description |
 |----------|------|-------------|
 | `xuid` | `String` | Xbox User ID |
-| `gamertag` | `String` | Gamertag |
-| `online` | `bool` | Whether the user is online |
-| `presence_text` | `String` | Human-readable presence string |
+| `user_state` | `GDKPresenceRecord.UserState` | `USER_STATE_UNKNOWN`, `USER_STATE_ONLINE`, `USER_STATE_AWAY`, or `USER_STATE_OFFLINE` |
+| `title_records` | `Array[Dictionary]` | Title/device presence records translated from Xbox Services |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `is_online()` | `bool` | `true` when `user_state` is `USER_STATE_ONLINE` |
+| `get_user_state_name()` | `String` | Human-readable state string: `unknown`, `online`, `away`, or `offline` |
+
+`title_records` dictionaries can include `title_id`, `title_name`,
+`title_active`, `rich_presence_string`, `device_type`, `device_type_name`,
+and broadcast fields when Xbox Services reports them.
 
 ## Social service: `GDK.social`
 
@@ -549,13 +564,31 @@ Script-visible wrapper around a tracked social user.
 | Property | Type | Description |
 |----------|------|-------------|
 | `xuid` | `String` | Xbox User ID |
-| `gamertag` | `String` | Gamertag |
+| `favorite` | `bool` | Whether the user is a favorite of the local user |
+| `friend` | `bool` | Whether the user is a friend of the local user |
 | `display_name` | `String` | Display name |
 | `real_name` | `String` | Real name (if available) |
-| `online` | `bool` | Whether the user is online |
-| `playing_title_id` | `int` | Title ID the user is currently playing |
-| `title_name` | `String` | Name of the title being played |
-| `presence_text` | `String` | Human-readable presence string |
+| `display_picture_url` | `String` | Raw display-picture URL |
+| `gamerscore` | `String` | Gamerscore string |
+| `gamertag` | `String` | Classic gamertag |
+| `presence` | `GDKPresenceRecord` | Current Social Manager presence snapshot |
+| `title_history` | `Dictionary` | Title-history fields reported by Social Manager |
+| `preferred_color` | `Dictionary` | Preferred color fields reported by Social Manager |
+
+### Additional getters
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `is_following_user()` | `bool` | Whether the local user follows this user |
+| `is_followed_by_caller()` | `bool` | Whether this user is followed by the caller |
+| `uses_avatar()` | `bool` | Whether the display picture uses an avatar |
+| `get_modern_gamertag()` | `String` | Modern gamertag |
+| `get_modern_gamertag_suffix()` | `String` | Modern gamertag suffix |
+| `get_unique_modern_gamertag()` | `String` | Modern gamertag including suffix |
+
+Use `presence.user_state` and `presence.title_records` for online state,
+current-title, and rich-presence details; those are not direct `GDKSocialUser`
+properties.
 
 ## `GDKSocialGroup`
 
@@ -576,21 +609,24 @@ Namespace for social filter enums.
 
 **`PresenceFilter`**
 
-| Value | Description |
-|-------|-------------|
-| `UNKNOWN` | Unknown |
-| `TITLE_ONLINE` | Online in this title |
-| `TITLE_ALL_USERS` | All users for this title |
-| `ALL_ONLINE` | All online users |
-| `ALL_DEVICES` | All users on any device |
-| `ALL_USERS` | All users |
+| GDScript constant | Enum value | Description |
+|-------------------|------------|-------------|
+| `PRESENCE_FILTER_UNKNOWN` | `UNKNOWN` | Unknown |
+| `PRESENCE_FILTER_TITLE_ONLINE` | `TITLE_ONLINE` | Users online in the current title |
+| `PRESENCE_FILTER_TITLE_OFFLINE` | `TITLE_OFFLINE` | Users offline in the current title |
+| `PRESENCE_FILTER_TITLE_ONLINE_OUTSIDE_TITLE` | `TITLE_ONLINE_OUTSIDE_TITLE` | Users online but outside the current title |
+| `PRESENCE_FILTER_ALL_ONLINE` | `ALL_ONLINE` | All online users |
+| `PRESENCE_FILTER_ALL_OFFLINE` | `ALL_OFFLINE` | All offline users |
+| `PRESENCE_FILTER_ALL_TITLE` | `ALL_TITLE` | All users associated with the current title |
+| `PRESENCE_FILTER_ALL` | `ALL` | All users regardless of presence or title |
 
 **`RelationshipFilter`**
 
-| Value | Description |
-|-------|-------------|
-| `FRIENDS` | Friends only |
-| `FAVORITE` | Favorite friends only |
+| GDScript constant | Enum value | Description |
+|-------------------|------------|-------------|
+| `RELATIONSHIP_FILTER_UNKNOWN` | `UNKNOWN` | Unknown |
+| `RELATIONSHIP_FILTER_FRIENDS` | `FRIENDS` | Friends only |
+| `RELATIONSHIP_FILTER_FAVORITE` | `FAVORITE` | Favorite friends only |
 
 ## Store service: `GDK.store`
 

--- a/docs/gdk/async-system.md
+++ b/docs/gdk/async-system.md
@@ -158,10 +158,10 @@ Current public methods:
 - `start_social_graph(user) -> GDKResult`
 - `stop_social_graph(user) -> void`
 - `get_friends_async(user) -> Signal`
-- `create_social_group(user, filter := null) -> GDKSocialGroup`
-- `create_social_group_from_xuids(user, xuids) -> GDKSocialGroup`
+- `create_social_group(user, filter := null) -> GDKResult` (`data` is the `GDKSocialGroup`)
+- `create_social_group_from_xuids(user, xuids) -> GDKResult` (`data` is the `GDKSocialGroup`)
 - `destroy_social_group(group) -> void`
-- `get_group_users(group) -> Array`
+- `get_group_users(group) -> GDKResult` (`data` is an `Array[GDKSocialUser]`)
 
 Current public signals:
 
@@ -487,9 +487,9 @@ That is the concrete example of the "manager state instead of a classic async re
 4. dispatches the completion port until the queue termination callback fires
 5. closes the queue handle
 6. clears retained pending requests
-7. calls `XGameRuntimeUninitialize()`
+7. leaves `XGameRuntimeUninitialize()` to the process-lifetime teardown in `~GDKRuntime()`
 
-Because the runtime sets `m_shutting_down` first, service finalizers can refuse to mutate state during teardown.
+Because the runtime sets `m_shutting_down` first, service finalizers can refuse to mutate state during teardown. `GDK.shutdown()` intentionally does not call `XGameRuntimeUninitialize()`; tests and games may cycle initialize/shutdown multiple times in one process, while the matching native uninitialize runs once when the extension is torn down.
 
 ## Why the base bridge does not use generic `XAsyncGetStatus`
 

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -56,16 +56,23 @@ can share one script while still choosing automatic or manual startup.
 - `editor\gdk_export_platform.gd`
 - `editor\gdk_setup_panel.gd`
 
-These files are still shipped and synced, but the repo's active packaging UI now
-lives in the separate `godot_gdk_packaging` addon. The current
-`gdk_editor_plugin.gd` no longer registers the previous custom export platform.
+These files are still shipped and synced. The current `gdk_editor_plugin.gd`
+registers the custom `Xbox GDK (PC)` export platform and keeps the runtime
+autoload installed, but it no longer docks `gdk_setup_panel.gd`. The repo's
+broader packaging UI lives in the separate `godot_gdk_packaging` addon.
 
-### Sample project
+### Sample projects
 
-> **No sample projects currently.** The repository is mid-revamp;
-> samples are returning in PR 3 of the tutorial-driven sample
-> series (`sample/tutorial_app/` and
-> `sample/tutorial_gameinput/`).
+The repository currently ships two tutorial-driven sample projects:
+
+- `sample\tutorial_app\` — integrated tutorial chain (GDK runtime/sign-in,
+  achievements, PlayFab-backed flows, Multiplayer Activity, Party, and the
+  final integration scene). This project receives `godot_gdk`, `godot_playfab`,
+  and `godot_gdk_packaging` mirrors from the CMake build.
+- `sample\tutorial_gameinput\` — standalone GameInput tutorial sample. It is
+  wired for the GameInput addon and does not consume the GDK runtime addon.
+
+Related GDK runtime/test surfaces:
 
 - `addons\godot_gdk\runtime\gdk_bootstrap.gd`
 - `tests\godot\gdk\tests\`
@@ -97,8 +104,8 @@ The effective runtime artifact chain is:
 ```text
 native C++ sources
   -> godot_gdk.windows.<config>.x86_64.dll
-  -> addons/godot_gdk/bin/
-  -> sample/*/addons/godot_gdk/bin/
+  -> addons\godot_gdk\bin\
+  -> sample\tutorial_app\addons\godot_gdk\bin\
 ```
 
 > **Note:** vcpkg only provides the build-time dependencies. Consumers who
@@ -162,4 +169,5 @@ In practice:
 
 - `tests\godot\gdk\` is the canonical GDK test harness
 - `tests\godot\playfab\` receives `godot_gdk` when `GODOT_PLAYFAB_TEST_HOST_WITH_GDK=ON` so optional Xbox-backed PlayFab compatibility tests can run; turn the option off to keep the PlayFab host custom-ID-only
-- Sample projects are temporarily absent. PR 3 of the tutorial-driven sample revamp will reintroduce `sample\tutorial_app\` (integrated chain) and `sample\tutorial_gameinput\` (standalone GameInput demo), wiring them into the same addon-sync infrastructure described above.
+- `sample\tutorial_app\` receives the GDK runtime addon and is the integrated tutorial sample for GDK + PlayFab flows
+- `sample\tutorial_gameinput\` is a standalone GameInput sample and is not a GDK runtime consumer

--- a/docs/gdk/native-runtime.md
+++ b/docs/gdk/native-runtime.md
@@ -11,17 +11,11 @@ See also:
 
 ## Runtime structure
 
-The current native implementation is the runtime/users/accessibility/achievements/presence/social/store/launcher baseline:
+The current native implementation has one root singleton and 21 public service namespaces:
 
 - root singleton: `GDK`
-- service namespace: `GDK.users`
-- service namespace: `GDK.accessibility`
-- service namespace: `GDK.achievements`
-- service namespace: `GDK.presence`
-- service namespace: `GDK.social`
-- service namespace: `GDK.store`
-- service namespace: `GDK.launcher`
-- wrapper types: `GDKResult`, `GDKUsers`, `GDKUser`, `GDKAccessibility`, `GDKClosedCaptionProperties`, `GDKAchievements`, `GDKAchievement`, `GDKPresence`, `GDKPresenceRecord`, `GDKSocial`, `GDKSocialFilter`, `GDKSocialGroup`, `GDKSocialUser`, `GDKStore`, `GDKStoreLicenseStatus`, `GDKMultiplayerActivity`, `GDKMultiplayerActivityInfo`
+- service namespaces: `GDK.users`, `GDK.game_ui`, `GDK.accessibility`, `GDK.achievements`, `GDK.package`, `GDK.stats`, `GDK.leaderboards`, `GDK.privacy`, `GDK.presence`, `GDK.social`, `GDK.store`, `GDK.profile`, `GDK.string_verify`, `GDK.title_storage`, `GDK.error_reporting`, `GDK.launcher`, `GDK.multiplayer_activity`, `GDK.capture`, `GDK.system`, `GDK.display`, and `GDK.activation`
+- wrapper types: `GDKResult`, `GDKUsers`, `GDKUser`, `GDKGameUI`, `GDKAccessibility`, `GDKClosedCaptionProperties`, `GDKAchievements`, `GDKAchievement`, `GDKPackage`, `GDKPackageMount`, `GDKPackageResourcePack`, `GDKStats`, `GDKLeaderboards`, `GDKLeaderboard`, `GDKLeaderboardColumn`, `GDKLeaderboardRow`, `GDKPrivacy`, `GDKPresence`, `GDKPresenceRecord`, `GDKSocial`, `GDKSocialFilter`, `GDKSocialGroup`, `GDKSocialUser`, `GDKStore`, `GDKStoreLicenseStatus`, `GDKProfile`, `GDKUserProfile`, `GDKStringVerify`, `GDKTitleStorage`, `GDKTitleStorageBlobMetadata`, `GDKTitleStorageBlobMetadataResult`, `GDKErrorReporting`, `GDKLauncher`, `GDKMultiplayerActivity`, `GDKMultiplayerActivityInfo`, `GDKCapture`, `GDKCaptureMetaData`, `GDKSystem`, `GDKDisplay`, `GDKDisplayTimeoutDeferral`, and `GDKActivation`
 - internal direct-await helpers: `GDKPendingSignal`, `GDKSignalXAsyncContext`
 - internal Xbox services scaffold: `GDKXboxServices`
 
@@ -32,22 +26,15 @@ The current native implementation is the runtime/users/accessibility/achievement
 It owns:
 
 - `GDKRuntime`
-- `GDKUsers`
-- `GDKAccessibility`
-- `GDKAchievements`
-- `GDKPresence`
-- `GDKSocial`
-- `GDKStore`
-- `GDKLauncher`
 - `GDKXboxServices`
+- service objects for `GDKUsers`, `GDKGameUI`, `GDKAccessibility`, `GDKAchievements`, `GDKPackage`, `GDKStats`, `GDKLeaderboards`, `GDKPrivacy`, `GDKPresence`, `GDKSocial`, `GDKStore`, `GDKProfile`, `GDKStringVerify`, `GDKTitleStorage`, `GDKErrorReporting`, `GDKLauncher`, `GDKMultiplayerActivity`, `GDKCapture`, `GDKSystem`, `GDKDisplay`, and `GDKActivation`
 
 Its responsibilities are:
 
 - runtime initialization
 - runtime shutdown
 - queue dispatch
-- service access
-- last-error exposure
+- service access through the 21 public namespaces
 - root-level runtime signals
 
 Current public shape:
@@ -58,12 +45,26 @@ Current public shape:
 - `is_initialized() -> bool`
 - `dispatch() -> int`
 - `get_users() -> GDKUsers`
+- `get_game_ui() -> GDKGameUI`
 - `get_accessibility() -> GDKAccessibility`
 - `get_achievements() -> GDKAchievements`
+- `get_package() -> GDKPackage`
+- `get_stats() -> GDKStats`
+- `get_leaderboards() -> GDKLeaderboards`
+- `get_privacy() -> GDKPrivacy`
 - `get_presence() -> GDKPresence`
 - `get_social() -> GDKSocial`
 - `get_store() -> GDKStore`
+- `get_profile() -> GDKProfile`
+- `get_string_verify() -> GDKStringVerify`
+- `get_title_storage() -> GDKTitleStorage`
+- `get_error_reporting() -> GDKErrorReporting`
 - `get_launcher() -> GDKLauncher`
+- `get_multiplayer_activity() -> GDKMultiplayerActivity`
+- `get_capture() -> GDKCapture`
+- `get_system() -> GDKSystem`
+- `get_display() -> GDKDisplay`
+- `get_activation() -> GDKActivation`
 
 ## Shared runtime: `GDKRuntime`
 
@@ -514,6 +515,40 @@ It currently exposes:
 The service has no native handle of its own; reads are direct calls to
 `XGameGetXboxTitleId`, `XSystemGetXboxLiveSandboxId`, and the Xbox services
 scaffold's cached SCID.
+
+## Display service
+
+`GDKDisplay` wraps PC-supported `XDisplay.h` display helpers.
+
+It currently exposes:
+
+- `try_enable_hdr_mode(preference)`
+- `acquire_timeout_deferral()`
+
+`try_enable_hdr_mode()` returns a `GDKResult` with HDR mode details. A
+successful `acquire_timeout_deferral()` returns a `GDKDisplayTimeoutDeferral`
+in `GDKResult.data`; releasing that wrapper calls the native timeout-deferral
+release path.
+
+## Activation service
+
+`GDKActivation` owns the addon's single native
+`XGameActivationRegisterForEvent` registration and fans protocol, file, and
+invite activation dictionaries out to script and interested services.
+
+It currently exposes:
+
+- `accept_pending_invite(invite_uri)`
+
+It emits:
+
+- `protocol_activated`
+- `file_activated`
+- `pending_invite_received`
+- `invite_accepted`
+
+`GDKMultiplayerActivity` listens to this service instead of registering a
+second native activation callback.
 
 ## Request flow
 

--- a/docs/gdk/sample-and-tests.md
+++ b/docs/gdk/sample-and-tests.md
@@ -11,18 +11,17 @@ See also:
 
 ## Sample projects
 
-> **No sample projects currently.** The repository is mid-revamp;
-> samples are returning in PR 3 of the tutorial-driven sample
-> series:
->
-> - `sample/tutorial_app/` — integrated tutorial chain (sign-in,
->   achievements, leaderboards, game saves, lobby, MPA, Party,
->   integration tech demo)
-> - `sample/tutorial_gameinput/` — standalone GameInput demo
->
-> Until then, [the tutorials](../tutorials/README.md) walk
-> through each surface in your own Godot project, and the test
-> hosts under `tests/godot/` exercise the addons end-to-end.
+The repository currently ships two tutorial-driven sample projects:
+
+- `sample\tutorial_app\` — integrated tutorial chain (sign-in, achievements,
+  leaderboards, game saves, lobby, Multiplayer Activity, Party, and the final
+  integration tech demo). The CMake build mirrors `godot_gdk`, `godot_playfab`,
+  and `godot_gdk_packaging` into this project.
+- `sample\tutorial_gameinput\` — standalone GameInput tutorial sample. It is
+  wired for the GameInput addon rather than the GDK runtime addon.
+
+The test hosts under `tests\godot\` remain the automated coverage projects;
+the sample projects are reader-facing tutorial references, not GUT hosts.
 
 ## Overview
 

--- a/docs/gdk/sample-setup.md
+++ b/docs/gdk/sample-setup.md
@@ -1,8 +1,10 @@
 # Godot GDK sample project setup
 
-The sample project needs your **Partner Center** credentials to work with
-Xbox Live services. You can configure everything through the in-editor
-**GDK Setup panel** or via a CLI script.
+The integrated tutorial sample needs your **Partner Center** credentials to
+work with Xbox Live services. The supported setup paths are the repo CLI script
+or manually editing the local config files and Project Settings. The
+`godot_gdk` editor plugin no longer docks a **GDK Setup** panel; it keeps the
+runtime autoload installed and registers the `Xbox GDK (PC)` export platform.
 
 ## Prerequisites
 
@@ -32,31 +34,41 @@ Xbox Live services. You can configure everything through the in-editor
 | Sandbox ID | Xbox Live Setup | `XDKS.1` |
 | Publisher CN | Product identity page | `CN=XXXXXXXX-XXXX-...` |
 
-## Option A: Configure in the Godot editor (recommended)
+## Option A: Configure via CLI (recommended)
 
-1. Build the addon and open your Godot project in the editor:
-   ```powershell
-   cmake --build build --preset debug
-   ```
-   Then launch your Godot 4.x editor and **Project → Open** the
-   `project.godot` of the project you are configuring.
-2. Find the **GDK Setup** panel in the bottom-right dock
-3. Enter your Partner Center values
-4. Click **Save Configuration** — this writes `sample_config.cfg` (used at
-   runtime by the sample's GDScript)
-5. Click **Apply to Export Preset** — this pushes the same values into the
-   export preset (used when packaging for distribution)
-
-The config file is gitignored, so your credentials stay local.
-
-## Option B: Configure via CLI
+From the repository root, build the mirrored sample addons and run the setup
+script:
 
 ```powershell
-.\tools\setup_sample.ps1
+cmake --build build --preset debug
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\setup_sample.ps1
 ```
 
-This prompts for each value and generates `sample_config.cfg`,
-`MicrosoftGame.config`, and updates `export_presets.cfg` in one step.
+The script prompts for each Partner Center value, derives the current-title
+SCID, then writes `sample\tutorial_app\sample_config.cfg` and
+`sample\tutorial_app\MicrosoftGame.config`. If `export_presets.cfg` already
+exists in that project, the script also updates the matching export-preset
+fields.
+
+The generated files are gitignored, so your credentials stay local.
+
+## Option B: Configure manually in the project
+
+1. Copy `sample\tutorial_app\sample_config.cfg.template` to
+   `sample\tutorial_app\sample_config.cfg` and fill in the Partner Center
+   values used by the tutorial scripts.
+2. Copy `sample\tutorial_app\MicrosoftGame.config.template` to
+   `sample\tutorial_app\MicrosoftGame.config` and replace the Title ID,
+   MSA App ID, Store ID, identity, publisher, and visual placeholders.
+3. Open `sample\tutorial_app\project.godot` in Godot. The committed project
+   already enables the `godot_gdk`, `godot_playfab`, and `godot_gdk_packaging`
+   plugins after the CMake build mirrors them into `sample\tutorial_app\addons\`.
+4. Review **Project → Project Settings** for `gdk/runtime/*` startup settings
+   and any PlayFab runtime values needed by the tutorial scenes.
+5. For editor-driven packaging, use **Project → Export… → Add… → Xbox GDK (PC)**.
+   For scripted packaging and sandbox actions, use the separate
+   `godot_gdk_packaging` addon (`addons\godot_gdk_packaging\gdkpkg.cmd` or its
+   top-level **GDK** editor menu).
 
 ## Set your PC sandbox
 
@@ -93,15 +105,17 @@ project.godot
   └─► addons/godot_gdk/runtime/gdk_bootstrap.gd
          reads gdk/runtime/* startup flags → initializes GDK / silent sign-in
 
-sample_config.cfg (single source of truth)
-  ├─► main.gd              reads achievement ID at runtime → unlock button
-  ├─► export preset        auto-populates defaults → used during export
-  └─► MicrosoftGame.config generated at export time from preset values
+sample_config.cfg (local tutorial values)
+  └─► tutorial scenes read achievement and sandbox-related sample settings
+
+MicrosoftGame.config
+  └─► packaging/export flows read title identity and shell visuals
 ```
 
-The **GDK Setup panel** and **export dialog** both read from
-`sample_config.cfg`. If a value is set in the export preset, it takes priority.
-If it's blank, the config file value is used as a fallback.
+The CLI script writes both generated files from the same prompts. When you edit
+manually, keep `sample_config.cfg`, `MicrosoftGame.config`, and any export
+preset values aligned yourself; there is no docked `GDK Setup` panel in the
+current runtime addon.
 
 ## Testing achievements
 

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -227,7 +227,7 @@ Shutdown must be queue-safe and op-safe:
 - active one-shot requests should be retained by the runtime until they reach a terminal state
 - queue termination should surface cancellation as failed `GDKResult` values rather than silently dropping callbacks
 - no service cache or Godot object should be mutated after the runtime starts teardown
-- `GDK.shutdown()` should clean up services first, then terminate and close the shared queue, then uninitialize the GDK runtime
+- `GDK.shutdown()` should clean up services first, then terminate and close the shared queue. `XGameRuntimeUninitialize()` is process-lifetime cleanup that runs once when the extension is torn down.
 
 #### Core behavior
 
@@ -410,7 +410,7 @@ and `GDK.achievements.runtime_error`).
 | Public surface | Native API(s) | Notes |
 | --- | --- | --- |
 | `GDK.initialize()` | `XGameRuntimeInitialize`, `XTaskQueueCreate` | Creates the shared task queue and runtime bootstrap state used by all one-shot completion signals and service-owned callback bridges. |
-| `GDK.shutdown()` | `XTaskQueueTerminate`, `XTaskQueueCloseHandle`, `XGameRuntimeUninitialize` | Service and user cleanup should run first; queue/runtime teardown happens last. |
+| `GDK.shutdown()` | `XTaskQueueTerminate`, `XTaskQueueCloseHandle` | Service and user cleanup runs first; queue teardown happens last. `XGameRuntimeUninitialize()` is intentionally reserved for extension teardown (`~GDKRuntime()`), not each shutdown cycle. |
 | `GDK.dispatch()` | `XTaskQueueDispatch`, `XblAchievementsManagerDoWork`, `XblSocialManagerDoWork`, `XErrorSetCallback` callback-drain bridge | Main-thread pump. Dispatch the completion port, translate native payloads into Godot objects, update caches, then emit signals. |
 | `GDK.launcher.launch_uri()` | `XLaunchUri` (`XLauncher.h`, `xgameruntime.lib`) | PC-supported URI launcher surface for app-to-app, Store, and Settings destinations. |
 | per-user Xbox services context | `XblContextCreateHandle`, `XblContextCloseHandle` | Create once for each admitted `GDKUser`; store inside the wrapper for achievements, stats, leaderboards, presence, and social calls. |
@@ -1023,19 +1023,10 @@ error_reported(result: GDKResult)
 | `gdk/runtime/embed_dispatch` | `true` | Dispatches GDK completions automatically from the main thread each frame. |
 | `gdk/runtime/auto_add_primary_user` | `false` | Starts a default local-user flow after initialization. |
 
-### Service flags
-
-| Setting | Default | Purpose |
-| --- | --- | --- |
-| `gdk/services/enable_achievements` | `true` | Registers and initializes the achievements service. |
-| `gdk/services/enable_stats` | `true` | Registers and initializes the stats service. |
-| `gdk/services/enable_leaderboards` | `true` | Registers and initializes the leaderboards service. |
-| `gdk/services/enable_privacy` | `true` | Registers and initializes the privacy service. |
-| `gdk/services/enable_presence` | `true` | Registers and initializes the presence service. |
-| `gdk/services/enable_social` | `true` | Registers and initializes the social service. |
-| `gdk/services/enable_profile` | `true` | Registers and initializes the profile service. |
-| `gdk/services/enable_string_verify` | `true` | Registers and initializes the string verification service. |
-| `gdk/services/enable_title_storage` | `true` | Registers and initializes the Title Storage service. |
+There are no `gdk/services/enable_*` Project Settings. The runtime settings
+above are the only `godot_gdk` settings registered by the addon; public service
+objects are constructed as part of the single `GDK` root singleton and are not
+gated by per-service enable flags.
 
 ## Build and packaging rules
 


### PR DESCRIPTION
## Summary

Audit B2 docs-only sweep for `godot_gdk` prose/spec drift. No runtime code, GDScript, or `doc_classes/*.xml` files are modified.

## Per-finding sign-off

1. **PresenceFilter fabricated enum names removed**
   - Fixed `docs/gdk/api-reference.md:612-621` to list real GDScript constants and enum values: `PRESENCE_FILTER_TITLE_OFFLINE` / `TITLE_OFFLINE`, `PRESENCE_FILTER_TITLE_ONLINE_OUTSIDE_TITLE` / `TITLE_ONLINE_OUTSIDE_TITLE`, `PRESENCE_FILTER_ALL_OFFLINE` / `ALL_OFFLINE`, `PRESENCE_FILTER_ALL_TITLE` / `ALL_TITLE`, and `PRESENCE_FILTER_ALL` / `ALL`.
   - Cross-checked `addons/godot_gdk/doc_classes/GDKSocialFilter.xml:50-73` and `addons/godot_gdk/src/gdk_social.cpp:321-328`.

2. **GDKPresenceRecord fabricated properties removed**
   - Fixed usage/properties in `docs/gdk/api-reference.md:475-508`; removed `gamertag`, `online`, and `presence_text` and documented `xuid`, `user_state`, `title_records`, `is_online()`, and `get_user_state_name()`.
   - Cross-checked `addons/godot_gdk/doc_classes/GDKPresenceRecord.xml:44-52` and `addons/godot_gdk/src/gdk_presence.cpp:478-493` / `:507-513`.

3. **GDKSocialUser fabricated properties removed**
   - Fixed `docs/gdk/api-reference.md:562-591`; removed `online`, `playing_title_id`, `title_name`, and `presence_text`; documented real properties plus real non-property getters.
   - Cross-checked `addons/godot_gdk/doc_classes/GDKSocialUser.xml:115-148` and `addons/godot_gdk/src/gdk_social.cpp:435-465`.

4. **Social return shapes corrected in async-system**
   - Fixed `docs/gdk/async-system.md:158-164`; `create_social_group*` and `get_group_users` now return `GDKResult` with `data` payloads.
   - Cross-checked `addons/godot_gdk/doc_classes/GDKSocial.xml:33-60`, `addons/godot_gdk/src/gdk_social.h:216-219`, and `addons/godot_gdk/src/gdk_social.cpp:906-1008`.

5. **Native runtime service set expanded and last-error claim removed**
   - Fixed `docs/gdk/native-runtime.md:14-18`, `:26-67`, and `:519-551` to document the live root + 21 public service namespaces, including display and activation.
   - Removed the stale root “last-error exposure” responsibility.
   - Cross-checked service construction/binding in `addons/godot_gdk/src/gdk.cpp:45-86` and `:126-174`, plus `addons/godot_gdk/doc_classes/GDK.xml:42-167` / `:170-232`.

6. **Sample setup no longer points at a docked GDK Setup panel**
   - Fixed `docs/gdk/sample-setup.md:3-7`, `:37-71`, and `:115-118` to describe CLI/manual config, Project Settings, the export platform, and `godot_gdk_packaging`.
   - Cross-checked `addons/godot_gdk/editor/gdk_editor_plugin.gd:13-21`; `git grep -n -E "add_control_to_dock|add_control_to_container" -- addons\\godot_gdk\\editor` returns no matches.

7. **Shutdown docs no longer say `shutdown()` uninitializes XGameRuntime**
   - Fixed `docs/gdk/async-system.md:482-492` and the matching spec mapping in `spec/gdext-gdk.md:227-230` / `:410-414`.
   - Cross-checked `addons/godot_gdk/src/gdk_runtime.cpp:23-36` and `:117-119`.

8. **Sample status updated**
   - Fixed `docs/gdk/sample-and-tests.md:14-24` and `docs/gdk/build-and-loading.md:64-74` / `:168-174` to list the live tutorial samples.
   - Live `public/main` differs from the audit note: legacy `sample/gdk_demo`, `sample/gdk_launch_point`, and `sample/multiplayer_pong` are absent. Cross-checked `CMakeLists.txt:30-71` and the committed `sample/tutorial_app` + `sample/tutorial_gameinput` directories.

9. **Unused service Project Settings removed from spec**
   - Fixed `spec/gdext-gdk.md:1026-1029`; removed the fabricated `gdk/services/enable_*` table.
   - Cross-checked `addons/godot_gdk/src/register_types.cpp:41-72`; only the three `gdk/runtime/*` settings are registered. `git grep -n "gdk/services/enable_" -- addons\\godot_gdk\\src` returns no matches.

10. **Editor export-platform docs reconciled**
    - Fixed `docs/gdk/build-and-loading.md:59-62` to match `docs/gdk/editor-tools.md:19-22`, `:34-37`, and `:60-63`: the runtime editor plugin still registers `Xbox GDK (PC)` but does not dock the old setup panel.
    - Cross-checked `addons/godot_gdk/editor/gdk_editor_plugin.gd:13-21`.

## Validation

- `git diff --check` passed.
- No `.gd`, `.cpp`, `.h`, or `addons/godot_gdk/doc_classes/*.xml` files changed.
- No code-classes (`doc_classes/*.xml`) modified — they are 100% method-coverage correct per the audit synthesis.
- Built/imported the needed GDK/PlayFab mirrors:
  - `git submodule update --init --recursive`
  - `cmake --preset default`
  - `cmake --build build --preset debug --target godot_gdk godot_playfab`
  - Godot `--headless --import` for `sample\tutorial_app` and GDK/PlayFab test hosts.
- GDK/docs-relevant parse gate passed:
  - `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1 -Projects addons,sample\tutorial_app,tests\godot\gdk,tests\godot\playfab`
- Full default build/parse gate note: `cmake --build build --preset debug` is currently blocked by an unrelated compile error in unmodified `addons\godot_gameinput\src\gameinput_mapper.cpp`; the full parse gate then only fails on `sample\tutorial_gameinput` because the GameInput addon mirror/classes are unavailable. `check_gd_scripts_headless.ps1 -ExcludeProjects sample\tutorial_gameinput,tests\godot\gameinput` passes.
- Live tests skipped; docs-only change with no runtime behavior changes and no live write coverage.
