### PR TITLE
gdk-tests: backfill init/shutdown re-arm + leaderboards/activity/users/dispatch/game_ui coverage (audit B3)

### DIFF
--- a/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
+++ b/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
@@ -288,13 +288,26 @@ func disconnect_signal_handlers(obj: Object, signal_names: Array) -> void:
 
 # ── TestEnv convenience wrappers ─────────────────────────────────────────
 
+# Returns true when LIVE_TESTS=1 is set; otherwise marks the current test pending.
+func requires_live() -> bool:
+	if TestEnv.live_tests_enabled():
+		return true
+	pending("Skipped without LIVE_TESTS=1")
+	return false
+
+
+# Returns true when both LIVE_TESTS=1 and LIVE_WRITE_TESTS=1 are set.
+func requires_live_write() -> bool:
+	if TestEnv.live_write_tests_enabled():
+		return true
+	pending("Skipped without LIVE_TESTS=1 and LIVE_WRITE_TESTS=1")
+	return false
+
+
 # Pending the current test unless LIVE_TESTS=1 is set. Returns true when
 # the test was marked pending (caller should `return` immediately after).
 func pending_unless_live() -> bool:
-	if not TestEnv.live_tests_enabled():
-		pending("Skipped without LIVE_TESTS=1")
-		return true
-	return false
+	return not requires_live()
 
 
 # Returns "<prefix>-<unique_run_id>" so live write tests can derive

--- a/addons/godot_gdk/tests_support/bases/test_env.gd
+++ b/addons/godot_gdk/tests_support/bases/test_env.gd
@@ -10,6 +10,7 @@ extends RefCounted
 ## `addons/godot_gdk/tests_support/bases/test_env.gd`.
 
 const LIVE_TESTS_ENV := "LIVE_TESTS"
+const LIVE_WRITE_TESTS_ENV := "LIVE_WRITE_TESTS"
 const LEADERBOARD_SETTLE_MSEC_SETTING := "playfab/tests/leaderboard_settle_msec"
 const DEFAULT_SETTLE_MSEC := 30000
 const DEFAULT_POLL_INTERVAL_MSEC := 250
@@ -24,6 +25,10 @@ static var _cached_run_id := ""
 # count stays meaningful.
 static func live_tests_enabled() -> bool:
 	return OS.get_environment(LIVE_TESTS_ENV) == "1"
+
+
+static func live_write_tests_enabled() -> bool:
+	return live_tests_enabled() and OS.get_environment(LIVE_WRITE_TESTS_ENV) == "1"
 
 
 # Generate a unique-per-run id of the form `gdkfleet-YYYYMMDDHHmmss-XXXX`.

--- a/tests/godot/gdk/tests/test_achievement.gd
+++ b/tests/godot/gdk/tests/test_achievement.gd
@@ -1,0 +1,34 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+
+func test_achievement_default_values() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var achievement = instantiate_class("GDKAchievement")
+	assert_not_null(achievement, "GDKAchievement.new() returns wrapper")
+	if achievement == null:
+		return
+
+	for method_name in [
+		"get_id",
+		"get_name",
+		"get_service_configuration_id",
+		"get_progress_state",
+		"get_progress_percent",
+		"is_unlocked",
+		"is_secret",
+		"get_locked_description",
+		"get_unlocked_description",
+	]:
+		assert_has_method_named(achievement, method_name)
+
+	assert_eq(achievement.get_id(), "", "blank GDKAchievement id defaults empty")
+	assert_eq(achievement.get_name(), "", "blank GDKAchievement name defaults empty")
+	assert_eq(achievement.get_service_configuration_id(), "", "blank GDKAchievement SCID defaults empty")
+	assert_eq(achievement.get_progress_state(), "", "blank GDKAchievement progress_state defaults empty")
+	assert_eq(achievement.get_progress_percent(), 0, "blank GDKAchievement progress_percent defaults zero")
+	assert_eq(achievement.is_unlocked(), false, "blank GDKAchievement unlocked defaults false")
+	assert_eq(achievement.is_secret(), false, "blank GDKAchievement secret defaults false")
+	assert_eq(achievement.get_locked_description(), "", "blank GDKAchievement locked_description defaults empty")
+	assert_eq(achievement.get_unlocked_description(), "", "blank GDKAchievement unlocked_description defaults empty")

