### PR TITLE
fix: PlayFabParty - resolve same-host join-vs-destroy race

### DIFF
--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -2081,12 +2081,28 @@ int PlayFabParty::_pump_state_changes() {
         return 0;
     }
 
+    std::vector<const Party::PartyStateChange *> deferred_network_destroys;
     int processed = 0;
     for (uint32_t i = 0; i < change_count; ++i) {
         const Party::PartyStateChange *change = changes[i];
         if (change == nullptr) {
             continue;
         }
+        if (change->stateChangeType == Party::PartyStateChangeType::NetworkDestroyed) {
+            const auto *destroyed = static_cast<const Party::PartyNetworkDestroyedStateChange *>(change);
+            if (_find_pending_join(destroyed->network) != nullptr) {
+                // Same-host joins can receive NetworkDestroyed before the
+                // completion/message that resolves the join later in this
+                // DoWork batch. Hold destruction until the rest of the batch
+                // has had a chance to deliver the pending join result.
+                deferred_network_destroys.push_back(change);
+                continue;
+            }
+        }
+        _process_state_change(change);
+        ++processed;
+    }
+    for (const Party::PartyStateChange *change : deferred_network_destroys) {
         _process_state_change(change);
         ++processed;
     }


### PR DESCRIPTION
## Summary
- Fix layer: addon race fix in `PlayFabParty::_pump_state_changes`; no `REQUIRES_MULTI_MACHINE` gate.
- Defers `NetworkDestroyed` state changes for networks with an in-flight join chain until the rest of the same Party state-change batch is processed.
- Adds live-write scenario helpers and gates `party.host_guest_create_join_leave` behind `requires_live_write()`.
- Disables the scenario's op-helper join retry (`retry_attempts: 1`) so live regression runs expose addon ordering regressions instead of masking them with backoff.
- Adds `tools/run_all_tests.ps1 -AllowLiveWrites` to propagate `LIVE_WRITE_TESTS=1` to child Godot processes.

## Race trace / diagnosis
The vulnerable path is:
1. `join_network_async` creates a pending join operation and tracks it against the Party network wrapper.
2. A Party `NetworkDestroyed` state change for that network can be delivered in the same SDK batch before the completion/message state change that resolves the join handshake.
3. The old processing order detached/untracked the wrapper immediately in `_process_network_destroyed()`.
4. The later join step then saw a detached wrapper in `_abort_join_op_if_network_dead()` and surfaced `party_resource_not_ready: Network destroyed during join` before the handshake result could be delivered.

The fix keeps Party state-change pointers inside the same `DoWork`/`FinishProcessingStateChanges` batch, processes all non-destroy changes first when a pending join exists, then processes the deferred destroys before `FinishProcessingStateChanges`.

## Sandbox / live-write verification
- Title id: `10D176`
- Verified before live writes: existing `Admin/GetTitleData` marker `godot_public_gdk_ext_live_tests` is present for repository `gaming-microsoft/godot-public-gdk-ext`, title id `10D176`, with the multiplayer custom-id pool configured. This is the default sandbox title used by `tools/configure_playfab_test_title.ps1`.
- `LIVE_TESTS=1` and `LIVE_WRITE_TESTS=1` were set for live mp_orchestrator runs.

## Repeat-run statistics
Baseline attempts against `public/main` in this environment did **not** reproduce the requested failure:
- Existing scenario with helper retries: 0/10 failures, 0/10 `Network destroyed during join` traces.
- Temporary no-retry baseline scenario (`retry_attempts: 1`): 0/10 failures, 0/10 traces.
- Additional no-retry baseline stress: 0/50 failures, 0/50 traces.

Fixed branch live regression:
- Updated no-retry live-write scenario: 0/10 failures, 0/10 `Network destroyed during join` traces.
- No `REQUIRES_MULTI_MACHINE` gate was applied because same-host Party transport is working in this sandbox and no SDK same-host unsupported contract was confirmed.

## Validation
- `cmake --preset default` ✅
- `cmake --build build --preset debug --target godot_playfab` ✅
- Targeted PlayFab GUT host ✅ — 48 passing, 8 pending without `LIVE_TESTS=1`
- `tools/check_gd_scripts_headless.ps1 -Projects tests\godot\mp_orchestrator` ✅
- `tools/run_mp_orchestrator.ps1 -Roles host,guest -Filter '^party\.host_guest_create_join_leave$'` with live env ✅ — 10/10 passed on fixed branch
- `tools/run_mp_orchestrator.ps1 ...` without live env ✅ — scenario skips through `requires_live_write()`
- Preferred `tools/run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId 10D176` ⚠️ blocked at full parse gate by pre-existing sample class-registration parse errors in `sample\tutorial_app` and `sample\tutorial_gameinput`
- Full `cmake --build build --preset debug` ⚠️ blocked by pre-existing `godot_gameinput` compile errors in `addons\godot_gameinput\src\gameinput_mapper.cpp`

No live-write coverage was run against a shared/production title.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
