### PR TITLE
pf-tests: backfill zero-coverage surface + cloud-script assertion + mp_orchestrator scenario ports (audit A6)

### DIFF
--- a/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_invalid_connection_string.gd
+++ b/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_invalid_connection_string.gd
@@ -1,0 +1,45 @@
+## C5a: invalid lobby connection strings fail without leaving a tracked lobby.
+##
+## Ports the legacy `invalid connection string typed failure` scenario from
+## tools/run_playfab_multiplayer_live.ps1.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "lobby.join.invalid_connection_string"
+const SCENARIO_NAME: String = "Invalid lobby connection string returns a typed failure"
+const CATEGORY: String = "lobby"
+const PRIORITY: String = "P0"
+const REQUIRED_ROLES: Array[String] = ["guest"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available"]
+const TIMEOUT_SEC: int = 120
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var guest = orch.client("guest")
+	var signed: Dictionary = await guest.send("sign_in", {}, 60_000)
+	var err: Variant = assert_ok(signed, "guest sign_in failed")
+	if err != null:
+		return err
+
+	var joined: Dictionary = await guest.send("join_lobby", {
+		"as": "invalid",
+		"connection_string": "not-a-valid-playfab-lobby-connection-string",
+	}, 60_000)
+	if bool(joined.get("ok", false)):
+		return fail("join_lobby unexpectedly accepted an invalid connection string", { "response": joined })
+	var code: String = String(joined.get("error", {}).get("code", ""))
+	if code.is_empty() or code == "timeout":
+		return fail("join_lobby invalid connection string did not return a typed non-timeout error", { "response": joined })
+
+	var snapshot: Dictionary = await guest.send("get_lobby_snapshot", { "handle": "invalid" }, 15_000)
+	if bool(snapshot.get("ok", false)):
+		return fail("failed join left an invalid lobby handle tracked", { "snapshot": snapshot })
+	err = assert_eq(String(snapshot.get("error", {}).get("code", "")), "unknown_handle", "invalid join should not track a lobby handle")
+	if err != null:
+		return err
+
+	return ok({ "error_code": code })

--- a/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_leave_third_member.gd
+++ b/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_leave_third_member.gd
@@ -1,0 +1,117 @@
+## C5a: guest2 leaves a three-member lobby and both survivors converge.
+##
+## Ports the legacy `third member leave propagation` scenario.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "lobby.leave.third_member"
+const SCENARIO_NAME: String = "Third member leave propagates to host and guest"
+const CATEGORY: String = "lobby"
+const PRIORITY: String = "P0"
+const REQUIRED_ROLES: Array[String] = ["host", "guest", "guest2"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available", "multi_host_processes"]
+const TIMEOUT_SEC: int = 240
+
+const HANDLE := "tri_lobby"
+const CONVERGENCE_TIMEOUT_MS: int = 45_000
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var host = orch.client("host")
+	var guest = orch.client("guest")
+	var guest2 = orch.client("guest2")
+	var roster: Array = [
+		{ "client": host, "label": "host" },
+		{ "client": guest, "label": "guest" },
+		{ "client": guest2, "label": "guest2" },
+	]
+	var err: Variant = await _sign_in_roster(roster)
+	if err != null:
+		return err
+
+	var created: Dictionary = await host.send("create_lobby", {
+		"as": HANDLE,
+		"max_players": 3,
+		"access_policy": 0,
+		"lobby_properties": { "scenario": "leave_third_member" },
+		"member_properties": { "role": "host" },
+	}, 60_000)
+	err = assert_ok(created, "host create_lobby failed")
+	if err != null:
+		return err
+	var connection_string: String = String(created.get("result", {}).get("lobby", {}).get("connection_string", ""))
+	if connection_string.is_empty():
+		return fail("create_lobby returned empty connection_string", { "result": created.get("result", {}) })
+
+	for label in ["guest", "guest2"]:
+		var joined: Dictionary = await orch.client(label).send("join_lobby", {
+			"as": HANDLE,
+			"connection_string": connection_string,
+			"member_properties": { "role": label },
+		}, 60_000)
+		err = assert_ok(joined, "%s join_lobby failed" % label)
+		if err != null:
+			return err
+
+	err = await _wait_roles_for_count(roster, 3, true)
+	if err != null:
+		return err
+
+	var left: Dictionary = await guest2.send("leave_lobby", { "handle": HANDLE }, 30_000)
+	err = assert_ok(left, "guest2 leave_lobby failed")
+	if err != null:
+		return err
+
+	var survivors: Array = [
+		{ "client": host, "label": "host" },
+		{ "client": guest, "label": "guest" },
+	]
+	err = await _wait_roles_for_count(survivors, 2, false)
+	if err != null:
+		return err
+	return ok({ "final_member_count": 2 })
+
+
+func _sign_in_roster(roster: Array) -> Variant:
+	for entry in roster:
+		var signed: Dictionary = await entry["client"].send("sign_in", {}, 60_000)
+		var err: Variant = assert_ok(signed, "%s sign_in failed" % entry["label"])
+		if err != null:
+			return err
+	return null
+
+
+func _wait_roles_for_count(roster: Array, expected_count: int, expect_guest2: bool) -> Variant:
+	var deadline_ms: int = Time.get_ticks_msec() + CONVERGENCE_TIMEOUT_MS
+	var last_counts: Dictionary = {}
+	var last_members: Dictionary = {}
+	while Time.get_ticks_msec() < deadline_ms:
+		var all_match: bool = true
+		for entry in roster:
+			var snap: Dictionary = await entry["client"].send("get_lobby_snapshot", { "handle": HANDLE }, 15_000)
+			if not bool(snap.get("ok", false)):
+				return fail("%s get_lobby_snapshot during leave convergence failed" % entry["label"], { "response": snap })
+			var lobby: Dictionary = snap.get("result", {}).get("lobby", {})
+			var count: int = int(lobby.get("member_count", -1))
+			var members: Array = lobby.get("members", [])
+			last_counts[entry["label"]] = count
+			last_members[entry["label"]] = members
+			if count != expected_count:
+				all_match = false
+			if _has_member_role(members, "guest2") != expect_guest2:
+				all_match = false
+		if all_match:
+			return null
+	return fail("lobby membership did not converge to expected third-member state within %dms" % CONVERGENCE_TIMEOUT_MS, { "expected_count": expected_count, "expect_guest2": expect_guest2, "last_counts": last_counts, "last_members": last_members })
+
+
+func _has_member_role(members: Array, role: String) -> bool:
+	for member in members:
+		var props: Dictionary = member.get("properties", {})
+		if String(props.get("role", "")) == role:
+			return true
+	return false

--- a/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_member_property_propagation_three_clients.gd
+++ b/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_member_property_propagation_three_clients.gd
@@ -1,0 +1,106 @@
+## C5a: guest member properties propagate to every lobby member.
+##
+## Ports the legacy `member property propagation` scenario with three roles.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "lobby.properties.member.propagation"
+const SCENARIO_NAME: String = "Member property update propagates to host, guest, and guest2"
+const CATEGORY: String = "lobby"
+const PRIORITY: String = "P0"
+const REQUIRED_ROLES: Array[String] = ["host", "guest", "guest2"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available", "multi_host_processes"]
+const TIMEOUT_SEC: int = 240
+
+const HANDLE := "tri_lobby"
+const MEMBER_CONVERGENCE_TIMEOUT_MS: int = 45_000
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var host = orch.client("host")
+	var guest = orch.client("guest")
+	var guest2 = orch.client("guest2")
+	var roster: Array = [
+		{ "client": host, "label": "host" },
+		{ "client": guest, "label": "guest" },
+		{ "client": guest2, "label": "guest2" },
+	]
+	var err: Variant = await _sign_in_roster(roster)
+	if err != null:
+		return err
+
+	var created: Dictionary = await host.send("create_lobby", {
+		"as": HANDLE,
+		"max_players": 3,
+		"access_policy": 0,
+		"lobby_properties": { "scenario": "member_property_propagation" },
+		"member_properties": { "role": "host" },
+	}, 60_000)
+	err = assert_ok(created, "host create_lobby failed")
+	if err != null:
+		return err
+	var connection_string: String = String(created.get("result", {}).get("lobby", {}).get("connection_string", ""))
+	if connection_string.is_empty():
+		return fail("create_lobby returned empty connection_string", { "result": created.get("result", {}) })
+
+	for label in ["guest", "guest2"]:
+		var joined: Dictionary = await orch.client(label).send("join_lobby", {
+			"as": HANDLE,
+			"connection_string": connection_string,
+			"member_properties": { "role": label },
+		}, 60_000)
+		err = assert_ok(joined, "%s join_lobby failed" % label)
+		if err != null:
+			return err
+
+	var set_resp: Dictionary = await guest.send("set_member_properties", {
+		"handle": HANDLE,
+		"properties": { "role": "guest", "ready": "true" },
+	}, 30_000)
+	err = assert_ok(set_resp, "guest set_member_properties failed")
+	if err != null:
+		return err
+
+	err = await _wait_all_roles_for_member_property(roster, "guest", "ready", "true")
+	if err != null:
+		return err
+	return ok({ "member_role": "guest", "ready": "true" })
+
+
+func _sign_in_roster(roster: Array) -> Variant:
+	for entry in roster:
+		var signed: Dictionary = await entry["client"].send("sign_in", {}, 60_000)
+		var err: Variant = assert_ok(signed, "%s sign_in failed" % entry["label"])
+		if err != null:
+			return err
+	return null
+
+
+func _wait_all_roles_for_member_property(roster: Array, role: String, key: String, expected_value: String) -> Variant:
+	var deadline_ms: int = Time.get_ticks_msec() + MEMBER_CONVERGENCE_TIMEOUT_MS
+	var last_members: Dictionary = {}
+	while Time.get_ticks_msec() < deadline_ms:
+		var all_match: bool = true
+		for entry in roster:
+			var snap: Dictionary = await entry["client"].send("get_lobby_snapshot", { "handle": HANDLE }, 15_000)
+			if not bool(snap.get("ok", false)):
+				return fail("%s get_lobby_snapshot during member-property convergence failed" % entry["label"], { "response": snap })
+			var members: Array = snap.get("result", {}).get("lobby", {}).get("members", [])
+			last_members[entry["label"]] = members
+			if not _member_has_property(members, role, key, expected_value):
+				all_match = false
+		if all_match:
+			return null
+	return fail("member property did not propagate to all roles within %dms" % MEMBER_CONVERGENCE_TIMEOUT_MS, { "last_members": last_members, "role": role, "key": key, "expected": expected_value })
+
+
+func _member_has_property(members: Array, role: String, key: String, expected_value: String) -> bool:
+	for member in members:
+		var props: Dictionary = member.get("properties", {})
+		if String(props.get("role", "")) == role and String(props.get(key, "")) == expected_value:
+			return true
+	return false

--- a/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_owner_migration_after_host_leave.gd
+++ b/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_owner_migration_after_host_leave.gd
@@ -1,0 +1,91 @@
+## C5a: host leaves a two-member lobby and ownership migrates to guest.
+##
+## Ports the legacy `owner migration after host leave` scenario.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "lobby.leave.host.owner_migration"
+const SCENARIO_NAME: String = "Host leave migrates lobby ownership to guest"
+const CATEGORY: String = "lobby"
+const PRIORITY: String = "P0"
+const REQUIRED_ROLES: Array[String] = ["host", "guest"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available", "multi_host_processes"]
+const TIMEOUT_SEC: int = 240
+
+const HANDLE := "shared_lobby"
+const OWNER_CONVERGENCE_TIMEOUT_MS: int = 60_000
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var host = orch.client("host")
+	var guest = orch.client("guest")
+
+	var host_signed: Dictionary = await host.send("sign_in", {}, 60_000)
+	var err: Variant = assert_ok(host_signed, "host sign_in failed")
+	if err != null:
+		return err
+	var guest_signed: Dictionary = await guest.send("sign_in", {}, 60_000)
+	err = assert_ok(guest_signed, "guest sign_in failed")
+	if err != null:
+		return err
+	var guest_entity_id: String = String(guest_signed.get("result", {}).get("entity_key", {}).get("id", ""))
+	if guest_entity_id.is_empty():
+		return fail("guest sign_in did not return entity_key.id", { "sign_in": guest_signed })
+
+	var created: Dictionary = await host.send("create_lobby", {
+		"as": HANDLE,
+		"max_players": 2,
+		"access_policy": 0,
+		"lobby_properties": { "scenario": "owner_migration_after_host_leave" },
+		"member_properties": { "role": "host" },
+	}, 60_000)
+	err = assert_ok(created, "host create_lobby failed")
+	if err != null:
+		return err
+	var connection_string: String = String(created.get("result", {}).get("lobby", {}).get("connection_string", ""))
+	if connection_string.is_empty():
+		return fail("create_lobby returned empty connection_string", { "result": created.get("result", {}) })
+
+	var joined: Dictionary = await guest.send("join_lobby", {
+		"as": HANDLE,
+		"connection_string": connection_string,
+		"member_properties": { "role": "guest" },
+	}, 60_000)
+	err = assert_ok(joined, "guest join_lobby failed")
+	if err != null:
+		return err
+
+	err = await _wait_guest_owner(guest, "", 2)
+	if err != null:
+		return err
+
+	var left: Dictionary = await host.send("leave_lobby", { "handle": HANDLE }, 30_000)
+	err = assert_ok(left, "host leave_lobby failed")
+	if err != null:
+		return err
+
+	err = await _wait_guest_owner(guest, guest_entity_id, 1)
+	if err != null:
+		return err
+	return ok({ "new_owner_entity_id": guest_entity_id })
+
+
+func _wait_guest_owner(guest, expected_owner_id: String, expected_count: int) -> Variant:
+	var deadline_ms: int = Time.get_ticks_msec() + OWNER_CONVERGENCE_TIMEOUT_MS
+	var last_owner_id: String = ""
+	var last_count: int = -1
+	while Time.get_ticks_msec() < deadline_ms:
+		var snap: Dictionary = await guest.send("get_lobby_snapshot", { "handle": HANDLE }, 15_000)
+		if not bool(snap.get("ok", false)):
+			return fail("guest get_lobby_snapshot during owner convergence failed", { "response": snap })
+		var lobby: Dictionary = snap.get("result", {}).get("lobby", {})
+		last_owner_id = String(lobby.get("owner_entity_key", {}).get("id", ""))
+		last_count = int(lobby.get("member_count", -1))
+		var owner_matches: bool = expected_owner_id.is_empty() or last_owner_id == expected_owner_id
+		if owner_matches and last_count == expected_count:
+			return null
+	return fail("guest snapshot never converged to expected owner/count within %dms" % OWNER_CONVERGENCE_TIMEOUT_MS, { "expected_owner_id": expected_owner_id, "last_owner_id": last_owner_id, "expected_count": expected_count, "last_count": last_count })

--- a/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_property_propagation_three_clients.gd
+++ b/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_property_propagation_three_clients.gd
@@ -1,0 +1,100 @@
+## C5a: host-set lobby properties propagate to all three members.
+##
+## Ports the legacy `lobby property propagation` scenario with three roles.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "lobby.properties.lobby.propagation"
+const SCENARIO_NAME: String = "Lobby property update propagates to host, guest, and guest2"
+const CATEGORY: String = "lobby"
+const PRIORITY: String = "P0"
+const REQUIRED_ROLES: Array[String] = ["host", "guest", "guest2"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available", "multi_host_processes"]
+const TIMEOUT_SEC: int = 240
+
+const HANDLE := "tri_lobby"
+const PROPERTY_CONVERGENCE_TIMEOUT_MS: int = 45_000
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var host = orch.client("host")
+	var guest = orch.client("guest")
+	var guest2 = orch.client("guest2")
+	var roster: Array = [
+		{ "client": host, "label": "host" },
+		{ "client": guest, "label": "guest" },
+		{ "client": guest2, "label": "guest2" },
+	]
+	var err: Variant = await _sign_in_roster(roster)
+	if err != null:
+		return err
+
+	var created: Dictionary = await host.send("create_lobby", {
+		"as": HANDLE,
+		"max_players": 3,
+		"access_policy": 0,
+		"lobby_properties": { "scenario": "lobby_property_propagation", "phase": "created" },
+		"member_properties": { "role": "host" },
+	}, 60_000)
+	err = assert_ok(created, "host create_lobby failed")
+	if err != null:
+		return err
+	var connection_string: String = String(created.get("result", {}).get("lobby", {}).get("connection_string", ""))
+	if connection_string.is_empty():
+		return fail("create_lobby returned empty connection_string", { "result": created.get("result", {}) })
+
+	for label in ["guest", "guest2"]:
+		var joined: Dictionary = await orch.client(label).send("join_lobby", {
+			"as": HANDLE,
+			"connection_string": connection_string,
+			"member_properties": { "role": label },
+		}, 60_000)
+		err = assert_ok(joined, "%s join_lobby failed" % label)
+		if err != null:
+			return err
+
+	var expected: Dictionary = { "phase": "propagated", "mode": "expanded" }
+	var set_resp: Dictionary = await host.send("set_lobby_properties", {
+		"handle": HANDLE,
+		"properties": expected,
+	}, 30_000)
+	err = assert_ok(set_resp, "host set_lobby_properties failed")
+	if err != null:
+		return err
+
+	err = await _wait_all_roles_for_lobby_properties(roster, expected)
+	if err != null:
+		return err
+	return ok({ "properties": expected })
+
+
+func _sign_in_roster(roster: Array) -> Variant:
+	for entry in roster:
+		var signed: Dictionary = await entry["client"].send("sign_in", {}, 60_000)
+		var err: Variant = assert_ok(signed, "%s sign_in failed" % entry["label"])
+		if err != null:
+			return err
+	return null
+
+
+func _wait_all_roles_for_lobby_properties(roster: Array, expected: Dictionary) -> Variant:
+	var deadline_ms: int = Time.get_ticks_msec() + PROPERTY_CONVERGENCE_TIMEOUT_MS
+	var last_props: Dictionary = {}
+	while Time.get_ticks_msec() < deadline_ms:
+		var all_match: bool = true
+		for entry in roster:
+			var snap: Dictionary = await entry["client"].send("get_lobby_snapshot", { "handle": HANDLE }, 15_000)
+			if not bool(snap.get("ok", false)):
+				return fail("%s get_lobby_snapshot during property convergence failed" % entry["label"], { "response": snap })
+			var props: Dictionary = snap.get("result", {}).get("lobby", {}).get("properties", {})
+			last_props[entry["label"]] = props
+			for key in expected.keys():
+				if String(props.get(key, "")) != String(expected[key]):
+					all_match = false
+		if all_match:
+			return null
+	return fail("lobby properties did not propagate to all roles within %dms" % PROPERTY_CONVERGENCE_TIMEOUT_MS, { "last_props": last_props, "expected": expected })

--- a/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_search_no_results_isolation.gd
+++ b/tests/godot/mp_orchestrator/scenarios/lobby/c5_lobby_search_no_results_isolation.gd
@@ -1,0 +1,61 @@
+## C5a: observer search with a non-matching filter returns no host lobby.
+##
+## Ports the legacy `search no-results isolation` scenario.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "lobby.search.no_results.isolation"
+const SCENARIO_NAME: String = "Search filter that excludes created lobby returns no results"
+const CATEGORY: String = "lobby"
+const PRIORITY: String = "P1"
+const REQUIRED_ROLES: Array[String] = ["host", "observer"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available", "multi_host_processes"]
+const TIMEOUT_SEC: int = 180
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var host = orch.client("host")
+	var observer = orch.client("observer")
+
+	var host_signed: Dictionary = await host.send("sign_in", {}, 60_000)
+	var err: Variant = assert_ok(host_signed, "host sign_in failed")
+	if err != null:
+		return err
+	var observer_signed: Dictionary = await observer.send("sign_in", {}, 60_000)
+	err = assert_ok(observer_signed, "observer sign_in failed")
+	if err != null:
+		return err
+
+	var unique_tag: String = "c5-no-results-%d" % Time.get_unix_time_from_system()
+	var created: Dictionary = await host.send("create_lobby", {
+		"as": "search_target",
+		"max_players": 2,
+		"access_policy": 0,
+		"search_properties": { "string_key1": unique_tag },
+		"lobby_properties": { "scenario": "search_no_results_isolation" },
+	}, 60_000)
+	err = assert_ok(created, "host create_lobby failed")
+	if err != null:
+		return err
+	var lobby_id: String = String(created.get("result", {}).get("lobby", {}).get("lobby_id", ""))
+	if lobby_id.is_empty():
+		return fail("create_lobby returned empty lobby_id", { "result": created.get("result", {}) })
+
+	var missing_filter: String = "string_key1 eq '%s-missing'" % unique_tag
+	var search: Dictionary = await observer.send("search_lobbies", {
+		"filter": missing_filter,
+		"max_results": 10,
+	}, 30_000)
+	err = assert_ok(search, "observer search_lobbies failed")
+	if err != null:
+		return err
+
+	var lobbies: Array = search.get("result", {}).get("lobbies", [])
+	for entry in lobbies:
+		if String(entry.get("lobby_id", "")) == lobby_id:
+			return fail("search returned a lobby excluded by the filter", { "filter": missing_filter, "lobby_id": lobby_id, "results": lobbies })
+	return ok({ "filter": missing_filter, "result_count": lobbies.size() })

--- a/tests/godot/mp_orchestrator/scenarios/match/c5_two_player_match_complete.gd
+++ b/tests/godot/mp_orchestrator/scenarios/match/c5_two_player_match_complete.gd
@@ -1,0 +1,97 @@
+## C5a: two clients create tickets in the same queue and both reach matched.
+##
+## Ports the legacy `two-player match completion` scenario. Arranged-lobby join
+## remains deferred until the mp_test_client exposes a join_arranged_lobby op.
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const SCENARIO_ID: String = "match.ticket.two_player_match.complete"
+const SCENARIO_NAME: String = "Two players in the same queue both reach matched"
+const CATEGORY: String = "match"
+const PRIORITY: String = "P0"
+const REQUIRED_ROLES: Array[String] = ["host", "guest"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_multiplayer_available", "matchmaking_queue_configured", "multi_host_processes"]
+const TIMEOUT_SEC: int = 300
+
+
+func run(orch) -> Dictionary:
+	if orch.env("LIVE_TESTS", "") != "1":
+		return skip("LIVE_TESTS != 1")
+	if orch.env("PLAYFAB_TITLE_ID", "").is_empty():
+		return skip("PLAYFAB_TITLE_ID not set")
+
+	var queue_name: String = orch.env("PLAYFAB_MULTIPLAYER_MATCH_QUEUE", "")
+	if queue_name.is_empty():
+		return skip("PLAYFAB_MULTIPLAYER_MATCH_QUEUE not set")
+
+	var host = orch.client("host")
+	var guest = orch.client("guest")
+
+	var host_signed: Dictionary = await host.send("sign_in", {}, 60_000)
+	var err: Variant = assert_ok(host_signed, "host sign_in failed")
+	if err != null:
+		return err
+	var guest_signed: Dictionary = await guest.send("sign_in", {}, 60_000)
+	err = assert_ok(guest_signed, "guest sign_in failed")
+	if err != null:
+		return err
+
+	var run_tag: String = "two-player-%d" % Time.get_unix_time_from_system()
+	var host_created: Dictionary = await host.send("create_match_ticket", {
+		"as": "ticket",
+		"queue_name": queue_name,
+		"timeout_seconds": 120,
+		"attributes": { "scenario": "two_player_match", "run_id": run_tag, "role": "host" },
+	}, 60_000)
+	err = assert_ok(host_created, "host create_match_ticket failed")
+	if err != null:
+		return err
+	var guest_created: Dictionary = await guest.send("create_match_ticket", {
+		"as": "ticket",
+		"queue_name": queue_name,
+		"timeout_seconds": 120,
+		"attributes": { "scenario": "two_player_match", "run_id": run_tag, "role": "guest" },
+	}, 60_000)
+	err = assert_ok(guest_created, "guest create_match_ticket failed")
+	if err != null:
+		return err
+
+	var host_ticket_id: String = String(host_created.get("result", {}).get("ticket", {}).get("ticket_id", ""))
+	var guest_ticket_id: String = String(guest_created.get("result", {}).get("ticket", {}).get("ticket_id", ""))
+	if host_ticket_id.is_empty() or guest_ticket_id.is_empty():
+		return fail("create_match_ticket returned an empty ticket_id", { "host": host_created.get("result", {}), "guest": guest_created.get("result", {}) })
+
+	var host_matched: Dictionary = await host.send("wait_match_ticket", {
+		"handle": "ticket",
+		"status_name": "matched",
+		"timeout_ms": 180_000,
+	}, 190_000)
+	err = assert_ok(host_matched, "host wait_match_ticket(matched) failed")
+	if err != null:
+		return err
+	var guest_matched: Dictionary = await guest.send("wait_match_ticket", {
+		"handle": "ticket",
+		"status_name": "matched",
+		"timeout_ms": 180_000,
+	}, 190_000)
+	err = assert_ok(guest_matched, "guest wait_match_ticket(matched) failed")
+	if err != null:
+		return err
+
+	var host_ticket: Dictionary = host_matched.get("result", {}).get("ticket", {})
+	var guest_ticket: Dictionary = guest_matched.get("result", {}).get("ticket", {})
+	var host_match_id: String = String(host_ticket.get("match_id", ""))
+	var guest_match_id: String = String(guest_ticket.get("match_id", ""))
+	if host_match_id.is_empty() or guest_match_id.is_empty():
+		return fail("matched tickets did not include match_id", { "host_ticket": host_ticket, "guest_ticket": guest_ticket })
+	err = assert_eq(host_match_id, guest_match_id, "host and guest matched into the same match_id")
+	if err != null:
+		return err
+	if String(host_ticket.get("arranged_lobby_connection_string", "")).is_empty() or String(guest_ticket.get("arranged_lobby_connection_string", "")).is_empty():
+		return fail("matched tickets did not include arranged lobby connection strings", { "host_ticket": host_ticket, "guest_ticket": guest_ticket })
+
+	return ok({
+		"queue_name": queue_name,
+		"host_ticket_id": host_ticket_id,
+		"guest_ticket_id": guest_ticket_id,
+		"match_id": host_match_id,
+	})

--- a/tests/godot/playfab/tests/test_api_services_live.gd
+++ b/tests/godot/playfab/tests/test_api_services_live.gd
@@ -292,6 +292,19 @@ func _assert_cloud_script_reaches_service(playfab: Object, playfab_user, api_fix
 			"generate_play_stream_event": false,
 		},
 		"PlayFab.cloud_script.execute_cloud_script_async")
+	assert_not_null(result, "PlayFab.cloud_script.execute_cloud_script_async returns PlayFabResult")
+	if result == null:
+		return
+	assert_ne(result.code, "playfab_api_start_failed", "CloudScript request reached PlayFab service instead of failing at API start")
+	assert_ne(result.code, "invalid_request", "CloudScript request marshalled before reaching PlayFab service")
+	if result.ok:
+		assert_true(result.data is Dictionary, "CloudScript service response includes data Dictionary")
+		if result.data is Dictionary:
+			var response: Dictionary = result.data
+			assert_eq(str(response.get("function_name", "")), function_name, "CloudScript response echoes requested function_name")
+			assert_true(response.has("error") or response.has("function_result") or response.has("logs"), "CloudScript response includes service payload fields")
+	else:
+		assert_true(str(result.message).length() > 0, "CloudScript service failure includes message")
 
 func _assert_api_ok(service: Object, method_name: String, playfab_user, request, label: String):
 	var result = await _call_api(service, method_name, playfab_user, request, label)

--- a/tests/godot/playfab/tests/test_core.gd
+++ b/tests/godot/playfab/tests/test_core.gd
@@ -226,6 +226,28 @@ func test_initialize_rejects_blank_title_id() -> void:
 		playfab.initialized.disconnect(initialized_handler)
 
 
+func test_initialize_reports_already_initialized() -> void:
+	if pending_unless_playfab_available():
+		return
+	var playfab = get_playfab()
+
+	reset_playfab_runtime()
+
+	var original_title_id = ProjectSettings.get_setting(PLAYFAB_TITLE_ID_SETTING, "")
+	var original_endpoint = ProjectSettings.get_setting(PLAYFAB_ENDPOINT_SETTING, "")
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, REARM_TEST_TITLE_ID)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, "")
+
+	var first_result = playfab.initialize()
+	assert_playfab_result_ok(first_result, "PlayFab.initialize() first call for already_initialized branch")
+	if first_result != null and first_result.ok:
+		assert_playfab_result_error(playfab.initialize(), "already_initialized", "PlayFab.initialize() second call reports already_initialized")
+		playfab.shutdown()
+
+	_restore_playfab_runtime_settings(original_title_id, original_endpoint)
+	reset_playfab_runtime()
+
+
 func test_initialize_shutdown_rearms_runtime_lifecycle() -> void:
 	if pending_unless_playfab_available():
 		return

--- a/tests/godot/playfab/tests/test_leaderboards_live.gd
+++ b/tests/godot/playfab/tests/test_leaderboards_live.gd
@@ -9,9 +9,8 @@ extends "res://addons/godot_gdk_tests/playfab_test_base.gd"
 ##
 ## Eventual consistency: PlayFab leaderboards do not always reflect a freshly
 ## submitted score on the next read. We use `TestEnv.poll_until` with the
-## `playfab/tests/leaderboard_settle_msec` budget. On timeout we report
-## `pending(...)` rather than failing so transient propagation delays don't
-## churn the orchestrator.
+## `playfab/tests/leaderboard_settle_msec` budget; if that budget expires under
+## live coverage, the timeout is a real failure.
 ##
 ## Cleanup: client-side leaderboard deletion is not part of the public API,
 ## so live write tests rely on per-run unique tags (via metadata) and unique
@@ -77,7 +76,7 @@ func test_get_leaderboard_async_live() -> void:
 
 	var result = await await_completion(leaderboard_signal, _DEFAULT_OP_TIMEOUT_MSEC)
 	if result == null:
-		pending("get_leaderboard_async timed out.")
+		fail("get_leaderboard_async timed out.")
 		playfab.shutdown()
 		return
 	if not result.ok:
@@ -111,7 +110,7 @@ func test_get_leaderboard_around_user_async_live() -> void:
 
 	var result = await await_completion(around_signal, _DEFAULT_OP_TIMEOUT_MSEC)
 	if result == null:
-		pending("get_leaderboard_around_user_async timed out.")
+		fail("get_leaderboard_around_user_async timed out.")
 		playfab.shutdown()
 		return
 	if not result.ok:
@@ -141,7 +140,7 @@ func test_get_friend_leaderboard_async_live() -> void:
 
 	var result = await await_completion(friend_signal, _DEFAULT_OP_TIMEOUT_MSEC)
 	if result == null:
-		pending("get_friend_leaderboard_async timed out.")
+		fail("get_friend_leaderboard_async timed out.")
 		playfab.shutdown()
 		return
 	if not result.ok:
@@ -180,7 +179,7 @@ func test_submit_score_settles_in_around_user_query() -> void:
 
 	var submit_result = await await_completion(submit_signal, _DEFAULT_OP_TIMEOUT_MSEC)
 	if submit_result == null:
-		pending("submit_score_async timed out.")
+		fail("submit_score_async timed out.")
 		playfab.shutdown()
 		return
 	if not submit_result.ok:
@@ -216,7 +215,7 @@ func test_submit_score_settles_in_around_user_query() -> void:
 	if settled == null:
 		var settle_budget := int(ProjectSettings.get_setting(
 			"playfab/tests/leaderboard_settle_msec", 30000))
-		pending("leaderboard did not settle within %dms" % settle_budget)
+		fail("leaderboard did not settle within %dms" % settle_budget)
 		playfab.shutdown()
 		return
 

--- a/tests/godot/playfab/tests/test_multiplayer_contract.gd
+++ b/tests/godot/playfab/tests/test_multiplayer_contract.gd
@@ -77,6 +77,8 @@ func test_multiplayer_service_contract() -> void:
 	var detached_lobby = instantiate_class("PlayFabLobby")
 	if detached_lobby != null:
 		assert_has_signal_named(detached_lobby, "state_changed")
+		assert_has_method_named(detached_lobby, "is_owner")
+		assert_false(detached_lobby.is_owner(null), "Detached PlayFabLobby.is_owner(null) returns false")
 	assert_false(multiplayer.is_initialized(), "PlayFab.multiplayer starts uninitialized")
 	assert_eq(multiplayer.get_lobbies().size(), 0, "PlayFab.multiplayer starts with no tracked lobbies")
 	assert_eq(multiplayer.get_match_tickets().size(), 0, "PlayFab.multiplayer starts with no tracked tickets")
@@ -88,12 +90,18 @@ func test_multiplayer_config_and_wrapper_contract() -> void:
 	if lobby_config != null:
 		assert_eq(lobby_config.max_players, 8, "PlayFabLobbyConfig.max_players default")
 		assert_eq(lobby_config.access_policy, get_class_constant("PlayFabLobbyConfig", "ACCESS_POLICY_PRIVATE"), "PlayFabLobbyConfig.access_policy default")
+		assert_eq(lobby_config.owner_migration_policy, get_class_constant("PlayFabLobbyConfig", "OWNER_MIGRATION_AUTOMATIC"), "PlayFabLobbyConfig.owner_migration_policy default")
+		assert_false(lobby_config.restrict_invites_to_lobby_owner, "PlayFabLobbyConfig.restrict_invites_to_lobby_owner default")
 		lobby_config.max_players = 4
 		lobby_config.access_policy = get_class_constant("PlayFabLobbyConfig", "ACCESS_POLICY_PUBLIC")
+		lobby_config.owner_migration_policy = get_class_constant("PlayFabLobbyConfig", "OWNER_MIGRATION_MANUAL")
+		lobby_config.restrict_invites_to_lobby_owner = true
 		lobby_config.search_properties = {"string_key1": "contract"}
 		lobby_config.lobby_properties = {"map": "arena"}
 		lobby_config.member_properties = {"display_name": "tester"}
 		assert_eq(lobby_config.max_players, 4, "PlayFabLobbyConfig.max_players setter")
+		assert_eq(lobby_config.owner_migration_policy, get_class_constant("PlayFabLobbyConfig", "OWNER_MIGRATION_MANUAL"), "PlayFabLobbyConfig.owner_migration_policy setter")
+		assert_true(lobby_config.restrict_invites_to_lobby_owner, "PlayFabLobbyConfig.restrict_invites_to_lobby_owner setter")
 		assert_eq(lobby_config.search_properties.get("string_key1"), "contract", "PlayFabLobbyConfig.search_properties setter")
 
 	var join_config = instantiate_class("PlayFabLobbyJoinConfig")
@@ -174,6 +182,59 @@ func test_multiplayer_not_initialized_failures() -> void:
 		assert_has_method_named(detached_ticket, "cancel_async")
 		await _assert_signal_error(detached_ticket.refresh_async(), "invalid_match_ticket", "Detached PlayFabMatchTicket.refresh_async() reports invalid_match_ticket")
 		await _assert_signal_error(detached_ticket.cancel_async(), "invalid_match_ticket", "Detached PlayFabMatchTicket.cancel_async() reports invalid_match_ticket")
+
+
+func test_multiplayer_shutdown_async_explicit_await_uninitialized() -> void:
+	if pending_unless_playfab_available():
+		return
+
+	var playfab = get_playfab()
+	reset_playfab_runtime()
+	var multiplayer = playfab.get_multiplayer()
+	if multiplayer == null:
+		return
+
+	assert_playfab_result_ok(await await_completion(multiplayer.shutdown_async()), "await PlayFab.multiplayer.shutdown_async() while uninitialized")
+	assert_false(multiplayer.is_initialized(), "PlayFab.multiplayer remains uninitialized after explicit awaited shutdown")
+
+
+func test_multiplayer_initialize_reports_already_initialized() -> void:
+	if pending_unless_playfab_available():
+		return
+
+	var playfab = get_playfab()
+	reset_playfab_runtime()
+	var multiplayer = playfab.get_multiplayer()
+	if multiplayer == null:
+		return
+
+	var original_title_id = ProjectSettings.get_setting(PLAYFAB_TITLE_ID_SETTING, "")
+	var original_endpoint = ProjectSettings.get_setting(PLAYFAB_ENDPOINT_SETTING, "")
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, "00000")
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, "")
+
+	var init_result = playfab.initialize()
+	if init_result == null or not init_result.ok:
+		pending("PlayFab.multiplayer already_initialized branch skipped: PlayFab.initialize() failed: %s" % (init_result.message if init_result != null else "null"))
+		ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, original_title_id)
+		ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, original_endpoint)
+		reset_playfab_runtime()
+		return
+
+	var first_mp_init = await await_completion(multiplayer.initialize_async())
+	if first_mp_init == null or not first_mp_init.ok:
+		pending("PlayFab.multiplayer already_initialized branch skipped: initialize_async() failed: %s" % (first_mp_init.message if first_mp_init != null else "null"))
+		playfab.shutdown()
+		ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, original_title_id)
+		ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, original_endpoint)
+		reset_playfab_runtime()
+		return
+
+	await _assert_signal_error(multiplayer.initialize_async(), "already_initialized", "PlayFab.multiplayer.initialize_async() second call")
+	playfab.shutdown()
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, original_title_id)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, original_endpoint)
+	reset_playfab_runtime()
 
 
 func test_multiplayer_shutdown_cancels_reentrant_pending_operations() -> void:

--- a/tests/godot/playfab/tests/test_multiplayer_lobby_live.gd
+++ b/tests/godot/playfab/tests/test_multiplayer_lobby_live.gd
@@ -47,14 +47,20 @@ func test_lobby_member_props_and_leave_state_signals() -> void:
 	multiplayer.state_changed.connect(on_service_change)
 
 	var create_result = await await_completion(multiplayer.create_lobby_async(playfab_user, lobby_config), _DEFAULT_OP_TIMEOUT_MSEC)
-	if create_result == null or not create_result.ok:
+	if create_result == null:
 		multiplayer.state_changed.disconnect(on_service_change)
-		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % (create_result.message if create_result != null else "null result"))
+		fail("PlayFab.multiplayer.create_lobby_async timed out.")
+		_finish_session(playfab, null)
+		return
+	if not create_result.ok:
+		multiplayer.state_changed.disconnect(on_service_change)
+		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % create_result.message)
 		_finish_session(playfab, null)
 		return
 
 	var lobby: Object = create_result.data
 	assert_object_is(lobby, "PlayFabLobby", "create_lobby_async returns PlayFabLobby")
+	assert_true(lobby != null and lobby.is_owner(playfab_user), "PlayFabLobby.is_owner(playfab_user) reports true for creating user")
 	if lobby == null:
 		multiplayer.state_changed.disconnect(on_service_change)
 		_finish_session(playfab, null)