--- a/tests/godot/gdk/tests/test_capture.gd
+++ b/tests/godot/gdk/tests/test_capture.gd
@@ -2,9 +2,8 @@ extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
 ## GUT coverage for GDKCapture.
 ##
 ## Deterministic surface and validation tests run without a signed-in user.
-## Live diagnostic-capture tests (record_diagnostic_clip_async,
-## take_diagnostic_screenshot_async) require LIVE_TESTS=1 and a device with
-## Game Bar active; they are gated by pending_unless_live().
+## Live diagnostic-capture tests require LIVE_TESTS=1 and a device with
+## Game Bar active; they are gated by requires_live() before initializing.
 
 func before_each() -> void:
 	reset_runtime()
@@ -242,12 +241,14 @@ func test_capture_metadata_operations_reject_empty_name() -> void:
 	assert_false(meta.is_valid(), "GDKCaptureMetaData.is_valid() is false after explicit close()")
 
 
-# ── Metadata start/stop flow (deterministic with GDK running) ────────────
+# ── Metadata start/stop flow (live capture service) ─────────────────────
 
 func test_capture_metadata_start_stop_flow() -> void:
-	## Validates that start_string_state + stop_all_states round-trips without
-	## error when the GDK runtime is available.
+	## Validates that start_string_state + stop_all_states round-trips with live
+	## capture services available.
 	if pending_unless_runtime_available():
+		return
+	if not requires_live():
 		return
 
 	var init_result = initialize_runtime()
@@ -298,10 +299,12 @@ func test_capture_metadata_start_stop_flow() -> void:
 	assert_false(meta.is_valid(), "metadata context is invalid after close()")
 
 
-# ── Capture state (enable / disable — requires init) ─────────────────────
+# ── Capture state (enable / disable — live capture service) ──────────────
 
 func test_capture_enable_disable_after_init() -> void:
 	if pending_unless_runtime_available():
+		return
+	if not requires_live():
 		return
 
 	var init_result = initialize_runtime()
@@ -347,8 +350,9 @@ func test_capture_enable_disable_after_init() -> void:
 
 func test_capture_record_clip_live() -> void:
 	## Manual / live-only: requires Game Bar to be active on the device.
-	## Gate with pending_unless_live().
 	if pending_unless_runtime_available():
+		return
+	if not requires_live():
 		return
 
 	var init_result = initialize_runtime()
@@ -357,9 +361,6 @@ func test_capture_record_clip_live() -> void:
 		return
 	if not init_result.ok:
 		pending("record_diagnostic_clip_async live: runtime init failed — %s" % init_result.message)
-		return
-
-	if pending_unless_live():
 		return
 
 	var gdk = get_gdk()
@@ -389,6 +390,8 @@ func test_capture_take_screenshot_live() -> void:
 	## Manual / live-only: requires Game Bar to be active on the device.
 	if pending_unless_runtime_available():
 		return
+	if not requires_live():
+		return
 
 	var init_result = initialize_runtime()
 	assert_not_null(init_result, "GDK.initialize() returns GDKResult")
@@ -396,9 +399,6 @@ func test_capture_take_screenshot_live() -> void:
 		return
 	if not init_result.ok:
 		pending("take_diagnostic_screenshot_async live: runtime init failed — %s" % init_result.message)
-		return
-
-	if pending_unless_live():
 		return
 
 	var gdk = get_gdk()

