### PR TITLE
e1: short-circuit async finalizers on shutdown (audit T1 sweep)

### DIFF
--- a/docs/gdk/async-system.md
+++ b/docs/gdk/async-system.md
@@ -491,6 +491,12 @@ That is the concrete example of the "manager state instead of a classic async re
 
 Because the runtime sets `m_shutting_down` first, service finalizers can refuse to mutate state during teardown. `GDK.shutdown()` intentionally does not call `XGameRuntimeUninitialize()`; tests and games may cycle initialize/shutdown multiple times in one process, while the matching native uninitialize runs once when the extension is torn down.
 
+### Finalizer contract
+
+Every `GDKSignalXAsyncContext::finalize(XAsyncBlock *)` implementation must short-circuit before result extraction or service/cache mutation when `get_runtime()->is_shutting_down()` or `get_pending_signal()->was_cancel_requested()` is true. The finalizer completes its pending signal with `GDKResult::cancelled(...)` and returns, so shutdown and explicit cancellation do not continue the success path after the runtime has started tearing down.
+
+If a future finalizer must perform native cleanup during shutdown, keep the cancelled-result gate first and document the cleanup-only exception both inline and in this section.
+
 ## Why the base bridge does not use generic `XAsyncGetStatus`
 
 This is the most important implementation rule for future work.
@@ -517,12 +523,13 @@ When adding a new one-shot wrapper, follow this checklist:
 1. Decide whether the wrapper is `XAsync`-backed or manager/dispatch-backed.
 2. Add the public service method that returns a completion `Signal`.
 3. For `XAsync`-backed work, create a service-specific context derived from `GDKSignalXAsyncContext`.