@@ -117,8 +123,12 @@ func test_lobby_shutdown_without_leave_does_not_emit_null_member() -> void:
 	lobby_config.access_policy = get_class_constant("PlayFabLobbyConfig", "ACCESS_POLICY_PRIVATE")
 
 	var create_result = await await_completion(multiplayer.create_lobby_async(playfab_user, lobby_config), _DEFAULT_OP_TIMEOUT_MSEC)
-	if create_result == null or not create_result.ok:
-		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % (create_result.message if create_result != null else "null result"))
+	if create_result == null:
+		fail("PlayFab.multiplayer.create_lobby_async timed out.")
+		_finish_session(playfab, null)
+		return
+	if not create_result.ok:
+		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % create_result.message)
 		_finish_session(playfab, null)
 		return
 
@@ -162,8 +172,12 @@ func test_failed_lobby_join_does_not_leave_tracked_wrapper() -> void:
 	lobby_config.access_policy = get_class_constant("PlayFabLobbyConfig", "ACCESS_POLICY_PRIVATE")
 
 	var create_result = await await_completion(multiplayer.create_lobby_async(playfab_user, lobby_config), _DEFAULT_OP_TIMEOUT_MSEC)
-	if create_result == null or not create_result.ok:
-		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % (create_result.message if create_result != null else "null result"))
+	if create_result == null:
+		fail("PlayFab.multiplayer.create_lobby_async timed out.")
+		_finish_session(playfab, null)
+		return
+	if not create_result.ok:
+		pending("PlayFab.multiplayer.create_lobby_async failed: %s" % create_result.message)
 		_finish_session(playfab, null)
 		return
 