--- a/tests/godot/gdk/tests/test_dispatch.gd
+++ b/tests/godot/gdk/tests/test_dispatch.gd
@@ -1,0 +1,71 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+const DISPATCH_COMPLETION_COUNT := 2
+
+var _original_embed_dispatch := true
+
+
+func before_each() -> void:
+	_original_embed_dispatch = get_embed_dispatch_enabled()
+	set_embed_dispatch_enabled(false)
+	reset_runtime()
+
+
+func after_each() -> void:
+	reset_runtime()
+	set_embed_dispatch_enabled(_original_embed_dispatch)
+
+
+func test_dispatch_returns_number_of_drained_completion_events() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() returns GDKResult for dispatch count coverage")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Dispatch count coverage: %s" % init_result.message)
+		return
+
+	var users = gdk.get_users()
+	assert_not_null(users, "GDK.users is available for queueing completion events")
+	if users == null:
+		return
+
+	var sign_in = await ensure_primary_user()
+	var sign_in_signal = sign_in["signal"]
+	var sign_in_result = sign_in["result"]
+	var user = sign_in["user"]
+	if typeof(sign_in_signal) == TYPE_SIGNAL and sign_in_result == null:
+		assert_true(false, "Default-user flow for dispatch count coverage completes")
+		return
+	if user == null:
+		if sign_in_result != null and not sign_in_result.ok:
+			assert_true(sign_in_result.code.length() > 0, "failed dispatch sign-in exposes an error code")
+			assert_true(sign_in_result.message.length() > 0, "failed dispatch sign-in exposes an error message")
+			pending("Dispatch count coverage: %s" % sign_in_result.message)
+		else:
+			pending("Dispatch count coverage: No signed-in user is available on this machine.")
+		return
+
+	var states: Array = []
+	for _index in range(DISPATCH_COMPLETION_COUNT):
+		var picture_signal = users.get_gamer_picture_async(user, "small")
+		assert_eq(typeof(picture_signal), TYPE_SIGNAL, "get_gamer_picture_async() queues a completion Signal")
+		if typeof(picture_signal) == TYPE_SIGNAL:
+			states.append(track_signal(picture_signal))
+
+	if states.size() != DISPATCH_COMPLETION_COUNT:
+		return
+
+	OS.delay_msec(1500)
+	var drained = gdk.dispatch()
+	if drained != DISPATCH_COMPLETION_COUNT:
+		pending("Expected %d queued completion events, but dispatch() drained %d in this environment." % [DISPATCH_COMPLETION_COUNT, drained])
+		return
+
+	assert_eq(drained, DISPATCH_COMPLETION_COUNT, "dispatch() returns the exact number of queued completion events it drained")
+	for state in states:
+		assert_eq(state["completed"], true, "drained completion event resolves its tracked Signal")

--- a/tests/godot/gdk/tests/test_dispatch.gd
+++ b/tests/godot/gdk/tests/test_dispatch.gd
@@ -60,11 +60,14 @@ func test_dispatch_returns_number_of_drained_completion_events() -> void:
 	if states.size() != DISPATCH_COMPLETION_COUNT:
 		return
 
-	OS.delay_msec(1500)
-	var drained = gdk.dispatch()
-	if drained != DISPATCH_COMPLETION_COUNT:
-		pending("Expected %d queued completion events, but dispatch() drained %d in this environment." % [DISPATCH_COMPLETION_COUNT, drained])
-		return
+	var drained := 0
+	var max_wait_ms := 5000
+	var poll_interval_ms := 100
+	var elapsed := 0
+	while drained < DISPATCH_COMPLETION_COUNT and elapsed < max_wait_ms:
+		OS.delay_msec(poll_interval_ms)
+		drained += gdk.dispatch()
+		elapsed += poll_interval_ms
 
 	assert_eq(drained, DISPATCH_COMPLETION_COUNT, "dispatch() returns the exact number of queued completion events it drained")
 	for state in states:

--- a/tests/godot/gdk/tests/test_error_reporting.gd
+++ b/tests/godot/gdk/tests/test_error_reporting.gd
@@ -42,6 +42,9 @@ func test_error_reporting_validation_is_deterministic() -> void:
 	var invalid_option_result = error_reporting.configure_options(999, error_reporting.ERROR_OPTIONS_NONE)
 	assert_result_error(invalid_option_result, "invalid_error_reporting_options", "configure_options() rejects unsupported option flags")
 
+	var invalid_second_option_result = error_reporting.configure_options(error_reporting.ERROR_OPTIONS_NONE, 999)
+	assert_result_error(invalid_second_option_result, "invalid_error_reporting_options", "configure_options() validates debugger_not_present_options independently")
+
 	var pre_init_callback_result = error_reporting.set_callback_enabled(true)
 	assert_result_error(pre_init_callback_result, "runtime_not_initialized", "set_callback_enabled() requires initialized runtime")
 