-4. In `finalize(XAsyncBlock *p_async_block)`, call the API-specific result functions.
-5. Translate native payloads into Godot wrappers or Variants.
-6. Update service-owned cache/state first.
-7. Emit service-level signals next.
-8. Complete the returned signal last.
-9. Use `GDKRuntime::make_error_signal()` for immediate startup/availability failures.
+4. In `finalize(XAsyncBlock *p_async_block)`, first apply the [finalizer contract](#finalizer-contract) shutdown/cancellation gate.
+5. Call the API-specific result functions.
+6. Translate native payloads into Godot wrappers or Variants.
+7. Update service-owned cache/state first.
+8. Emit service-level signals next.
+9. Complete the returned signal last.
+10. Use `GDKRuntime::make_error_signal()` for immediate startup/availability failures.
 
 For manager/event-driven waits like achievements and social friends queries, store a retained `GDKPendingSignal` in service-owned pending state and use a cancel handler that unregisters it immediately if the request is cancelled during teardown.
 

--- a/docs/playfab/async-system.md
+++ b/docs/playfab/async-system.md
@@ -34,3 +34,9 @@ Do not run `dispatch()` from a worker thread. If dispatch is not pumped, async s
 ## Shutdown and cancellation
 
 `PlayFab.shutdown()` cancels outstanding Party and Multiplayer pending signals before native teardown and rejects new Party/Multiplayer work while shutdown is in progress. Existing callers should still await or connect their signals and handle a cancellation-style `PlayFabResult` instead of assuming the signal disappears.
+
+### Finalizer contract
+
+Every `PlayFabSignalXAsyncContext::finalize(XAsyncBlock *)` implementation must short-circuit before result extraction or service/cache mutation when `get_runtime()->is_shutting_down()` or `get_pending_signal()->was_cancel_requested()` is true. The finalizer completes its pending signal with `PlayFabResult::cancelled(...)` and returns, so shutdown and explicit cancellation do not continue the success path after the runtime has started tearing down.
+
+If a future finalizer must perform native cleanup during shutdown, keep the cancelled-result gate first and document the cleanup-only exception both inline and in this section.


### PR DESCRIPTION
## Summary

- Swept every concrete `finalize(XAsyncBlock *)` in `addons\godot_gdk\src`, `addons\godot_playfab\src`, and `addons\godot_gameinput\src`.
- Audit result: GDK 33 swept / 0 gaps, PlayFab 12 swept / 0 gaps, GameInput 0 swept / 0 gaps.
- Added explicit live-write test gating (`requires_live_write()` / `LIVE_WRITE_TESTS`) and `run_all_tests.ps1 -AllowLiveWrites` sandbox-warning plumbing.
- Added a PlayFab live-gated shutdown-cancellation regression in `tests\godot\playfab`.

## Audit notes

No code gaps were found after merging latest `public/main`: every GDK and PlayFab XAsync finalizer checked by the sweep already short-circuits through `is_shutting_down()` or `was_cancel_requested()` before native result extraction or service/cache mutation. `PackageMountAsyncContext::finalize()` is gated on this branch.

## Live sandbox verification

Verified title `10D176` before enabling live writes by reading the existing title-data marker with the developer secret (secret not printed):

```text
Verified sandbox live-test marker for PlayFab title 10D176.
Marker repository: gaming-microsoft/godot-public-gdk-ext
Marker custom_id: godot-gdk-ext-live-smoke
Marker matchmaking_queue: godot_gdk_ext_live_smoke_queue
```

## Validation

- `git submodule update --init --recursive` ✅
- Finalizer audit script ✅

```text
GDK: swept=33, gaps=0
PlayFab: swept=12, gaps=0
GameInput: swept=0, gaps=0
```

- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1` ✅
- `cmake --preset default` ✅
- `cmake --build build --preset debug -- /v:minimal /clp:ErrorsOnly` ✅
- Preferred live orchestrator with sandbox live writes ❌ (live ran, but full-suite live is blocked by unrelated existing host issues after the parse/build stages passed):

```powershell
pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId "10D176" -PlayFabCustomId "godot-gdk-ext-live-smoke" -PlayFabMatchmakingQueue "godot_gdk_ext_live_smoke_queue"
```

Representative output:

```text
!!! SANDBOX-ONLY LIVE WRITES ENABLED !!!
LIVE_WRITE_TESTS=1 will be forwarded to Godot children for PlayFab title '10D176'.
== [1/7] Parse gate (check_gd_scripts_headless.ps1) ==
   PASS: OK
== [2/7] CMake build (debug) ==
   PASS: OK
== [3/7] C++ doctest (gdk_unit_tests.exe) ==
   PASS: OK
  - host: tests\godot\gdk
    FAIL: GUT timed out in tests\godot\gdk after 600 s.
  - host: tests\godot\playfab
    FAIL: GUT failed in 'tests\godot\playfab' -- 2 failing test(s), exit 1.
  - host: tests\godot\gameinput
    PASS: OK (51 test(s), 47 passing, 4 pending, 34825/34825 asserts validated, 0 failed).
Overall: fail
```

Full live PlayFab host output shows unrelated pre-existing failures in existing live files (for example `test_multiplayer_lobby_live.gd` parse errors for missing `fail()` and `test_multiplayer_match_live.gd` calling nonexistent `PlayFab.initialize_async`). Earlier pre-merge attempts also hit the known `audit-followup-parse-gate-samples` blocker; after merging latest `public/main`, the parse gate is green and the active full-live blockers are the GDK timeout / PlayFab live-host failures above.

- Fallback focused PlayFab GUT live regression ✅ (run in `tests\godot\playfab` with `LIVE_TESTS=1`, `LIVE_WRITE_TESTS=1`, title `10D176`; focused to the new regression because the full live host is blocked as described above):

```powershell
$env:LIVE_TESTS = "1"
$env:LIVE_WRITE_TESTS = "1"
$env:PLAYFAB_TITLE_ID = "10D176"
$env:PLAYFAB_CUSTOM_ID = "godot-gdk-ext-live-smoke"
$env:PLAYFAB_MULTIPLAYER_MATCH_QUEUE = "godot_gdk_ext_live_smoke_queue"
# from tests\godot\playfab:
Godot_v4.6.2-stable_win64_console.exe --headless -s res://addons/gut/gut_cmdln.gd -gtest=res://tests/test_async_finalizer_shutdown_live.gd -gexit
```

```text
res://tests/test_async_finalizer_shutdown_live.gd
* test_party_shutdown_live_cancels_pending_operations
[PlayFab] Runtime initialized
[PlayFab] Runtime shutdown
1/1 passed.

Scripts               1
Tests                 1
Passing Tests         1
Asserts               8
Time              0.445s
---- All tests passed! ----
```

Live coverage decision: live tests were run against verified sandbox title `10D176`; `-AllowLiveWrites` / `LIVE_WRITE_TESTS=1` was enabled only for that sandbox. No production/shared title was used.
