### PR TITLE
fix: PlayFabParty leave_async - treat PartyLeaveNetwork operation-succeeded as success

### DIFF
--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -1569,6 +1569,20 @@ Signal PlayFabParty::_test_enqueue_shutdown_pending() {
 int64_t PlayFabParty::_test_pending_operation_count() const {
     return static_cast<int64_t>(m_pending_operations.size() + m_pending_operations_deferred_delete.size());
 }
+
+Dictionary PlayFabParty::_test_classify_leave_network_completed(int64_t p_state_change_result, int64_t p_error_detail) const {
+    const auto state_change_result = static_cast<Party::PartyStateChangeResult>(p_state_change_result);
+    Ref<PlayFabResult> result = _party_leave_network_completed_result(state_change_result, static_cast<uint32_t>(p_error_detail));
+    Dictionary payload;
+    payload["state_change_result"] = _party_state_change_result_name(state_change_result);
+    if (result.is_valid()) {
+        payload["ok"] = result->is_ok();
+        payload["hresult"] = result->get_hresult();
+        payload["code"] = result->get_code();
+        payload["message"] = result->get_message();
+    }
+    return payload;
+}
 #endif
 
 void PlayFabParty::_track_network(const Ref<PlayFabPartyNetwork> &p_network) {
@@ -2173,7 +2187,7 @@ void PlayFabParty::_process_create_new_network_completed(const Party::PartyState
         return;
     }
     if (change->result != Party::PartyStateChangeResult::Succeeded) {
-        Ref<PlayFabResult> result = _party_error_result(change->errorDetail, PARTY_NETWORK_CREATE_FAILED, "PartyCreateNewNetwork");
+        Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_NETWORK_CREATE_FAILED, "PartyCreateNewNetwork");
         if (operation->network.is_valid()) {
             operation->network->set_state_value(NETWORK_STATE_FAILED);
             _emit_network_state(operation->network, NETWORK_CHANGE_ERROR, 0, result, "Create new network failed.");
@@ -2195,7 +2209,7 @@ void PlayFabParty::_process_connect_to_network_completed(const Party::PartyState
         return;
     }
     if (change->result != Party::PartyStateChangeResult::Succeeded) {
-        Ref<PlayFabResult> result = _party_error_result(change->errorDetail, PARTY_NETWORK_CONNECT_FAILED, "PartyConnectToNetwork");
+        Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_NETWORK_CONNECT_FAILED, "PartyConnectToNetwork");
         if (operation->network.is_valid()) {
             operation->network->set_state_value(NETWORK_STATE_FAILED);
             _emit_network_state(operation->network, NETWORK_CHANGE_ERROR, 0, result, "Connect to network failed.");
@@ -2241,7 +2255,7 @@ void PlayFabParty::_process_authenticate_local_user_completed(const Party::Party
         return;
     }
     if (change->result != Party::PartyStateChangeResult::Succeeded) {
-        Ref<PlayFabResult> result = _party_error_result(change->errorDetail, PARTY_NETWORK_CONNECT_FAILED, "PartyAuthenticateLocalUser");
+        Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_NETWORK_CONNECT_FAILED, "PartyAuthenticateLocalUser");
         if (operation->network.is_valid()) {
             operation->network->set_state_value(NETWORK_STATE_FAILED);
             _emit_network_state(operation->network, NETWORK_CHANGE_ERROR, 0, result, "Authenticate failed.");
@@ -2289,7 +2303,7 @@ void PlayFabParty::_process_create_endpoint_completed(const Party::PartyStateCha
         return;
     }
     if (change->result != Party::PartyStateChangeResult::Succeeded) {
-        Ref<PlayFabResult> result = _party_error_result(change->errorDetail, PARTY_TRANSPORT_CREATE_FAILED, "PartyCreateEndpoint");
+        Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_TRANSPORT_CREATE_FAILED, "PartyCreateEndpoint");
         if (operation->network.is_valid()) {
             operation->network->set_state_value(NETWORK_STATE_FAILED);
             _emit_network_state(operation->network, NETWORK_CHANGE_ERROR, 0, result, "Create endpoint failed.");
@@ -2529,19 +2543,7 @@ void PlayFabParty::_process_network_descriptor_changed(const Party::PartyStateCh
 void PlayFabParty::_process_leave_network_completed(const Party::PartyStateChange *p_change) {
     const auto *change = static_cast<const Party::PartyLeaveNetworkCompletedStateChange *>(p_change);
     PendingOperation *operation = static_cast<PendingOperation *>(change->asyncIdentifier);
-    Ref<PlayFabResult> result;
-    // Treat any non-Succeeded result with a zero errorDetail as a success.
-    // PartyLeaveNetwork can surface result codes like CanceledByPlatform or
-    // benign-but-not-Succeeded statuses where errorDetail == 0 and
-    // GetErrorMessage returns the literal string "operation succeeded".
-    // Without this guard we'd report `party_resource_not_ready:
-    // PartyLeaveNetwork: operation succeeded` even though the leave itself
-    // completed without an actionable error.
-    if (change->result != Party::PartyStateChangeResult::Succeeded && change->errorDetail != 0) {
-        result = _party_error_result(change->errorDetail, PARTY_RESOURCE_NOT_READY, "PartyLeaveNetwork");
-    } else {
-        result = PlayFabResult::ok_result();
-    }
+    Ref<PlayFabResult> result = _party_leave_network_completed_result(change->result, change->errorDetail);
     Ref<PlayFabPartyNetwork> network;
     if (operation != nullptr) {
         network = operation->network;
@@ -2613,7 +2615,7 @@ void PlayFabParty::_process_create_chat_control_completed(const Party::PartyStat
         return;
     }
     if (change->result != Party::PartyStateChangeResult::Succeeded) {
-        Ref<PlayFabResult> result = _party_error_result(change->errorDetail, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyCreateChatControl");
+        Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyCreateChatControl");
         if (operation->network.is_valid()) {
             _emit_network_state(operation->network, NETWORK_CHANGE_ERROR, 0, result, "Create chat control failed.");
         }
@@ -2661,7 +2663,7 @@ void PlayFabParty::_process_connect_chat_control_completed(const Party::PartySta
         return;
     }
     if (change->result != Party::PartyStateChangeResult::Succeeded) {
-        Ref<PlayFabResult> result = _party_error_result(change->errorDetail, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyNetwork::ConnectChatControl");
+        Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyNetwork::ConnectChatControl");
         if (operation->network.is_valid()) {
             _emit_network_state(operation->network, NETWORK_CHANGE_ERROR, 0, result, "Connect chat control failed.");
         }
@@ -3303,6 +3305,21 @@ Ref<PlayFabResult> PlayFabParty::_party_error_result(uint32_t p_party_error, con
     return PlayFabResult::error_result(E_FAIL, p_code, message);
 }
 
+Ref<PlayFabResult> PlayFabParty::_party_state_change_error_result(Party::PartyStateChangeResult p_result, uint32_t p_party_error, const String &p_code, const String &p_action) const {
+    if (p_party_error != c_partyErrorSuccess) {
+        return _party_error_result(p_party_error, p_code, p_action);
+    }
+    return PlayFabResult::error_result(E_FAIL, p_code,
+            vformat("%s failed with PartyStateChangeResult::%s.", p_action, _party_state_change_result_name(p_result)));
+}
+
+Ref<PlayFabResult> PlayFabParty::_party_leave_network_completed_result(Party::PartyStateChangeResult p_result, uint32_t p_party_error) const {
+    if (p_result == Party::PartyStateChangeResult::Succeeded || p_result == Party::PartyStateChangeResult::LeaveNetworkCalled) {
+        return PlayFabResult::ok_result();
+    }
+    return _party_state_change_error_result(p_result, p_party_error, PARTY_RESOURCE_NOT_READY, "PartyLeaveNetwork");
+}
+
 String PlayFabParty::_party_error_message(uint32_t p_party_error) {
     PartyString text = nullptr;
     PartyError err = Party::PartyManager::GetErrorMessage(p_party_error, &text);
@@ -3310,6 +3327,43 @@ String PlayFabParty::_party_error_message(uint32_t p_party_error) {
         return String("Unknown PlayFab Party error.");
     }
     return String::utf8(text);
+}
+
+String PlayFabParty::_party_state_change_result_name(Party::PartyStateChangeResult p_result) {
+    switch (p_result) {
+        case Party::PartyStateChangeResult::Succeeded:
+            return "Succeeded";
+        case Party::PartyStateChangeResult::UnknownError:
+            return "UnknownError";
+        case Party::PartyStateChangeResult::CanceledByTitle:
+            return "CanceledByTitle";
+        case Party::PartyStateChangeResult::InternetConnectivityError:
+            return "InternetConnectivityError";
+        case Party::PartyStateChangeResult::PartyServiceError:
+            return "PartyServiceError";
+        case Party::PartyStateChangeResult::NoServersAvailable:
+            return "NoServersAvailable";
+        case Party::PartyStateChangeResult::UserNotAuthorized:
+            return "UserNotAuthorized";
+        case Party::PartyStateChangeResult::UserCreateNetworkThrottled:
+            return "UserCreateNetworkThrottled";
+        case Party::PartyStateChangeResult::TitleNotEnabledForParty:
+            return "TitleNotEnabledForParty";
+        case Party::PartyStateChangeResult::NetworkLimitReached:
+            return "NetworkLimitReached";
+        case Party::PartyStateChangeResult::NetworkNoLongerExists:
+            return "NetworkNoLongerExists";
+        case Party::PartyStateChangeResult::NetworkNotJoinable:
+            return "NetworkNotJoinable";
+        case Party::PartyStateChangeResult::VersionMismatch:
+            return "VersionMismatch";
+        case Party::PartyStateChangeResult::LeaveNetworkCalled:
+            return "LeaveNetworkCalled";
+        case Party::PartyStateChangeResult::FailedToBindToLocalUdpSocket:
+            return "FailedToBindToLocalUdpSocket";
+        default:
+            return vformat("Unknown(%d)", static_cast<int64_t>(p_result));
+    }
 }
 
 void PlayFabParty::_emit_network_state(const Ref<PlayFabPartyNetwork> &p_network, int64_t p_kind, int64_t p_peer_id, const Ref<PlayFabResult> &p_result, const String &p_reason) {
@@ -3348,6 +3402,7 @@ void PlayFabParty::_bind_methods() {
 #ifdef GODOT_PLAYFAB_TEST_HOOKS
     ClassDB::bind_method(D_METHOD("_test_enqueue_shutdown_pending"), &PlayFabParty::_test_enqueue_shutdown_pending);
     ClassDB::bind_method(D_METHOD("_test_pending_operation_count"), &PlayFabParty::_test_pending_operation_count);
+    ClassDB::bind_method(D_METHOD("_test_classify_leave_network_completed", "state_change_result", "error_detail"), &PlayFabParty::_test_classify_leave_network_completed);
 #endif
 
     ADD_SIGNAL(MethodInfo("party_error", PropertyInfo(Variant::OBJECT, "result", PROPERTY_HINT_RESOURCE_TYPE, "PlayFabResult")));

--- a/addons/godot_playfab/src/playfab_party.h
+++ b/addons/godot_playfab/src/playfab_party.h
@@ -32,6 +32,7 @@ class PartyLocalChatControl;
 class PartyLocalEndpoint;
 class PartyLocalUser;
 class PartyNetwork;
+enum class PartyStateChangeResult;
 struct PartyStateChange;
 }
 
@@ -626,6 +627,7 @@ private:
 #ifdef GODOT_PLAYFAB_TEST_HOOKS
     Signal _test_enqueue_shutdown_pending();
     int64_t _test_pending_operation_count() const;
+    Dictionary _test_classify_leave_network_completed(int64_t p_state_change_result, int64_t p_error_detail) const;
 #endif
 
     void _emit_network_state(const Ref<PlayFabPartyNetwork> &p_network, int64_t p_kind, int64_t p_peer_id, const Ref<PlayFabResult> &p_result, const String &p_reason);
@@ -651,7 +653,10 @@ private:
     int64_t _translate_chat_permissions_from_native(int32_t p_native) const;
 
     Ref<PlayFabResult> _party_error_result(uint32_t p_party_error, const String &p_code, const String &p_action) const;
+    Ref<PlayFabResult> _party_state_change_error_result(Party::PartyStateChangeResult p_result, uint32_t p_party_error, const String &p_code, const String &p_action) const;
+    Ref<PlayFabResult> _party_leave_network_completed_result(Party::PartyStateChangeResult p_result, uint32_t p_party_error) const;
     static String _party_error_message(uint32_t p_party_error);
+    static String _party_state_change_result_name(Party::PartyStateChangeResult p_result);
 
 protected:
     static void _bind_methods();

--- a/tests/godot/playfab/tests/test_party.gd
+++ b/tests/godot/playfab/tests/test_party.gd
@@ -387,6 +387,37 @@ func test_party_shutdown_cancels_reentrant_pending_operations() -> void:
 	assert_eq(party._test_pending_operation_count(), 0, "Shutdown drains all PlayFab Party pending operations")
 
 
+func test_party_leave_network_completed_classification_uses_state_result() -> void:
+	if pending_unless_playfab_available():
+		return
+
+	var playfab = get_playfab()
+	reset_playfab_runtime()
+	var party = playfab.get_party()
+	if party == null:
+		return
+	if not party.has_method("_test_classify_leave_network_completed"):
+		pending("PlayFab Party leave classification test requires debug test hooks.")
+		return
+
+	# Party SDK enum values from PartyStateChangeResult in Party.h.
+	const PARTY_STATE_CHANGE_SUCCEEDED := 0
+	const PARTY_STATE_CHANGE_CANCELED_BY_TITLE := 2
+	const PARTY_STATE_CHANGE_LEAVE_NETWORK_CALLED := 14
+
+	var succeeded_with_detail: Dictionary = party._test_classify_leave_network_completed(PARTY_STATE_CHANGE_SUCCEEDED, 1)
+	assert_true(bool(succeeded_with_detail.get("ok", false)), "PartyLeaveNetwork treats Succeeded as success even with diagnostic detail")
+
+	var graceful_leave: Dictionary = party._test_classify_leave_network_completed(PARTY_STATE_CHANGE_LEAVE_NETWORK_CALLED, 0)
+	assert_true(bool(graceful_leave.get("ok", false)), "PartyLeaveNetwork treats LeaveNetworkCalled as a successful local leave")
+
+	var canceled_zero_detail: Dictionary = party._test_classify_leave_network_completed(PARTY_STATE_CHANGE_CANCELED_BY_TITLE, 0)
+	assert_false(bool(canceled_zero_detail.get("ok", true)), "PartyLeaveNetwork does not treat every zero errorDetail as success")
+	assert_eq(String(canceled_zero_detail.get("code", "")), "party_resource_not_ready", "Failed PartyLeaveNetwork keeps the expected error code")
+	assert_true(String(canceled_zero_detail.get("message", "")).contains("CanceledByTitle"), "Zero-detail PartyLeaveNetwork failure names the SDK state result")
+	assert_false(String(canceled_zero_detail.get("message", "")).contains("operation succeeded"), "Zero-detail PartyLeaveNetwork failure does not report operation succeeded")
+
+
 func _assert_signal_error(async_signal, expected_code: String, name: String) -> void:
 	assert_eq(typeof(async_signal), TYPE_SIGNAL, "%s returns completion Signal" % name)
 	if typeof(async_signal) != TYPE_SIGNAL:

--- a/tests/godot/playfab/tests/test_party_live.gd
+++ b/tests/godot/playfab/tests/test_party_live.gd
@@ -22,8 +22,8 @@ func test_party_create_and_leave_single_host_reports_success_without_resource_no
 	var sign_in = await sign_in_with_configured_custom_id(playfab, "PlayFab Party create/leave regression", _PARTY_INIT_TIMEOUT_MSEC)
 	var playfab_user = sign_in.get("playfab_user")
 	if playfab_user == null:
+		playfab.shutdown()
 		return
-
 	var party = playfab.get_party()
 	assert_object_is(party, "PlayFabParty", "PlayFab.get_party() returns PlayFabParty for live Party regression")
 	if party == null:

--- a/tests/godot/playfab/tests/test_party_live.gd
+++ b/tests/godot/playfab/tests/test_party_live.gd
@@ -1,0 +1,91 @@
+extends "res://addons/godot_gdk_tests/playfab_test_base.gd"
+## Live regression coverage for PlayFab Party network leave completion.
+##
+## Gated by `pending_unless_live()` because it signs in to the configured
+## PlayFab sandbox and creates a transient Party network before leaving it.
+
+const _PARTY_INIT_TIMEOUT_MSEC := 60_000
+const _PARTY_CREATE_TIMEOUT_MSEC := 90_000
+const _PARTY_LEAVE_TIMEOUT_MSEC := 30_000
+const _STATE_PUMP_FRAMES := 30
+
+
+func test_party_create_and_leave_single_host_reports_success_without_resource_not_ready() -> void:
+	if pending_unless_live():
+		return
+	if pending_unless_playfab_available():
+		return
+
+	var playfab = get_playfab()
+	reset_playfab_runtime()
+
+	var sign_in = await sign_in_with_configured_custom_id(playfab, "PlayFab Party create/leave regression", _PARTY_INIT_TIMEOUT_MSEC)
+	var playfab_user = sign_in.get("playfab_user")
+	if playfab_user == null:
+		return
+
+	var party = playfab.get_party()
+	assert_object_is(party, "PlayFabParty", "PlayFab.get_party() returns PlayFabParty for live Party regression")
+	if party == null:
+		playfab.shutdown()
+		return
+
+	var config = instantiate_class("PlayFabPartyConfig")
+	assert_object_is(config, "PlayFabPartyConfig", "PlayFabPartyConfig instantiable for live Party regression")
+	if config == null:
+		playfab.shutdown()
+		return
+	config.max_players = 4
+	config.direct_peer_connectivity = get_class_constant("PlayFabParty", "DIRECT_PEER_CONNECTIVITY_ANY")
+	config.enable_voice_chat = false
+	config.enable_text_chat = false
+
+	var init_result = await await_completion(party.initialize_async(config), _PARTY_INIT_TIMEOUT_MSEC)
+	if init_result == null:
+		pending("PlayFab.party.initialize_async timed out before Party leave regression check.")
+		playfab.shutdown()
+		return
+	if not init_result.ok:
+		pending("PlayFab.party.initialize_async failed before Party leave regression check: %s" % init_result.message)
+		playfab.shutdown()
+		return
+
+	var create_result = await await_completion(party.create_and_join_network_async(playfab_user, config), _PARTY_CREATE_TIMEOUT_MSEC)
+	if create_result == null:
+		pending("PlayFab.party.create_and_join_network_async timed out before Party leave regression check.")
+		await await_completion(party.shutdown_async(), _PARTY_INIT_TIMEOUT_MSEC)
+		playfab.shutdown()
+		return
+	if not create_result.ok:
+		pending("PlayFab.party.create_and_join_network_async failed before Party leave regression check: %s" % create_result.message)
+		await await_completion(party.shutdown_async(), _PARTY_INIT_TIMEOUT_MSEC)
+		playfab.shutdown()
+		return
+
+	var network = create_result.data
+	assert_object_is(network, "PlayFabPartyNetwork", "create_and_join_network_async returns PlayFabPartyNetwork")
+	if network == null:
+		await await_completion(party.shutdown_async(), _PARTY_INIT_TIMEOUT_MSEC)
+		playfab.shutdown()
+		return
+
+	var network_changes: Array = []
+	var on_network_change = func(change): network_changes.append(change)
+	network.state_changed.connect(on_network_change)
+
+	var leave_result = await await_completion(network.leave_async(), _PARTY_LEAVE_TIMEOUT_MSEC)
+	assert_true(leave_result != null and leave_result.ok,
+			"network.leave_async succeeds (%s)" % (leave_result.message if leave_result != null else "null"))
+	await advance_process_frames(_STATE_PUMP_FRAMES)
+
+	for change in network_changes:
+		var result = change.result
+		if result == null:
+			continue
+		assert_ne(String(result.code), "party_resource_not_ready", "leave_async state changes do not emit party_resource_not_ready")
+		assert_false(String(result.message).contains("PartyLeaveNetwork: operation succeeded"), "leave_async state changes do not report operation-succeeded as an error")
+
+	if network.is_connected("state_changed", on_network_change):
+		network.state_changed.disconnect(on_network_change)
+	await await_completion(party.shutdown_async(), _PARTY_INIT_TIMEOUT_MSEC)
+	playfab.shutdown()


### PR DESCRIPTION
## Bug trace

`party.create_and_leave_single_host` can surface `party_resource_not_ready` with `PartyLeaveNetwork: operation succeeded` when the Party leave completion's state-change result indicates a successful local leave but the addon classifies the diagnostic `errorDetail` text as a failure.

The Party SDK body for `PartyLeaveNetworkCompletedStateChange` carries both `result` and `errorDetail`. The SDK documents `PartyStateChangeResult::Succeeded` as success and `PartyStateChangeResult::LeaveNetworkCalled` as "the network was gracefully exited by the local device"; `errorDetail == c_partyErrorSuccess` renders as `operation succeeded` and is only diagnostic.

## Classification logic

- `PartyLeaveNetworkCompleted` now returns success when `result` is `Succeeded` or `LeaveNetworkCalled`, regardless of diagnostic `errorDetail` text.
- True failures with nonzero `errorDetail` still use the Party SDK error detail.
- True failures with `errorDetail == c_partyErrorSuccess` now report the `PartyStateChangeResult` name instead of `operation succeeded`.

## Sibling bugs found

The same zero-detail diagnostic-message trap existed in Party completion handlers for create/connect/authenticate/create-endpoint/create-chat-control/connect-chat-control. Those now use the shared state-change helper so zero-detail failures are labeled by SDK state result. `PartyNetworkDestroyed` has no `PartyStateChangeResult` and is unchanged.

## Tests

- Added non-live GUT coverage for `PartyLeaveNetworkCompleted` classification (`Succeeded`, `LeaveNetworkCalled`, and zero-detail failure).
- Added live-gated GUT regression that creates one Party network, leaves it, and asserts no `party_resource_not_ready` / `PartyLeaveNetwork: operation succeeded` result is emitted.

## Validation

- `cmake --preset default` ✅
- `cmake --build build --config Debug --target godot_playfab` ✅
- `pwsh -File .\tools\run_all_tests.ps1 -SkipBuild -Hosts tests\godot\playfab -ParseExcludeProjects sample -VerboseOutput` ✅ (`gut:tests/godot/playfab`: 58 tests, 49 passing, 9 pending, 1688/1688 asserts)
- `pwsh -File .\tools\check_gd_scripts_headless.ps1` attempted; currently fails in pre-existing sample `auth.gd` type resolution (`GDKUser`) outside this diff.
- `cmake --build build --preset debug` attempted; currently fails in pre-existing `addons\godot_gameinput\src\gameinput_mapper.cpp(184,5)` syntax error outside this diff.
- `party.create_and_leave_single_host` rerun with `LIVE_TESTS=1`; skipped because `PLAYFAB_TITLE_ID` is unset in this environment. Live tests/writes were not run.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