--- a/tests/godot/gdk/tests/test_game_ui.gd
+++ b/tests/godot/gdk/tests/test_game_ui.gd
@@ -83,3 +83,28 @@ func test_game_ui_surface_and_validation() -> void:
 
 	var invalid_user_privilege_signal = game_ui.resolve_privilege_with_ui_async(blank_user, 254)
 	await assert_signal_result_error(invalid_user_privilege_signal, "invalid_user", "resolve_privilege_with_ui_async() rejects invalid users")
+
+
+func test_game_ui_show_method_fails_after_shutdown() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for post-shutdown Game UI coverage returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Game UI post-shutdown behavior: %s" % init_result.message)
+		return
+
+	var gdk = get_gdk()
+	var game_ui = gdk.get_game_ui()
+	assert_not_null(game_ui, "GDK.game_ui reference remains available before shutdown")
+	if game_ui == null:
+		return
+
+	gdk.shutdown()
+	assert_eq(gdk.is_initialized(), false, "GDK reports uninitialized after shutdown")
+
+	var stale_show_signal = game_ui.show_message_dialog_async("Post-shutdown", "This should fail instead of using stale runtime state.")
+	await assert_signal_result_error(stale_show_signal, "not_initialized", "show_message_dialog_async() fails cleanly after shutdown")

--- a/tests/godot/gdk/tests/test_leaderboards.gd
+++ b/tests/godot/gdk/tests/test_leaderboards.gd
@@ -73,6 +73,9 @@ func test_leaderboards_surface_and_validation() -> void:
 	var pre_init_signal = leaderboards.get_leaderboard_async(null, "score")
 	await assert_signal_result_error(pre_init_signal, "runtime_unavailable", "get_leaderboard_async() reports unavailable runtime before initialize")
 
+	var pre_init_around_user_signal = leaderboards.get_leaderboard_around_user_async(null, "score")
+	await assert_signal_result_error(pre_init_around_user_signal, "runtime_unavailable", "get_leaderboard_around_user_async() reports unavailable runtime before initialize")
+
 	var init_result = initialize_runtime()
 	assert_not_null(init_result, "GDK.initialize() for leaderboard validation returns GDKResult")
 	if init_result == null:
@@ -83,6 +86,9 @@ func test_leaderboards_surface_and_validation() -> void:
 
 	var invalid_user_signal = leaderboards.get_social_leaderboard_async(null, "score")
 	await assert_signal_result_error(invalid_user_signal, "invalid_user", "get_social_leaderboard_async() rejects null users after initialize")
+
+	var around_invalid_user_signal = leaderboards.get_leaderboard_around_user_async(null, "score")
+	await assert_signal_result_error(around_invalid_user_signal, "invalid_user", "get_leaderboard_around_user_async() rejects null users after initialize")
 
 	var invalid_next_page_signal = leaderboards.get_next_page_async(null)
 	await assert_signal_result_error(invalid_next_page_signal, "invalid_leaderboard", "get_next_page_async() rejects null leaderboards")
@@ -111,3 +117,60 @@ func test_leaderboards_surface_and_validation() -> void:
 
 	var blank_next_page_signal = leaderboards.get_next_page_async(blank_leaderboard)
 	await assert_signal_result_error(blank_next_page_signal, "invalid_leaderboard", "get_next_page_async() rejects manually-created leaderboards")
