### PR TITLE
e3: SDK worker-thread callback lifetime audit (audit T3 sweep)

### DIFF
--- a/addons/godot_gameinput/src/gameinput_mapper.cpp
+++ b/addons/godot_gameinput/src/gameinput_mapper.cpp
@@ -178,7 +178,6 @@ void GameInputMapper::_release_held_action_for(int binding_index) {
                 input->parse_input_event(evt);
             }
         }
-        }
     }
 
     m_prev_pressed.erase(binding_index);

--- a/addons/godot_gameinput/src/gameinput_singleton.cpp
+++ b/addons/godot_gameinput/src/gameinput_singleton.cpp
@@ -325,6 +325,7 @@ void GameInput::shutdown() {
     m_accepting_callbacks.store(false, std::memory_order_release);
 
     if (m_game_input && m_device_callback_token) {
+        // UnregisterCallback blocks until in-flight callbacks finish; StopCallback does not.
         bool unregistered = m_game_input->UnregisterCallback(m_device_callback_token);
         if (!unregistered) {
             UtilityFunctions::push_warning(

--- a/addons/godot_gdk/src/gdk_error_reporting.cpp
+++ b/addons/godot_gdk/src/gdk_error_reporting.cpp
@@ -34,16 +34,20 @@ void GDKErrorReporting::set_owner(GDK *p_owner) {
 }
 
 Ref<GDKResult> GDKErrorReporting::on_runtime_initialized() {
+    XErrorSetCallback(nullptr, nullptr);
+    _clear_callback_context();
+
     std::lock_guard<std::mutex> lock(m_pending_errors_mutex);
     m_pending_errors.clear();
     m_runtime_ready = true;
     m_callback_enabled = false;
-    XErrorSetCallback(nullptr, nullptr);
     return GDKResult::ok_result();
 }
 
 void GDKErrorReporting::shutdown() {
-    XErrorSetCallback(nullptr, nullptr);
+    if (m_runtime_ready) {
+        _set_callback(nullptr);
+    }
 
     std::lock_guard<std::mutex> lock(m_pending_errors_mutex);
     m_pending_errors.clear();
@@ -111,24 +115,48 @@ Ref<GDKResult> GDKErrorReporting::configure_options(
 
 Ref<GDKResult> GDKErrorReporting::set_callback_enabled(bool p_enabled) {
     XErrorCallback *callback = p_enabled ? _error_callback : nullptr;
-    void *context = p_enabled ? this : nullptr;
-    Ref<GDKResult> result = _set_callback(callback, context);
+    Ref<GDKResult> result = _set_callback(callback);
     if (result->is_ok()) {
         m_callback_enabled = p_enabled;
     }
     return result;
 }
 
-Ref<GDKResult> GDKErrorReporting::_set_callback(XErrorCallback *p_callback, void *p_context) {
+void GDKErrorReporting::_clear_callback_context() {
+    if (m_callback_context) {
+        std::lock_guard<std::mutex> lock(m_callback_context->mutex);
+        m_callback_context->active.store(false, std::memory_order_release);
+        m_callback_context->service = nullptr;
+    }
+
+    if (m_callback_token) {
+        constexpr size_t MAX_RETIRED_CALLBACK_TOKENS = 16;
+        m_retired_callback_tokens.push_back(m_callback_token);
+        if (m_retired_callback_tokens.size() > MAX_RETIRED_CALLBACK_TOKENS) {
+            m_retired_callback_tokens.erase(m_retired_callback_tokens.begin());
+        }
+        m_callback_token.reset();
+    }
+    m_callback_context.reset();
+}
+
+Ref<GDKResult> GDKErrorReporting::_set_callback(XErrorCallback *p_callback) {
     if (!m_runtime_ready) {
         return GDKResult::error_result(E_FAIL, "runtime_not_initialized", RUNTIME_NOT_INITIALIZED_ERROR_MESSAGE);
     }
 
-    XErrorSetCallback(p_callback, p_context);
-
-    GDKRuntime *runtime = get_runtime_internal();
-    if (runtime != nullptr) {
+    if (p_callback == nullptr) {
+        _clear_callback_context();
+        XErrorSetCallback(nullptr, nullptr);
+        return GDKResult::ok_result();
     }
+
+    _clear_callback_context();
+    m_callback_context = std::make_shared<CallbackContext>();
+    m_callback_context->service = this;
+    m_callback_token = std::make_shared<CallbackToken>();
+    m_callback_token->context = m_callback_context;
+    XErrorSetCallback(p_callback, m_callback_token.get());
 
     return GDKResult::ok_result();
 }
@@ -150,10 +178,19 @@ void GDKErrorReporting::push_error_internal(HRESULT p_hr, const char *p_message)
 }
 
 bool GDKErrorReporting::_error_callback(HRESULT p_hr, const char *p_message, void *p_context) {
-    GDKErrorReporting *service = static_cast<GDKErrorReporting *>(p_context);
-    if (service != nullptr) {
-        service->push_error_internal(p_hr, p_message);
+    CallbackToken *token = static_cast<CallbackToken *>(p_context);
+    std::shared_ptr<CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+    if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
+        return true;
     }
+
+    std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+    GDKErrorReporting *service = callback_context->service;
+    if (!callback_context->active.load(std::memory_order_acquire) || service == nullptr) {
+        return true;
+    }
+
+    service->push_error_internal(p_hr, p_message);
     return true;
 }
 

--- a/addons/godot_gdk/src/gdk_error_reporting.h
+++ b/addons/godot_gdk/src/gdk_error_reporting.h
@@ -6,6 +6,8 @@
 #endif
 #include <windows.h>
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -41,15 +43,29 @@ private:
         std::string message;
     };
 
+    struct CallbackContext {
+        GDKErrorReporting *service = nullptr;
+        std::atomic_bool active = true;
+        std::mutex mutex;
+    };
+
+    struct CallbackToken {
+        std::weak_ptr<CallbackContext> context;
+    };
+
     GDK *m_owner = nullptr;
     bool m_runtime_ready = false;
     bool m_callback_enabled = false;
     std::mutex m_pending_errors_mutex;
     std::vector<PendingError> m_pending_errors;
+    std::shared_ptr<CallbackContext> m_callback_context;
+    std::shared_ptr<CallbackToken> m_callback_token;
+    std::vector<std::shared_ptr<CallbackToken>> m_retired_callback_tokens;
 
     static bool _error_callback(HRESULT p_hr, const char *p_message, void *p_context);
     static Ref<GDKResult> _parse_options(int64_t p_options_value, XErrorOptions *r_options);
-    Ref<GDKResult> _set_callback(XErrorCallback *p_callback, void *p_context);
+    void _clear_callback_context();
+    Ref<GDKResult> _set_callback(XErrorCallback *p_callback);
 
 protected:
     static void _bind_methods();

--- a/addons/godot_gdk/src/gdk_stats.cpp
+++ b/addons/godot_gdk/src/gdk_stats.cpp
@@ -535,6 +535,12 @@ void GDKStats::_apply_staged_stats_to_cache(const Ref<GDKUser> &p_user, const st
 }
 
 void GDKStats::_close_tracking_state(TrackingState &p_state) {
+    if (p_state.callback_context) {
+        std::lock_guard<std::mutex> lock(p_state.callback_context->mutex);
+        p_state.callback_context->active.store(false, std::memory_order_release);
+        p_state.callback_context->stats = nullptr;
+    }
+
     if (p_state.handler_registered && p_state.context != nullptr) {
         XblUserStatisticsRemoveStatisticChangedHandler(p_state.context, p_state.handler_token);
     }
@@ -545,6 +551,16 @@ void GDKStats::_close_tracking_state(TrackingState &p_state) {
         XblContextCloseHandle(p_state.context);
         p_state.context = nullptr;
     }
+
+    if (p_state.callback_token) {
+        constexpr size_t MAX_RETIRED_CALLBACK_TOKENS = 16;
+        m_retired_callback_tokens.push_back(p_state.callback_token);
+        if (m_retired_callback_tokens.size() > MAX_RETIRED_CALLBACK_TOKENS) {
+            m_retired_callback_tokens.erase(m_retired_callback_tokens.begin());
+        }
+        p_state.callback_token.reset();
+    }
+    p_state.callback_context.reset();
 }
 
 Ref<GDKResult> GDKStats::on_runtime_initialized() {
@@ -840,7 +856,11 @@ Ref<GDKResult> GDKStats::track_stats(const Ref<GDKUser> &p_user, const PackedStr
             return GDKResult::hresult_error(context_hr, "Failed to create an Xbox services context for statistics tracking.", "xbox_context_unavailable");
         }
 
-        new_state.handler_token = XblUserStatisticsAddStatisticChangedHandler(new_state.context, _statistic_changed_handler, this);
+        new_state.callback_context = std::make_shared<TrackingState::CallbackContext>();
+        new_state.callback_context->stats = this;
+        new_state.callback_token = std::make_shared<TrackingState::CallbackToken>();
+        new_state.callback_token->context = new_state.callback_context;
+        new_state.handler_token = XblUserStatisticsAddStatisticChangedHandler(new_state.context, _statistic_changed_handler, new_state.callback_token.get());
         new_state.handler_registered = true;
         m_tracking_states.push_back(new_state);
         state = &m_tracking_states.back();
@@ -961,8 +981,15 @@ void GDKStats::on_user_removed(const Ref<GDKUser> &p_user) {
 }
 
 void CALLBACK GDKStats::_statistic_changed_handler(XblStatisticChangeEventArgs p_args, void *p_context) {
-    GDKStats *stats = static_cast<GDKStats *>(p_context);
-    if (stats == nullptr) {
+    TrackingState::CallbackToken *token = static_cast<TrackingState::CallbackToken *>(p_context);
+    std::shared_ptr<TrackingState::CallbackContext> callback_context = token != nullptr ? token->context.lock() : nullptr;
+    if (!callback_context || !callback_context->active.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> context_lock(callback_context->mutex);
+    GDKStats *stats = callback_context->stats;
+    if (!callback_context->active.load(std::memory_order_acquire) || stats == nullptr) {
         return;
     }
 

--- a/addons/godot_gdk/src/gdk_stats.h
+++ b/addons/godot_gdk/src/gdk_stats.h
@@ -6,6 +6,8 @@
 #endif
 #include <windows.h>
 
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -51,12 +53,24 @@ private:
     };
 
     struct TrackingState {
+        struct CallbackContext {
+            GDKStats *stats = nullptr;
+            std::atomic_bool active = true;
+            std::mutex mutex;
+        };
+
+        struct CallbackToken {
+            std::weak_ptr<CallbackContext> context;
+        };
+
         Ref<GDKUser> user;
         XUserLocalId local_id = {};
         uint64_t xbox_user_id = 0;
         XblContextHandle context = nullptr;
         XblFunctionContext handler_token = {};
         bool handler_registered = false;
+        std::shared_ptr<CallbackContext> callback_context;
+        std::shared_ptr<CallbackToken> callback_token;
     };
 
     struct PendingStatChange {
@@ -73,6 +87,7 @@ private:
     std::vector<TrackingState> m_tracking_states;
     std::vector<PendingStatChange> m_pending_stat_changes;
     mutable std::mutex m_pending_stat_changes_mutex;
+    std::vector<std::shared_ptr<TrackingState::CallbackToken>> m_retired_callback_tokens;
 
     static void CALLBACK _statistic_changed_handler(XblStatisticChangeEventArgs p_args, void *p_context);
 

--- a/docs/gameinput/plugin.md
+++ b/docs/gameinput/plugin.md
@@ -162,6 +162,11 @@ preferred for clarity.
   raw `IGameInputDevice*`. Stale wrappers stay alive but `is_connected()`
   starts returning `false` and other methods return safe defaults.
 * Device ids are never recycled within a session.
+* Shutdown uses `IGameInput::UnregisterCallback` rather than `StopCallback`:
+  Microsoft documents `UnregisterCallback` as the point after which callback
+  resources may be removed, while `StopCallback` only prevents future dispatch.
+  This keeps the raw callback context, cached devices, and pending-event queue
+  alive until any in-flight GameInput worker callback has finished.
 
 ## In-editor docs
 


### PR DESCRIPTION
## Summary

- Swept SDK callback registrations in GDK, PlayFab, and GameInput for worker-thread context lifetime hazards.
- Fixed GDK stats and XError callback contexts with the PR #17-style shared token + weak context + atomic inactive guard.
- Documented the GameInput v3 `UnregisterCallback` shutdown contract and fixed a pre-existing GameInput mapper brace build break surfaced by validation.

## Sweep table

| Area | Registration / callback source | Context and teardown | Verdict |
| --- | --- | --- | --- |
| GDK runtime | `XTaskQueueTerminate(..., _queue_terminated)` | Stack `bool` is used only while shutdown dispatches completion until the callback fires before stack unwind. | OK |
| GDK users | `XUserRegisterForChangeEvent` | Raw `GDKUsers*`; `XUserUnregisterForChangeEvent(..., true)` waits before refs are cleared. | OK |
| GDK activation | `XGameActivationRegisterForEvent` | Raw `GDKActivation*`; `XGameActivationUnregisterForEvent(..., true)` waits before listeners are cleared. | OK |
| GDK presence | `XblPresenceAddDevicePresenceChangedHandler`, `XblPresenceAddTitlePresenceChangedHandler` | Already PR #17 pattern: `shared_ptr` context, weak token, atomic inactive guard, retired token retention. | OK |
| GDK stats | `XblUserStatisticsAddStatisticChangedHandler` | Previously raw `GDKStats*`; now weak token + shared context + atomic inactive guard before `RemoveStatisticChangedHandler`. | GAP fixed |
| GDK error reporting | `XErrorSetCallback` | Previously raw `GDKErrorReporting*`; now weak token + shared context + atomic inactive guard before clearing the SDK callback. | GAP fixed |
| PlayFab XAsync APIs | `PF*Async` / `XAsyncBlock` via `PlayFabSignalXAsyncContext` and API helpers | Heap contexts own request data and self-delete only from completion thunk; shutdown cancels retained signals. | OK |
| PlayFab runtime queues | `XTaskQueueTerminate` in runtime and multiplayer | Heap terminate contexts with atomic completion; timeout path intentionally leaks context to avoid UAF if SDK callback arrives late. | OK |
| PlayFab Party | `PartyManager::StartProcessingStateChanges` / `FinishProcessingStateChanges` | Synchronous dispatch batch; shutdown/reset defers native teardown while a state-change batch is active. | OK |
| PlayFab Multiplayer | `PFMultiplayer*Async`, lobby/matchmaking state changes | Pending operations are tracked and completed/cancelled from state-change dispatch; native teardown happens after cancellation/drain. | OK |
| GameInput | `IGameInput::RegisterDeviceCallback` / `UnregisterCallback` | Raw `GameInput*` remains valid because `UnregisterCallback` is documented to block until callback resources are safe to remove; atomic guard still ignores late work. | OK; contract documented |

## GameInput v3 contract decision

Microsoft documents `IGameInput::UnregisterCallback` as: the callback will no longer be called, and resources may be removed after `UnregisterCallback` completes. The sibling `StopCallback` explicitly does **not** make resources safe to remove. Decision: no additional sleep/barrier is needed for GameInput v3 shutdown; use `UnregisterCallback`, not `StopCallback`, and document that contract in `docs/gameinput/plugin.md`.

## Validation

- `git submodule update --init --recursive` (needed for this fresh worktree)
- `cmake --preset default` ✅
- `cmake --build build --preset debug` ✅
- `build\bin\Debug\gdk_unit_tests.exe` ✅ (8 tests, 34 assertions)
- GDScript parse gate: not run; no `.gd` files changed.
- Targeted GUT hosts: not run because no Godot console executable is present in env/sample/tests in this worktree. Full orchestrator intentionally skipped due `audit-followup-parse-gate-samples`.
- Live tests: skipped (default); no live writes.

No public API was added or renamed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