@@ -174,8 +188,12 @@ func test_failed_lobby_join_does_not_leave_tracked_wrapper() -> void:
 
 	var stale_connection_string := str(lobby.get_connection_string())
 	var leave_result = await await_completion(lobby.leave_async(), _DEFAULT_OP_TIMEOUT_MSEC)
-	if leave_result == null or not leave_result.ok:
-		pending("PlayFabLobby.leave_async failed before stale-join regression check: %s" % (leave_result.message if leave_result != null else "null result"))
+	if leave_result == null:
+		fail("PlayFabLobby.leave_async timed out before stale-join regression check.")
+		_finish_session(playfab, null)
+		return
+	if not leave_result.ok:
+		pending("PlayFabLobby.leave_async failed before stale-join regression check: %s" % leave_result.message)
 		_finish_session(playfab, null)
 		return
 	await advance_process_frames(_STATE_PUMP_FRAMES)
@@ -184,7 +202,7 @@ func test_failed_lobby_join_does_not_leave_tracked_wrapper() -> void:
 	var join_config = instantiate_class("PlayFabLobbyJoinConfig")
 	var join_result = await await_completion(multiplayer.join_lobby_async(playfab_user, stale_connection_string, join_config), _DEFAULT_OP_TIMEOUT_MSEC)
 	if join_result == null:
-		pending("PlayFab.multiplayer.join_lobby_async(stale_connection_string) timed out; cannot assert failure cleanup.")
+		fail("PlayFab.multiplayer.join_lobby_async(stale_connection_string) timed out; cannot assert failure cleanup.")
 		_finish_session(playfab, null)
 		return
 	if join_result.ok:
@@ -198,6 +216,32 @@ func test_failed_lobby_join_does_not_leave_tracked_wrapper() -> void:
 	await advance_process_frames(_STATE_PUMP_FRAMES)
 	assert_eq(multiplayer.get_lobbies().size(), before_count,
 			"failed join completion does not leave its PlayFabLobby wrapper tracked")
+
+	_finish_session(playfab, null)
+
+
+func test_multiplayer_live_validation_error_branches() -> void:
+	var session = await _begin_multiplayer_session()
+	var playfab_user = session.get("playfab_user")
+	if playfab_user == null:
+		return
+
+	var playfab: Object = session["playfab"]
+	var multiplayer: Object = session["multiplayer"]
+
+	var join_config = instantiate_class("PlayFabLobbyJoinConfig")
+	await _assert_signal_error(
+		multiplayer.join_arranged_lobby_async(playfab_user, "  ", join_config),
+		"invalid_arranged_lobby_connection_string",
+		"PlayFab.multiplayer.join_arranged_lobby_async() rejects blank arranged connection string")
+
+	var lobby_config = instantiate_class("PlayFabLobbyConfig")
+	if lobby_config != null:
+		lobby_config.lobby_properties = {"bad_value": 12}
+		await _assert_signal_error(
+			multiplayer.create_lobby_async(playfab_user, lobby_config),
+			"invalid_properties",
+			"PlayFab.multiplayer.create_lobby_async() rejects non-string lobby property values")
 
 	_finish_session(playfab, null)
 