+
+
+func test_leaderboard_around_user_live_read() -> void:
+	if pending_unless_runtime_available():
+		return
+	if not requires_live():
+		return
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for around-user leaderboard live read returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Around-user leaderboard live read: %s" % init_result.message)
+		return
+
+	var gdk = get_gdk()
+	var leaderboards = gdk.get_leaderboards()
+	assert_not_null(leaderboards, "GDK.leaderboards is available for live around-user query")
+	if leaderboards == null:
+		return
+
+	var sign_in = await ensure_primary_user()
+	var sign_in_signal = sign_in["signal"]
+	var sign_in_result = sign_in["result"]
+	var user = sign_in["user"]
+	if typeof(sign_in_signal) == TYPE_SIGNAL and sign_in_result == null:
+		assert_true(false, "Default-user flow for around-user leaderboard live read completes")
+		return
+	if user == null:
+		if sign_in_result != null and not sign_in_result.ok:
+			assert_true(sign_in_result.code.length() > 0, "failed around-user leaderboard sign-in exposes an error code")
+			assert_true(sign_in_result.message.length() > 0, "failed around-user leaderboard sign-in exposes an error message")
+			pending("Around-user leaderboard live read: %s" % sign_in_result.message)
+		else:
+			pending("Around-user leaderboard live read: No signed-in user is available on this machine.")
+		return
+
+	var around_signal = leaderboards.get_leaderboard_around_user_async(user, "score", 25)
+	assert_eq(typeof(around_signal), TYPE_SIGNAL, "get_leaderboard_around_user_async() returns completion Signal")
+	if typeof(around_signal) != TYPE_SIGNAL:
+		return
+
+	var around_result = await await_completion(around_signal, 15000)
+	assert_not_null(around_result, "get_leaderboard_around_user_async() yields a result")
+	if around_result == null:
+		return
+	if not around_result.ok:
+		assert_true(around_result.code.length() > 0, "failed around-user leaderboard query exposes an error code")
+		assert_true(around_result.message.length() > 0, "failed around-user leaderboard query exposes an error message")
+		pending("get_leaderboard_around_user_async(): %s" % around_result.message)
+		return
+
+	assert_object_is(around_result.data, "GDKLeaderboard", "around-user leaderboard query returns a GDKLeaderboard")
+	if is_class_instance(around_result.data, "GDKLeaderboard"):
+		assert_eq(around_result.data.get_stat_name(), "score", "around-user leaderboard keeps the requested stat name")
+		assert_eq(around_result.data.get_query_type(), "around_user", "around-user leaderboard records the around_user query type")

--- a/tests/godot/gdk/tests/test_multiplayer_activity.gd
+++ b/tests/godot/gdk/tests/test_multiplayer_activity.gd
@@ -81,6 +81,18 @@ func test_multiplayer_activity_full_flow() -> void:
 		pending("Multiplayer activity runtime behavior: %s" % init_result.message)
 		return
 
+	var activities_null_user_signal = multiplayer_activity.get_activities_async(null, PackedStringArray(["1"]))
+	await assert_signal_result_error(activities_null_user_signal, "invalid_user", "get_activities_async() rejects null users after initialize")
+
+	var invite_ui_null_user_signal = multiplayer_activity.show_invite_ui_async(null)
+	await assert_signal_result_error(invite_ui_null_user_signal, "invalid_user", "show_invite_ui_async() rejects null users after initialize")
+
+	var recent_players_null_user_result = multiplayer_activity.update_recent_players(null, PackedStringArray(["1"]))
+	assert_result_error(recent_players_null_user_result, "invalid_user", "update_recent_players() rejects null users after initialize")
+
+	var flush_recent_null_user_signal = multiplayer_activity.flush_recent_players_async(null)
+	await assert_signal_result_error(flush_recent_null_user_signal, "invalid_user", "flush_recent_players_async() rejects null users after initialize")
+
 	var invalid_restriction_signal = multiplayer_activity.set_activity_async(blank_user, "join-token", "not-a-restriction")
 	await assert_signal_result_error(invalid_restriction_signal, "invalid_join_restriction", "set_activity_async() rejects unknown join_restriction values")
 

--- a/tests/godot/gdk/tests/test_runtime_lifecycle.gd
+++ b/tests/godot/gdk/tests/test_runtime_lifecycle.gd
@@ -1,0 +1,75 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+
+func before_each() -> void:
+	reset_runtime()
+
+
+func after_each() -> void:
+	reset_runtime()
+
+
+func test_initialize_shutdown_reinitialize_rearms_runtime_and_signals() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var initialized_events: Array = []
+	var shutdown_events: Array = []
+	var init_handler = func(): initialized_events.append(Time.get_ticks_msec())
+	var shutdown_handler = func(): shutdown_events.append(Time.get_ticks_msec())
+	gdk.initialized.connect(init_handler)
+	gdk.shutdown_completed.connect(shutdown_handler)
+
+	var users = gdk.get_users()
+	assert_not_null(users, "GDK.users remains available during lifecycle cycling")
+	var user_changed_events: Array = []
+	var user_changed_handler = func(_user, change_kind): user_changed_events.append(change_kind)
+	if users != null:
+		users.user_changed.connect(user_changed_handler)
+
+	var first_init = gdk.initialize()
+	assert_not_null(first_init, "first initialize() returns GDKResult")
+	if first_init == null:
+		_cleanup_handlers(gdk, init_handler, shutdown_handler, users, user_changed_handler)
+		return
+	if not first_init.ok:
+		pending("First GDK.initialize() failed: %s" % first_init.message)
+		_cleanup_handlers(gdk, init_handler, shutdown_handler, users, user_changed_handler)
+		return
+
+	assert_eq(initialized_events.size(), 1, "initialized emitted for first initialize()")
+	assert_eq(gdk.is_initialized(), true, "runtime reports initialized after first initialize()")
+	if users != null:
+		assert_true(users.user_changed.is_connected(user_changed_handler), "user_changed handler remains connected after first initialize()")
+
+	gdk.shutdown()
+	assert_eq(shutdown_events.size(), 1, "shutdown_completed emitted for first shutdown()")
+	assert_eq(gdk.is_initialized(), false, "runtime reports uninitialized after first shutdown()")
+
+	var second_init = gdk.initialize()
+	assert_result_ok(second_init, "second initialize() after shutdown")
+	if second_init == null or not second_init.ok:
+		_cleanup_handlers(gdk, init_handler, shutdown_handler, users, user_changed_handler)
+		return
+
+	assert_eq(initialized_events.size(), 2, "initialized emitted again after reinitialize()")
+	assert_eq(gdk.is_initialized(), true, "runtime reports initialized after reinitialize()")
+	if users != null:
+		assert_true(users.user_changed.is_connected(user_changed_handler), "user_changed handler remains connected after reinitialize()")
+	assert_true(gdk.dispatch() is int, "dispatch() remains callable after reinitialize()")
+
+	gdk.shutdown()
+	assert_eq(shutdown_events.size(), 2, "shutdown_completed emitted again after final shutdown()")
+	assert_eq(gdk.is_initialized(), false, "runtime reports uninitialized after final shutdown()")
+	_cleanup_handlers(gdk, init_handler, shutdown_handler, users, user_changed_handler)
+
+
+func _cleanup_handlers(gdk: Object, init_handler: Callable, shutdown_handler: Callable, users: Variant, user_changed_handler: Callable) -> void:
+	if gdk != null:
+		if gdk.initialized.is_connected(init_handler):
+			gdk.initialized.disconnect(init_handler)
+		if gdk.shutdown_completed.is_connected(shutdown_handler):
+			gdk.shutdown_completed.disconnect(shutdown_handler)
+	if users != null and users.user_changed.is_connected(user_changed_handler):
+		users.user_changed.disconnect(user_changed_handler)

--- a/tests/godot/gdk/tests/test_stats.gd
+++ b/tests/godot/gdk/tests/test_stats.gd
@@ -89,3 +89,50 @@ func test_stats_surface_and_validation() -> void:
 
 	var no_staged_signal = stats.flush_stats_async(user)
 	await assert_signal_result_error(no_staged_signal, "no_staged_stats", "flush_stats_async() rejects empty staged-stat batches")
+
+
+func test_set_stat_integer_live_stages_value() -> void:
+	if pending_unless_runtime_available():
+		return
+	if not requires_live():
+		return
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for set_stat_integer live coverage returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("set_stat_integer live coverage: %s" % init_result.message)
+		return
+
+	var gdk = get_gdk()
+	var stats = gdk.get_stats()
+	assert_not_null(stats, "GDK.stats is available for set_stat_integer live coverage")
+	if stats == null:
+		return
+
+	var sign_in = await ensure_primary_user()
+	var sign_in_signal = sign_in["signal"]
+	var sign_in_result = sign_in["result"]
+	var user = sign_in["user"]
+	if typeof(sign_in_signal) == TYPE_SIGNAL and sign_in_result == null:
+		assert_true(false, "Default-user flow for set_stat_integer live coverage completes")
+		return
+	if user == null:
+		if sign_in_result != null and not sign_in_result.ok:
+			assert_true(sign_in_result.code.length() > 0, "failed stats live sign-in exposes an error code")
+			assert_true(sign_in_result.message.length() > 0, "failed stats live sign-in exposes an error message")
+			pending("set_stat_integer live coverage: %s" % sign_in_result.message)
+		else:
+			pending("set_stat_integer live coverage: No signed-in user is available on this machine.")
+		return
+
+	var stat_name = with_unique_id("gdk_b3_integer_stat")
+	var set_result = stats.set_stat_integer(user, stat_name, 42)
+	assert_result_ok(set_result, "set_stat_integer() stages an integer value for a signed-in user")
+	if set_result == null or not set_result.ok:
+		return
+	assert_true(set_result.data is Dictionary, "set_stat_integer() returns staged stat metadata")
+	if set_result.data is Dictionary:
+		assert_eq(set_result.data["name"], stat_name, "set_stat_integer() result echoes stat name")
+		assert_eq(int(set_result.data["value"]), 42, "set_stat_integer() result echoes integer value")