@@ -240,8 +284,11 @@ func _begin_multiplayer_session() -> Dictionary:
 		return outcome
 
 	var mp_init = await await_completion(multiplayer.initialize_async(), _DEFAULT_OP_TIMEOUT_MSEC)
-	if mp_init == null or not mp_init.ok:
-		pending("PlayFab.multiplayer.initialize_async failed: %s" % (mp_init.message if mp_init != null else "null result"))
+	if mp_init == null:
+		fail("PlayFab.multiplayer.initialize_async timed out.")
+		return outcome
+	if not mp_init.ok:
+		pending("PlayFab.multiplayer.initialize_async failed: %s" % mp_init.message)
 		return outcome
 
 	outcome["playfab_user"] = custom_id_session["playfab_user"]
@@ -266,8 +313,11 @@ func _sign_in_with_or_create_custom_id(playfab: Object, label: String) -> Dictio
 		pending("%s skipped: PlayFab.users.sign_in_with_custom_id_async() did not start." % label)
 		return outcome
 	var sign_in_result = await await_completion(sign_in_signal, _DEFAULT_OP_TIMEOUT_MSEC)
-	if sign_in_result == null or not sign_in_result.ok:
-		pending("%s skipped: %s" % [label, sign_in_result.message if sign_in_result != null else "timed out"])
+	if sign_in_result == null:
+		fail("%s sign_in_with_custom_id_async timed out." % label)
+		return outcome
+	if not sign_in_result.ok:
+		pending("%s skipped: %s" % [label, sign_in_result.message])
 		return outcome
 	outcome["playfab_user"] = sign_in_result.data
 	return outcome