--- a/tests/godot/gdk/tests/test_users.gd
+++ b/tests/godot/gdk/tests/test_users.gd
@@ -70,6 +70,9 @@ func test_users_full_flow() -> void:
 		assert_eq(blank_user.is_signed_in(), false, "blank GDKUser signed_in defaults false")
 		assert_eq(blank_user.is_store_user(), false, "blank GDKUser store_user defaults false")
 
+	var pre_init_add_with_ui_signal = users.add_user_with_ui_async()
+	await assert_signal_result_error(pre_init_add_with_ui_signal, "not_initialized", "add_user_with_ui_async() rejects before initialize")
+
 	var init_result = initialize_runtime()
 	assert_not_null(init_result, "GDK.initialize() for users behavior returns GDKResult")
 	if init_result == null:
@@ -80,6 +83,12 @@ func test_users_full_flow() -> void:
 
 	assert_eq(users.get_users().size(), 0, "get_users() starts empty after init")
 	assert_true(users.get_primary_user() == null, "get_primary_user() starts null after init")
+
+	var null_privilege_signal = users.check_privilege_async(null, 254)
+	await assert_signal_result_error(null_privilege_signal, "invalid_user", "check_privilege_async() rejects null users after initialize")
+
+	var null_issue_signal = users.resolve_issue_with_ui_async(null, "")
+	await assert_signal_result_error(null_issue_signal, "invalid_user", "resolve_issue_with_ui_async() rejects null users after initialize")
 
 	var user_changed_events: Array = []
 	users.connect("user_changed", func(user_arg, change_kind_arg): user_changed_events.append({"user": user_arg, "change_kind": change_kind_arg}))
@@ -120,10 +129,12 @@ func test_users_full_flow() -> void:
 		assert_eq(primary_user.get_local_id(), user.get_local_id(), "primary user matches the signed-in user")
 
 	assert_true(users.get_users().size() >= 1, "signed-in user is cached in the users service")
-	assert_eq(user_changed_events.size(), 1, "user_changed emitted for the first signed-in user")
-	if user_changed_events.size() > 0:
-		assert_eq(user_changed_events[0]["user"].get_local_id(), user.get_local_id(), "user_changed identifies the signed-in user")
-		assert_eq(user_changed_events[0]["change_kind"], "added", "user_changed reports added for a newly cached user")
+	assert_true(user_changed_events.size() >= 1, "user_changed emitted for the first signed-in user")
+	var matching_added_events := 0
+	for event in user_changed_events:
+		if event["user"].get_local_id() == user.get_local_id() and event["change_kind"] == "added":
+			matching_added_events += 1
+	assert_eq(matching_added_events, 1, "user_changed identifies the first signed-in user as added")
 
 	assert_true(user.get_local_id() != 0, "signed-in user local_id is populated")
 	assert_true(user.get_xuid().length() > 0, "signed-in user XUID is populated")


### PR DESCRIPTION
## Summary

Backfills the audit B3 GDK addon test gaps without changing addon source, docs, or samples. Adds/extends GUT coverage for runtime lifecycle re-arming, leaderboard around-user, multiplayer activity validation, users UI paths, Game UI stale-runtime behavior, dispatch count draining, achievement defaults, capture live gates, and stats integer staging.

## Finding map

- HIGH-1 init -> shutdown -> re-init: `tests/godot/gdk/tests/test_runtime_lifecycle.gd`.
- HIGH-2 `GDKLeaderboards.get_leaderboard_around_user_async`: `test_leaderboards.gd` offline validation + live-gated query.
- HIGH-3 four `GDKMultiplayerActivity` methods: `test_multiplayer_activity.gd` pins `get_activities_async`, `show_invite_ui_async`, `update_recent_players`, `flush_recent_players_async` null-user paths.
- MED-4/5/6 users UI/privilege paths: `test_users.gd` pins `add_user_with_ui_async`, `resolve_issue_with_ui_async`, `check_privilege_async`.
- MED-7 error reporting second-arg validation: `test_error_reporting.gd`.
- MED-8 Game UI after shutdown: `test_game_ui.gd`.
- MED-9 dispatch drained count: `test_dispatch.gd` queues two gamer-picture completions and asserts `GDK.dispatch() == 2`.
- LOW-10 achievement defaults: `test_achievement.gd`.
- LOW-11 live-capture gate before init: `test_capture.gd` now calls `requires_live()` before runtime init for live/native capture flows.
- LOW-12 stats integer happy path: `test_stats.gd` live-gated `set_stat_integer` staging test.

## Assertion pins

| Test | Direct assert/helper count | Pin |
| --- | ---: | --- |
| `test_runtime_lifecycle::test_initialize_shutdown_reinitialize_rearms_runtime_and_signals` | 14 | first init, shutdown signal, second init success, signal re-emission, dispatch callable |
| `test_leaderboards::test_leaderboards_surface_and_validation` | +2 | around-user pre-init `runtime_unavailable`; null-user `invalid_user` |
| `test_leaderboards::test_leaderboard_around_user_live_read` | 12 | live Signal/result shape; success payload type/stat/query type; failure code/message |
| `test_multiplayer_activity::test_multiplayer_activity_full_flow` | +4 | four missing activity methods reject null user |
| `test_users::test_users_full_flow` | +3 validation pins | add-with-UI pre-init, resolve-issue null user, check-privilege null user |
| `test_error_reporting::test_error_reporting_surface` | +1 | second `configure_options` argument rejects unsupported bits |
| `test_game_ui::test_game_ui_show_method_fails_after_shutdown` | 4 | init, service, post-shutdown state, `show_message_dialog_async` failure |
| `test_dispatch::test_dispatch_returns_number_of_drained_completion_events` | 7 passing-path | two queued completions; dispatch count equals two; both signals complete |
| `test_achievement::test_achievement_default_values` | 19 | method surface plus blank-wrapper default values |
| `test_stats::test_set_stat_integer_live_stages_value` | 6 passing-path | live user integer stat staging payload |
| `test_capture` live/native capture flows | 0 new asserts | moves live gate before initialization to avoid offline init/use |

## Tier breakdown

- Offline/local-user audit pins: 10 test functions/sections.
- Live-gated: 6 functions/sections (`leaderboard_around_user`, `set_stat_integer`, and four capture native/live flows). Existing multiplayer live tail remains pending without `LIVE_TESTS=1`.
- Live-write-gated: 0. No live-write coverage added or run.

## Validation

- `pwsh -File .\tools\check_gd_scripts_headless.ps1 -Projects addons`: passed.
- Full parse gate was run and still fails on pre-existing sample tutorial contexts (`sample\tutorial_app`, `sample\tutorial_gameinput`) with missing GDK/PlayFab/GameInput script classes; tracking note: `audit-followup-parse-gate-samples`.
- `build\bin\Debug\gdk_unit_tests.exe`: 8/8 test cases, 34/34 assertions passed.
- GDK GUT host (`tests\godot\gdk`, console Godot 4.6.2): 240 passing / 13 pending / 0 failing; 253 tests; 2397 assertions.
- Live tests were skipped (`LIVE_TESTS` unset). Live writes were not run.

## Notes

- `requires_live()` / `requires_live_write()` helpers were added to the GDK test base; existing `pending_unless_live()` now delegates to `requires_live()` for compatibility.
- Full `run_all_tests.ps1` was intentionally narrowed because the repo-wide parse gate is blocked by the pre-existing sample follow-up above; doctest + targeted GDK GUT are the green bar for this tests-only lane.