@@ -321,6 +371,13 @@ func _assert_kind_emitted_with_member(changes: Array, expected_kind: int, playfa
 			return
 	assert_true(false,
 			"%s did not emit kind=%d with non-null change.member matching local user (recorded %d changes)" % [op_label, expected_kind, changes.size()])
+
+
+func _assert_signal_error(async_signal, expected_code: String, name: String) -> void:
+	assert_eq(typeof(async_signal), TYPE_SIGNAL, "%s returns completion Signal" % name)
+	if typeof(async_signal) != TYPE_SIGNAL:
+		return
+	assert_playfab_result_error(await await_completion(async_signal, _DEFAULT_OP_TIMEOUT_MSEC), expected_code, name)
 
 
 func _assert_member_removed_count_at_most_one(changes: Array, playfab_user, op_label: String) -> void:

--- a/tests/godot/playfab/tests/test_party.gd
+++ b/tests/godot/playfab/tests/test_party.gd
@@ -191,6 +191,9 @@ func test_party_peer_contract() -> void:
 	assert_eq(peer.get_unique_id(), 0, "Detached PlayFabPartyPeer.get_unique_id() == 0")
 	assert_eq(peer.get_connection_status(), MultiplayerPeer.CONNECTION_DISCONNECTED, "Detached PlayFabPartyPeer.get_connection_status() == DISCONNECTED")
 	assert_eq(peer.get_available_packet_count(), 0, "Detached PlayFabPartyPeer.get_available_packet_count() == 0")
+	peer.close_with_reason("audit-detached-close")
+	assert_eq(peer.get_connection_status(), MultiplayerPeer.CONNECTION_DISCONNECTED, "Detached PlayFabPartyPeer.close_with_reason() keeps peer disconnected")
+	assert_eq(peer.get_peers().size(), 0, "Detached PlayFabPartyPeer.close_with_reason() leaves peer list empty")
 
 
 func test_party_network_detached_helpers() -> void:
@@ -332,6 +335,24 @@ func test_party_chat_control_helpers() -> void:
 	await _assert_signal_error(control.send_text_async([], "hello"), "party_resource_not_ready", "Detached PlayFabPartyChatControl.send_text_async() reports party_resource_not_ready")
 	await _assert_signal_error(control.set_permissions_async(null, get_class_constant("PlayFabParty", "CHAT_PERMISSION_RECEIVE_TEXT")), "party_chat_permission_failed", "Detached PlayFabPartyChatControl.set_permissions_async() reports party_chat_permission_failed")
 	await _assert_signal_error(control.set_muted_async(null, true), "party_chat_permission_failed", "Detached PlayFabPartyChatControl.set_muted_async() reports party_chat_permission_failed")
+	var destroy_signal = control.destroy_async()
+	assert_eq(typeof(destroy_signal), TYPE_SIGNAL, "Detached PlayFabPartyChatControl.destroy_async() returns completion Signal")
+	if typeof(destroy_signal) == TYPE_SIGNAL:
+		assert_playfab_result_ok(await await_completion(destroy_signal), "Detached PlayFabPartyChatControl.destroy_async()")
+
+
+func test_party_shutdown_async_explicit_await_uninitialized() -> void:
+	if pending_unless_playfab_available():
+		return
+
+	var playfab = get_playfab()
+	reset_playfab_runtime()
+	var party = playfab.get_party()
+	if party == null:
+		return
+
+	assert_playfab_result_ok(await await_completion(party.shutdown_async()), "await PlayFab.party.shutdown_async() while uninitialized")
+	assert_false(party.is_initialized(), "PlayFab.party remains uninitialized after explicit awaited shutdown")
 
 
 func test_party_shutdown_cancels_reentrant_pending_operations() -> void:

--- a/tests/godot/playfab/tests/test_users.gd
+++ b/tests/godot/playfab/tests/test_users.gd
@@ -19,6 +19,12 @@ func test_users_api() -> void:
 	for method_name in ["sign_in_with_xuser_async", "sign_in_with_custom_id_async", "get_user_by_local_id", "get_user_by_custom_id", "get_user", "get_users"]:
 		assert_has_method_named(users, method_name)
 
+	var blank_user_for_cache = instantiate_class("PlayFabUser")
+	if users.has_method("add_or_update_user_session"):
+		assert_false(bool(users.call("add_or_update_user_session", blank_user_for_cache)), "PlayFabUsers.add_or_update_user_session(blank) rejects an uncached blank user")
+	else:
+		assert_false(users.has_method("add_or_update_user_session"), "PlayFabUsers.add_or_update_user_session is not script-visible on public/main")
+
 	for signal_name in ["user_signed_in", "user_signed_out", "user_changed"]:
 		assert_true(not users.has_signal(signal_name), "PlayFabUsers.%s is not exposed" % signal_name)
 


### PR DESCRIPTION
## Summary

Backfills audit A6 PlayFab test coverage only: zero-coverage PlayFab surfaces, live helper assertion coverage, live-timeout fail behavior, and mp_orchestrator parity ports for the legacy PlayFab Multiplayer worker.

## Per-test mapping and assertion pins

| File / test | Finding | Assert count | Pin |
|---|---:|---:|---|
| `test_users.gd::test_users_api` | HIGH T6 | 1 new conditional assert | Exercises `PlayFabUsers.add_or_update_user_session` if it is script-bound; otherwise pins that public/main keeps the internal cache mutator hidden. |
| `test_core.gd::test_initialize_reports_already_initialized` | HIGH error branch | 2 | First `PlayFab.initialize()` succeeds; second returns `already_initialized`. |
| `test_multiplayer_contract.gd::test_multiplayer_config_and_wrapper_contract` | HIGH T6 | 4 new | `PlayFabLobbyConfig.owner_migration_policy` and `restrict_invites_to_lobby_owner` getter/setter round trips. |
| `test_multiplayer_contract.gd::test_multiplayer_service_contract` | HIGH T6 | 2 new | `PlayFabLobby.is_owner(null)` is callable and false on a detached lobby. |
| `test_multiplayer_contract.gd::test_multiplayer_shutdown_async_explicit_await_uninitialized` | HIGH T6 | 2 | Explicitly awaits `PlayFabMultiplayer.shutdown_async()` and verifies OK/uninitialized. |
| `test_multiplayer_contract.gd::test_multiplayer_initialize_reports_already_initialized` | HIGH error branch | 2 on exercised path | Second `PlayFabMultiplayer.initialize_async()` returns `already_initialized` when local SDK init succeeds. |
| `test_party.gd::test_party_shutdown_async_explicit_await_uninitialized` | HIGH T6 | 2 | Explicitly awaits `PlayFabParty.shutdown_async()` and verifies OK/uninitialized. |
| `test_party.gd::test_party_peer_contract` | HIGH T6 | 2 new | Invokes `PlayFabPartyPeer.close_with_reason()` on detached peer and verifies disconnected/no peers. |
| `test_party.gd::test_party_chat_control_helpers` | HIGH T6 | 2 new | Invokes/awaits `PlayFabPartyChatControl.destroy_async()` and verifies OK. |
| `test_api_services_live.gd::_assert_cloud_script_reaches_service` | HIGH silent pass | 3 unconditional + 1/3 conditional | Asserts CloudScript returns a result, is not local-start/marshal failure, and includes service payload/message. |
| `test_leaderboards_live.gd::*` | HIGH false pending | 0 new asserts; 5 fail pins | Converts real live timeouts/settle timeout from `pending()` to `fail()`. |
| `test_multiplayer_lobby_live.gd::test_lobby_member_props_and_leave_state_signals` | HIGH T6 + false pending | 1 new | Live `PlayFabLobby.is_owner(playfab_user)` true for creating user; create timeout fails. |
| `test_multiplayer_lobby_live.gd::test_multiplayer_live_validation_error_branches` | HIGH error branches | 4 | `invalid_arranged_lobby_connection_string` and `invalid_properties` forced after live sign-in. |
| `test_multiplayer_lobby_live.gd` helpers/call sites | HIGH false pending | 0 new asserts; 7 fail pins | Live create/leave/join/sign-in/multiplayer-init timeouts now fail instead of pending. |

## Live tier breakdown

- Offline/non-live GUT coverage: 48 passing tests in the targeted PlayFab host.
- `requires_live` / live-gated coverage: 8 pending in the non-live GUT run; includes CloudScript, leaderboards, live lobby, and validation-branch checks.
- `requires_live_write`: 0 newly introduced GUT tests with separate live-write gating; new live validation branches fail before service mutation. mp_orchestrator scenario ports are live-write scenarios and remain list-smoked only.

## mp_orchestrator legacy-worker inventory

Legacy scenarios inventoried from `tools/run_playfab_multiplayer_live.ps1` / `tests/godot/playfab_multiplayer_worker/worker.gd`:

| Legacy scenario | mp_orchestrator status |
|---|---|
| public lobby create snapshot | Existing: `lobby.create_inspect_leave` |
| search no-results isolation | Added: `lobby.search.no_results.isolation` |
| multiple lobby tracking | Existing: `lobby.tracking_multiple_per_host` |
| private lobby not searchable | Existing: `lobby.search_private_not_searchable` |
| invalid connection string typed failure | Added: `lobby.join.invalid_connection_string` |
| public lobby search by string key | Existing: `lobby.search_public_by_string_key` |
| client join by connection string | Existing: `lobby.join_by_connection_string` |
| three-client membership snapshots | Existing: `lobby.join_three_clients` |
| member property propagation | Added: `lobby.properties.member.propagation` |
| lobby property propagation | Added: `lobby.properties.lobby.propagation` |
| third member leave propagation | Added: `lobby.leave.third_member` |
| client leave propagation | Existing: `lobby.leave_client` |
| rejoin after leave | Existing: `lobby.leave_rejoin_after_leave` |
| owner migration after host leave | Added: `lobby.leave.host.owner_migration` |
| match ticket create and cancel | Existing: `match.ticket.create_and_cancel` |
| two-player match completion | Added: `match.ticket.two_player_match.complete` |
| explicit arranged-lobby join | Deferred: `mp_test_client` lacks `join_arranged_lobby` op; no addon/client op added in this tests-only PR. |
| arranged-lobby cleanup | Deferred: blocked on `join_arranged_lobby` op. |

Scenario ports added: 7 total (6 lobby, 1 match). `tools\run_mp_orchestrator.ps1 -List` discovers 24 scenarios including all 7 new IDs.

## Pre-existing todo handling

- `lobby-member-prop-convergence`: addressed by `lobby.properties.member.propagation` (three roles must observe guest member property convergence).
- `lobby-prop-delete-via-null`: already pinned by existing `lobby.set_lobby_properties_roundtrip`; no addon changes made.
- `match-ticket-id-polling`: reinforced by `match.ticket.two_player_match.complete`, which fails on empty ticket IDs before waiting for `matched`.
- `party-multi-network-destroyed`: deferred; same-host multi-process race is not reliable enough to pin as a deterministic fail in this tests-only PR.
- `party-single-leave-race`: deferred beyond existing party orchestrator coverage; not reliably reproducible without live sandbox setup.

## Validation

- `cmake --build build --preset debug --target godot_playfab`: PASS (after submodule init) and mirrored PlayFab/GUT test addons.
- Full parse gate `tools\check_gd_scripts_headless.ps1`: blocked by pre-existing sample parse failures (`sample\tutorial_app\autoload\auth.gd` cannot resolve `GDKUser`); this belongs with `audit-followup-parse-gate-samples`.
- Targeted parse gate: `tools\check_gd_scripts_headless.ps1 -Projects tests\godot\playfab,tests\godot\mp_orchestrator`: PASS (mp_orchestrator checked; PlayFab GUT tests are `.gut_skip_validation` and covered by GUT).
- `tools\run_all_tests.ps1 -SkipBuild -Hosts tests\godot\playfab -ParseProjects tests\godot\mp_orchestrator`: PASS.
  - GUT PlayFab host: 56 tests, 48 passing, 0 failing, 8 pending, 1682/1682 asserts.
  - PlayFab bootstrap mini-runners: all 3 PASS.
  - Live tests: skipped (`-Live` not supplied).
- `tools\run_mp_orchestrator.ps1 -List`: PASS; discovery only, full live orchestration not run (no sandbox live setup).