### PR TITLE
followup: unblock run_all_tests.ps1 parse gate on samples

### DIFF
--- a/sample/tutorial_app/autoload/auth.gd
+++ b/sample/tutorial_app/autoload/auth.gd
@@ -1,5 +1,7 @@
 extends Node
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 1 — Sign in a user (state-machine autoload).
 ##
 ## The `Auth` autoload is the tutorial app's identity service. It runs a
@@ -16,7 +18,7 @@ extends Node
 ##     if not await Auth.sign_in():
 ##         _show_error(Auth.get_last_error_stage(), Auth.get_last_error_message())
 ##         return
-##     var user: GDKUser = Auth.xbox_user
+##     var user = Auth.xbox_user
 ##
 ## Source: docs/tutorials/01-sign-in-user.md
 
@@ -31,22 +33,22 @@ enum State {
 signal state_changed(state: State)
 
 var _state: State = State.UNINITIALIZED
-var _xbox_user: GDKUser = null
-var _playfab_user: PlayFabUser = null
+var _xbox_user = null
+var _playfab_user = null
 var _last_error_stage: String = ""
 var _last_error_message: String = ""
 
-# Read-only typed accessors. xbox_user/playfab_user are intentionally
+# Read-only addon-object accessors. xbox_user/playfab_user are intentionally
 # null unless the full chain reached SIGNED_IN so consumers cannot
 # accidentally use a half-completed session (e.g. Xbox-only without
 # PlayFab) — that ambiguity is the bug item 7 from the sample review.
-var xbox_user: GDKUser:
+var xbox_user:
 	get:
 		return _xbox_user if _state == State.SIGNED_IN else null
 	set(_value):
 		push_error("[Auth] xbox_user is read-only — drive state via sign_in()")
 
-var playfab_user: PlayFabUser:
+var playfab_user:
 	get:
 		return _playfab_user if _state == State.SIGNED_IN else null
 	set(_value):
@@ -101,7 +103,7 @@ func _do_sign_in() -> bool:
 	_playfab_user = null
 
 	_set_state(State.SIGNING_IN_XBOX)
-	var xbox: GDKUser = await _ensure_xbox_user()
+	var xbox = await _ensure_xbox_user()
 	if xbox == null:
 		_set_state(State.FAILED)
 		return false
@@ -109,7 +111,7 @@ func _do_sign_in() -> bool:
 	print("[Auth] Xbox primary user: %s" % xbox.gamertag)
 
 	_set_state(State.SIGNING_IN_PLAYFAB)
-	var pf: PlayFabUser = await _ensure_playfab_user(xbox)
+	var pf = await _ensure_playfab_user(xbox)
 	if pf == null:
 		_set_state(State.FAILED)
 		return false
@@ -133,39 +135,39 @@ func _set_error(stage: String, message: String) -> void:
 	_last_error_message = message
 	push_warning("[Auth] sign-in failed at %s: %s" % [stage, message])
 
-func _ensure_xbox_user() -> GDKUser:
+func _ensure_xbox_user():
 	if not Engine.has_singleton("GDK"):
 		_set_error("gdk.missing", "godot_gdk extension is not loaded")
 		return null
 
-	if not GDK.is_initialized():
-		var init: GDKResult = GDK.initialize()
+	if not AddonApi.singleton("GDK").is_initialized():
+		var init = AddonApi.singleton("GDK").initialize()
 		if not init.ok:
 			_set_error("gdk.initialize", init.message)
 			return null
 
 	# 1. Already have a primary user (auto-init, prior sign-in)? Use it.
-	var primary: GDKUser = GDK.users.get_primary_user()
+	var primary = AddonApi.singleton("GDK").users.get_primary_user()
 	if primary != null and primary.signed_in:
 		return primary
 
 	# 2. Try the silent path. This picks up the Xbox-app account on the
 	#    PC without surfacing any UI. Common failure: no_default_user.
-	var silent: GDKResult = await GDK.users.add_default_user_async()
+	var silent = await AddonApi.singleton("GDK").users.add_default_user_async()
 	if silent.ok and silent.data != null and silent.data.signed_in:
 		return silent.data
 
 	print("[Auth] Silent sign-in failed (%s) — falling back to UI." % silent.message)
 
 	# 3. UI fallback. Shows the system account picker.
-	var ui: GDKResult = await GDK.users.add_user_with_ui_async()
+	var ui = await AddonApi.singleton("GDK").users.add_user_with_ui_async()
 	if ui.ok and ui.data != null and ui.data.signed_in:
 		return ui.data
 
 	_set_error("gdk.add_user_with_ui", ui.message)
 	return null
 
-func _ensure_playfab_user(xbox: GDKUser) -> PlayFabUser:
+func _ensure_playfab_user(xbox):
 	if not Engine.has_singleton("PlayFab"):
 		_set_error("playfab.missing", "godot_playfab extension is not loaded")
 		return null
@@ -174,8 +176,8 @@ func _ensure_playfab_user(xbox: GDKUser) -> PlayFabUser:
 		_set_error("playfab.sign_in", "Xbox user is not signed in")
 		return null
 
-	if not PlayFab.is_initialized():
-		var init: PlayFabResult = PlayFab.initialize()
+	if not AddonApi.singleton("PlayFab").is_initialized():
+		var init = AddonApi.singleton("PlayFab").initialize()
 		if not init.ok:
 			_set_error("playfab.initialize", init.message)
 			return null
@@ -183,7 +185,7 @@ func _ensure_playfab_user(xbox: GDKUser) -> PlayFabUser:
 	# Pass the GDKUser object directly. The addon reads the local user
 	# handle out of it internally; the boundary is intentionally typed
 	# as Object because Ref<> types cannot cross GDExtension DLLs.
-	var result: PlayFabResult = await PlayFab.users.sign_in_with_xuser_async(xbox)
+	var result = await AddonApi.singleton("PlayFab").users.sign_in_with_xuser_async(xbox)
 	if not result.ok:
 		_set_error("playfab.sign_in", result.message)
 		return null

--- a/sample/tutorial_app/autoload/lobby.gd
+++ b/sample/tutorial_app/autoload/lobby.gd
@@ -1,5 +1,7 @@
 extends Node
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorials 5 + 6 — Lobby + Multiplayer Activity + Presence + privilege gates.
 ##
 ## Owns the live PlayFabLobby reference, mirrors lobby state into the Xbox
@@ -60,7 +62,7 @@ enum State {
 }
 
 signal state_changed(state: State)
-signal lobby_joined(lobby: PlayFabLobby)
+signal lobby_joined(lobby)
 signal lobby_left
 signal lobby_disconnected  ## PlayFab fired DISCONNECTED firehose; involuntary.
 
@@ -76,7 +78,7 @@ signal invite_pending_confirmation(invite_id: int, connection_string: String)
 signal invite_pending_cleared(invite_id: int)
 
 var _state: State = State.UNINITIALIZED
-var _lobby: PlayFabLobby = null
+var _lobby = null
 var _auth: Node = null
 var _gdk_signals_connected: bool = false
 var _pf_multiplayer_signals_connected: bool = false
@@ -85,7 +87,7 @@ var _watched_xuids: PackedStringArray = PackedStringArray()
 # first get_friends_async() call and torn down in _exit_tree so the
 # Social Manager doesn't keep tracking after the autoload is gone.
 var _social_graph_started: bool = false
-var _friends_group: GDKSocialGroup = null
+var _friends_group = null
 # Item 3 / B3 — pending-invite slot. Only populated while IN_LOBBY and
 # waiting for a UI confirmation. _pending_invite_id is a token bound
 # to the emitted signal so confirm/reject calls from a stale dialog
@@ -98,7 +100,7 @@ var _pending_invite_confirming: bool = false
 ## actually in IN_LOBBY. During LEAVING / on disconnect callers should
 ## listen for lobby_left / lobby_disconnected to do their cleanup, not
 ## poke this getter for a stale ref.
-var current_lobby: PlayFabLobby:
+var current_lobby:
 	get:
 		return _lobby if _state == State.IN_LOBBY else null
 
@@ -119,12 +121,12 @@ func _exit_tree() -> void:
 	# the graph itself is a no-op if start_social_graph was never called.
 	if Engine.has_singleton("GDK"):
 		if _friends_group != null:
-			GDK.social.destroy_social_group(_friends_group)
+			AddonApi.singleton("GDK").social.destroy_social_group(_friends_group)
 			_friends_group = null
 		if _social_graph_started:
-			var user: GDKUser = _auth.get("xbox_user") if _auth != null else null
+			var user = _auth.get("xbox_user") if _auth != null else null
 			if user != null:
-				GDK.social.stop_social_graph(user)
+				AddonApi.singleton("GDK").social.stop_social_graph(user)
 			_social_graph_started = false
 
 func get_state() -> State:
@@ -141,7 +143,7 @@ func is_busy() -> bool:
 
 # Kept for back-compat with sample / test code that called the getter
 # directly. New consumers should use the `current_lobby` property.
-func get_current_lobby() -> PlayFabLobby:
+func get_current_lobby():
 	return current_lobby
 
 func _set_state(next: State) -> void:
@@ -186,12 +188,12 @@ func _ensure_ready() -> bool:
 		# don't require PlayFab to be initialized, and
 		# pending_invite_received needs to be wired before the engine can
 		# hand us a deferred launch-with-invite.
-		GDK.multiplayer_activity.pending_invite_received.connect(_on_pending_invite_received)
-		GDK.multiplayer_activity.invite_accepted.connect(_on_invite_accepted)
-		GDK.multiplayer_activity.activities_updated.connect(_on_activities_updated)
-		GDK.presence.device_presence_changed.connect(_on_device_presence_changed)
-		GDK.presence.title_presence_changed.connect(_on_title_presence_changed)
-		GDK.presence.presence_changed.connect(_on_presence_changed)
+		AddonApi.singleton("GDK").multiplayer_activity.pending_invite_received.connect(_on_pending_invite_received)
+		AddonApi.singleton("GDK").multiplayer_activity.invite_accepted.connect(_on_invite_accepted)
+		AddonApi.singleton("GDK").multiplayer_activity.activities_updated.connect(_on_activities_updated)
+		AddonApi.singleton("GDK").presence.device_presence_changed.connect(_on_device_presence_changed)
+		AddonApi.singleton("GDK").presence.title_presence_changed.connect(_on_title_presence_changed)
+		AddonApi.singleton("GDK").presence.presence_changed.connect(_on_presence_changed)
 		_gdk_signals_connected = true
 		print("[Lobby] GDK MPA + presence handlers connected. PlayFab Multiplayer init is lazy.")
 
@@ -207,17 +209,17 @@ func _ensure_pf_multiplayer_initialized() -> bool:
 		push_error("[Lobby] PlayFab extension not loaded")
 		return false
 
-	if not PlayFab.multiplayer.is_initialized():
-		var init: PlayFabResult = await PlayFab.multiplayer.initialize_async()
+	if not AddonApi.singleton("PlayFab").multiplayer.is_initialized():
+		var init = await AddonApi.singleton("PlayFab").multiplayer.initialize_async()
 		if not init.ok:
 			push_warning("[Lobby] PlayFab.multiplayer init failed: %s" % init.message)
 			return false
 		print("[Lobby] PlayFab.multiplayer initialized lazily")
 
 	if not _pf_multiplayer_signals_connected:
-		PlayFab.multiplayer.state_changed.connect(_on_state_changed)
-		PlayFab.multiplayer.invite_received.connect(_on_pf_invite_received)
-		PlayFab.multiplayer.multiplayer_error.connect(_on_multiplayer_error)
+		AddonApi.singleton("PlayFab").multiplayer.state_changed.connect(_on_state_changed)
+		AddonApi.singleton("PlayFab").multiplayer.invite_received.connect(_on_pf_invite_received)
+		AddonApi.singleton("PlayFab").multiplayer.multiplayer_error.connect(_on_multiplayer_error)
 		_pf_multiplayer_signals_connected = true
 
 	return true
@@ -225,7 +227,7 @@ func _ensure_pf_multiplayer_initialized() -> bool:
 ## Centralized lobby-firehose lifetime. Always go through these helpers
 ## instead of touching `_lobby` directly; a stale lobby with a still-
 ## connected signal will keep delivering events to us.
-func _attach_lobby(lobby: PlayFabLobby) -> void:
+func _attach_lobby(lobby) -> void:
 	_detach_lobby()
 	_lobby = lobby
 	_lobby.state_changed.connect(_on_lobby_state_changed)
@@ -244,24 +246,24 @@ func _detach_lobby() -> void:
 # Returns "" for non-Xbox sign-ins (the per-peer check is skipped in
 # that case — the privilege gate already filtered out non-comms users).
 func _local_xuid() -> String:
-	var user: GDKUser = _auth.get("xbox_user") if _auth != null else null
+	var user = _auth.get("xbox_user") if _auth != null else null
 	if user == null:
 		return ""
 	return user.xuid
 
 # Tutorial 5 Step 2 — Multiplayer privilege gate.
 func can_use_multiplayer() -> bool:
-	var user: GDKUser = _auth.get("xbox_user") if _auth != null else null
+	var user = _auth.get("xbox_user") if _auth != null else null
 	if user == null:
 		return false
 
-	var pf: GDKResult = await GDK.users.check_privilege_async(
+	var pf = await AddonApi.singleton("GDK").users.check_privilege_async(
 			user, XUSER_PRIVILEGE_MULTIPLAYER)
 	if pf.ok and bool(pf.data.get("has_privilege", false)):
 		return true
 
 	print("[Lobby] multiplayer denied (%s) — resolving with UI" % pf.data.get("deny_reason", ""))
-	var resolved: GDKResult = await GDK.users.resolve_privilege_with_ui_async(
+	var resolved = await AddonApi.singleton("GDK").users.resolve_privilege_with_ui_async(
 			user, XUSER_PRIVILEGE_MULTIPLAYER)
 	if not resolved.ok:
 		push_warning("[Lobby] resolve_privilege_with_ui failed: %s" % resolved.message)
@@ -270,10 +272,10 @@ func can_use_multiplayer() -> bool:
 
 # Tutorial 5 Step 2 (filter helper) / Tutorial 6 Step 5 (cert).
 func filter_invitable(xuids: PackedStringArray) -> PackedStringArray:
-	var user: GDKUser = _auth.get("xbox_user") if _auth != null else null
+	var user = _auth.get("xbox_user") if _auth != null else null
 	if user == null or xuids.is_empty():
 		return PackedStringArray()
-	var pf: GDKResult = await GDK.privacy.batch_check_permission_async(
+	var pf = await AddonApi.singleton("GDK").privacy.batch_check_permission_async(
 			user, "play_multiplayer", xuids)
 	if not pf.ok:
 		push_warning("[Lobby] permission batch failed: %s" % pf.message)
@@ -296,22 +298,22 @@ func filter_invitable(xuids: PackedStringArray) -> PackedStringArray:
 # leave, or change presence — callers wanting live updates should
 # connect to that signal and re-call this method.
 func get_friends_async() -> Array:
-	var user: GDKUser = _auth.get("xbox_user") if _auth != null else null
+	var user = _auth.get("xbox_user") if _auth != null else null
 	if user == null or not Engine.has_singleton("GDK"):
 		return []
 	if not _social_graph_started:
-		var sg: GDKResult = GDK.social.start_social_graph(user)
+		var sg = AddonApi.singleton("GDK").social.start_social_graph(user)
 		if not sg.ok:
 			push_warning("[Lobby] start_social_graph failed: %s" % sg.message)
 			return []
 		_social_graph_started = true
 	if _friends_group == null:
-		var f: GDKResult = await GDK.social.get_friends_async(user)
+		var f = await AddonApi.singleton("GDK").social.get_friends_async(user)
 		if not f.ok:
 			push_warning("[Lobby] get_friends failed: %s" % f.message)
 			return []
 		_friends_group = f.data
-	var users: GDKResult = GDK.social.get_group_users(_friends_group)
+	var users = AddonApi.singleton("GDK").social.get_group_users(_friends_group)
 	if not users.ok:
 		push_warning("[Lobby] get_group_users failed: %s" % users.message)
 		return []
@@ -339,12 +341,12 @@ func host_lobby() -> bool:
 		_set_state(State.READY)
 		return false
 
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 
-	var config := PlayFabLobbyConfig.new()
+	var config := AddonApi.instantiate("PlayFabLobbyConfig")
 	config.max_players = 4
-	config.access_policy = PlayFabLobbyConfig.ACCESS_POLICY_PUBLIC
-	config.owner_migration_policy = PlayFabLobbyConfig.OWNER_MIGRATION_AUTOMATIC
+	config.access_policy = AddonApi.constant("PlayFabLobbyConfig", "ACCESS_POLICY_PUBLIC")
+	config.owner_migration_policy = AddonApi.constant("PlayFabLobbyConfig", "OWNER_MIGRATION_AUTOMATIC")
 	# Item 12 / C1 — property scopes:
 	#   search_properties: indexed for find_lobbies_async; reserved
 	#     key namespace (string_keyN / number_keyN). Visible to anyone
@@ -367,7 +369,7 @@ func host_lobby() -> bool:
 		"xuid": _local_xuid(),
 	}
 
-	var result: PlayFabResult = await PlayFab.multiplayer.create_lobby_async(user, config)
+	var result = await AddonApi.singleton("PlayFab").multiplayer.create_lobby_async(user, config)
 	if not result.ok:
 		push_warning("[Lobby] create_lobby failed: %s (%s)" % [result.message, result.code])
 		_set_state(State.READY)
@@ -415,15 +417,15 @@ func join_lobby(connection_string: String) -> bool:
 		_set_state(State.READY)
 		return false
 
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 
-	var config := PlayFabLobbyJoinConfig.new()
+	var config := AddonApi.instantiate("PlayFabLobbyJoinConfig")
 	config.member_properties = {
 		"loadout": "shotgun",
 		"xuid": _local_xuid(),
 	}
 
-	var result: PlayFabResult = await PlayFab.multiplayer.join_lobby_async(user, connection_string, config)
+	var result = await AddonApi.singleton("PlayFab").multiplayer.join_lobby_async(user, connection_string, config)
 	if not result.ok:
 		push_warning("[Lobby] join_lobby failed: %s (%s)" % [result.message, result.code])
 		_set_state(State.READY)
@@ -442,7 +444,7 @@ func join_lobby(connection_string: String) -> bool:
 func push_loadout_change(loadout: String) -> void:
 	if not is_in_lobby():
 		return
-	var pf: PlayFabResult = await _lobby.set_member_properties_async({ "loadout": loadout })
+	var pf = await _lobby.set_member_properties_async({ "loadout": loadout })
 	if not pf.ok:
 		push_warning("[Lobby] member props failed: %s" % pf.message)
 
@@ -450,10 +452,10 @@ func push_loadout_change(loadout: String) -> void:
 func change_map(new_map: String) -> void:
 	if not is_in_lobby():
 		return
-	var pf_user: PlayFabUser = _auth.get("playfab_user")
+	var pf_user = _auth.get("playfab_user")
 	if not _lobby.is_owner(pf_user):
 		return
-	var pf: PlayFabResult = await _lobby.set_properties_async({ "map": new_map })
+	var pf = await _lobby.set_properties_async({ "map": new_map })
 	if not pf.ok:
 		push_warning("[Lobby] lobby props failed: %s" % pf.message)
 
@@ -471,7 +473,7 @@ func leave_lobby() -> bool:
 
 	_set_state(State.LEAVING)
 	await _clear_activity()
-	var pf: PlayFabResult = await _lobby.leave_async()
+	var pf = await _lobby.leave_async()
 	if pf.ok:
 		print("[Lobby] left lobby")
 	else:
@@ -496,7 +498,7 @@ func invite_friend(xuid: String) -> bool:
 		push_warning("[MPA] Invite blocked by play_multiplayer permission for %s" % xuid)
 		return false
 
-	var result: GDKResult = await GDK.multiplayer_activity.send_invites_async(
+	var result = await AddonApi.singleton("GDK").multiplayer_activity.send_invites_async(
 		_auth.get("xbox_user"),
 		allowed,
 		false,
@@ -513,22 +515,22 @@ func open_invite_picker() -> void:
 		push_warning("[MPA] Cannot open picker — not in a lobby")
 		return
 
-	var result: GDKResult = await GDK.multiplayer_activity.show_invite_ui_async(_auth.get("xbox_user"))
+	var result = await AddonApi.singleton("GDK").multiplayer_activity.show_invite_ui_async(_auth.get("xbox_user"))
 	if not result.ok:
 		push_warning("[MPA] show_invite_ui failed: %s" % result.message)
 
 # Tutorial 6 Steps 6 + 7 — friend activity + presence tracking.
 func track_friend_activities(xuids: PackedStringArray) -> void:
 	_watched_xuids = xuids
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 
-	var activities: GDKResult = await GDK.multiplayer_activity.get_activities_async(user, xuids)
+	var activities = await AddonApi.singleton("GDK").multiplayer_activity.get_activities_async(user, xuids)
 	if not activities.ok:
 		push_warning("[MPA] get_activities failed: %s" % activities.message)
 
-	GDK.presence.track_presence(user, xuids)
+	AddonApi.singleton("GDK").presence.track_presence(user, xuids)
 
-	var presence: GDKResult = await GDK.presence.get_presence_async(xuids)
+	var presence = await AddonApi.singleton("GDK").presence.get_presence_async(xuids)
 	if not presence.ok:
 		push_warning("[Pres] get_presence failed: %s" % presence.message)
 
@@ -539,7 +541,7 @@ func track_friend_activities(xuids: PackedStringArray) -> void:
 func stop_tracking_friends() -> void:
 	if _watched_xuids.is_empty():
 		return
-	GDK.presence.stop_tracking_presence(_auth.get("xbox_user"), _watched_xuids)
+	AddonApi.singleton("GDK").presence.stop_tracking_presence(_auth.get("xbox_user"), _watched_xuids)
 	_watched_xuids = PackedStringArray()
 
 # --- Internal: MPA + presence helpers ---
@@ -547,7 +549,7 @@ func stop_tracking_friends() -> void:
 func _publish_activity(allow_cross_platform_join: bool = false) -> void:
 	if _lobby == null:
 		return
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return
 
@@ -555,7 +557,7 @@ func _publish_activity(allow_cross_platform_join: bool = false) -> void:
 	var max_players: int = _lobby.max_member_count
 	var connection_string: String = _lobby.connection_string
 
-	var result: GDKResult = await GDK.multiplayer_activity.set_activity_async(
+	var result = await AddonApi.singleton("GDK").multiplayer_activity.set_activity_async(
 		user,
 		connection_string,
 		MPA_JOIN_RESTRICTION_FOLLOWED,
@@ -571,10 +573,10 @@ func _publish_activity(allow_cross_platform_join: bool = false) -> void:
 		max_players, current_players, str(allow_cross_platform_join)])
 
 func _clear_activity() -> void:
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return
-	var result: GDKResult = await GDK.multiplayer_activity.delete_activity_async(user)
+	var result = await AddonApi.singleton("GDK").multiplayer_activity.delete_activity_async(user)
 	if result.ok:
 		print("[MPA] Activity cleared")
 	else:
@@ -583,23 +585,23 @@ func _clear_activity() -> void:
 func _publish_lobby_presence() -> void:
 	if PRESENCE_IN_LOBBY.is_empty():
 		return
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return
-	var pf: GDKResult = await GDK.presence.set_presence_async(user, PRESENCE_IN_LOBBY)
+	var pf = await AddonApi.singleton("GDK").presence.set_presence_async(user, PRESENCE_IN_LOBBY)
 	if not pf.ok:
 		push_warning("[Lobby] presence write failed: %s" % pf.message)
 
 func _clear_lobby_presence() -> void:
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return
-	var pf: GDKResult = await GDK.presence.clear_presence_async(user)
+	var pf = await AddonApi.singleton("GDK").presence.clear_presence_async(user)
 	if not pf.ok:
 		push_warning("[Lobby] presence clear failed: %s" % pf.message)
 
 func _print_activity(xuid: String) -> void:
-	var info: GDKMultiplayerActivityInfo = GDK.multiplayer_activity.get_cached_activity(xuid)
+	var info = AddonApi.singleton("GDK").multiplayer_activity.get_cached_activity(xuid)
 	if info == null:
 		print("[MPA] Friend %s is offline / not in a session" % xuid)
 		return
@@ -610,7 +612,7 @@ func _print_activity(xuid: String) -> void:
 	print("[MPA] Friend %s is in session: %s" % [xuid, conn])
 
 func _print_presence(xuid: String) -> void:
-	var record: GDKPresenceRecord = GDK.presence.get_cached_presence(xuid)
+	var record = AddonApi.singleton("GDK").presence.get_cached_presence(xuid)
 	if record == null:
 		print("[Pres] %s: (unknown)" % xuid)
 		return
@@ -624,34 +626,34 @@ func _print_presence(xuid: String) -> void:
 
 # --- Internal: signal handlers ---
 
-func _on_state_changed(_change: PlayFabMultiplayerStateChange) -> void:
+func _on_state_changed(_change) -> void:
 	pass # Per-lobby changes route to _on_lobby_state_changed below.
 
-func _on_pf_invite_received(invite: PlayFabLobbyInvite) -> void:
+func _on_pf_invite_received(invite) -> void:
 	print("[Lobby] invite from %s: %s" % [invite.sender_entity_key, invite.connection_string])
 
-func _on_multiplayer_error(result: PlayFabResult) -> void:
+func _on_multiplayer_error(result) -> void:
 	push_warning("[Lobby] multiplayer error: %s (%s)" % [result.message, result.code])
 
-func _on_lobby_state_changed(change: PlayFabLobbyStateChange) -> void:
-	match change.kind:
-		PlayFabLobby.MEMBER_ADDED:
-			var m: PlayFabLobbyMember = change.member
-			print("[Lobby] member added: %s (local=%s)" % [m.user_id, str(m.is_local)])
-			await _publish_activity()
-		PlayFabLobby.MEMBER_REMOVED:
-			var m: PlayFabLobbyMember = change.member
-			print("[Lobby] member removed: %s" % m.user_id)
-			await _publish_activity()
-		PlayFabLobby.MEMBER_UPDATED:
-			var m: PlayFabLobbyMember = change.member
-			print("[Lobby] member updated: %s" % m.user_id)
-		PlayFabLobby.PROPERTIES_UPDATED:
-			print("[Lobby] lobby properties: %s" % str(change.properties))
-		PlayFabLobby.OWNER_CHANGED:
-			print("[Lobby] owner changed: %s" % str(change.lobby.owner_entity_key))
-		PlayFabLobby.DISCONNECTED:
-			await _handle_pf_disconnected()
+func _on_lobby_state_changed(change) -> void:
+	var kind: int = change.kind
+	if kind == AddonApi.constant("PlayFabLobby", "MEMBER_ADDED"):
+		var m = change.member
+		print("[Lobby] member added: %s (local=%s)" % [m.user_id, str(m.is_local)])
+		await _publish_activity()
+	elif kind == AddonApi.constant("PlayFabLobby", "MEMBER_REMOVED"):
+		var m = change.member
+		print("[Lobby] member removed: %s" % m.user_id)
+		await _publish_activity()
+	elif kind == AddonApi.constant("PlayFabLobby", "MEMBER_UPDATED"):
+		var m = change.member
+		print("[Lobby] member updated: %s" % m.user_id)
+	elif kind == AddonApi.constant("PlayFabLobby", "PROPERTIES_UPDATED"):
+		print("[Lobby] lobby properties: %s" % str(change.properties))
+	elif kind == AddonApi.constant("PlayFabLobby", "OWNER_CHANGED"):
+		print("[Lobby] owner changed: %s" % str(change.lobby.owner_entity_key))
+	elif kind == AddonApi.constant("PlayFabLobby", "DISCONNECTED"):
+		await _handle_pf_disconnected()
 
 # DISCONNECTED is fired by PlayFab when the server kicks us off the lobby
 # (network error, lobby destroyed, evicted). Treat as a transient event:
@@ -777,11 +779,11 @@ func _on_activities_updated(xuids: PackedStringArray) -> void:
 
 func _on_device_presence_changed(xuid: String) -> void:
 	if xuid in _watched_xuids:
-		await GDK.presence.get_presence_async([xuid])
+		await AddonApi.singleton("GDK").presence.get_presence_async([xuid])
 
 func _on_title_presence_changed(xuid: String, _title_id: int) -> void:
 	if xuid in _watched_xuids:
-		await GDK.presence.get_presence_async([xuid])
+		await AddonApi.singleton("GDK").presence.get_presence_async([xuid])
 
 func _on_presence_changed(xuid: String, _record) -> void:
 	_print_presence(xuid)

--- a/sample/tutorial_app/autoload/party.gd
+++ b/sample/tutorial_app/autoload/party.gd
@@ -1,5 +1,7 @@
 extends Node
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 7 — PlayFab Party network for voice + text chat + RPC.
 ##
 ## Stands up a peer-to-peer transport layered on top of the T5/T6 lobby.
@@ -55,7 +57,7 @@ enum State {
 }
 
 signal state_changed(state: State)
-signal network_joined(network: PlayFabPartyNetwork)
+signal network_joined(network)
 signal network_left           ## Voluntary teardown (leave_party).
 signal network_destroyed      ## Involuntary teardown (NETWORK_CHANGE_DESTROYED / lobby drop / shutdown).
 signal peer_connected(peer_id: int)
@@ -66,8 +68,8 @@ signal rpc_received(peer_id: int, text: String) ## ping RPC received from a peer
 var _state: State = State.UNINITIALIZED
 var _auth: Node = null
 var _lobby_node: Node = null
-var _lobby: PlayFabLobby = null
-var _network: PlayFabPartyNetwork = null
+var _lobby = null
+var _network = null
 var _is_host: bool = false
 var _gdk_lobby_signals_connected: bool = false
 var _pf_party_signals_connected: bool = false
@@ -82,7 +84,7 @@ var _teardown_in_progress: bool = false ## True while leave_party is unwinding v
 ## Guarded accessor — returns null unless we are actually in a network.
 ## Callers that need the network across teardown should listen for
 ## network_left / network_destroyed and capture the payload there.
-var network: PlayFabPartyNetwork:
+var network:
 	get:
 		return _network if _state == State.IN_NETWORK else null
 
@@ -116,7 +118,7 @@ func is_busy() -> bool:
 
 # Kept for back-compat with sample / test code that called the getter
 # directly. New consumers should use the `network` property.
-func get_current_network() -> PlayFabPartyNetwork:
+func get_current_network():
 	return network
 
 func _set_state(next: State) -> void:
@@ -167,22 +169,22 @@ func _ensure_pf_party_initialized() -> bool:
 		push_error("[Party] PlayFab extension not loaded")
 		return false
 
-	if not PlayFab.party.is_initialized():
-		var cfg := PlayFabPartyConfig.new()
+	if not AddonApi.singleton("PlayFab").party.is_initialized():
+		var cfg := AddonApi.instantiate("PlayFabPartyConfig")
 		cfg.max_players = 8
-		cfg.direct_peer_connectivity = PlayFabParty.DIRECT_PEER_CONNECTIVITY_ANY
+		cfg.direct_peer_connectivity = AddonApi.constant("PlayFabParty", "DIRECT_PEER_CONNECTIVITY_ANY")
 		cfg.enable_voice_chat = true
 		cfg.enable_text_chat = true
 		cfg.enable_transcription = false
 
-		var init: PlayFabResult = await PlayFab.party.initialize_async(cfg)
+		var init = await AddonApi.singleton("PlayFab").party.initialize_async(cfg)
 		if not init.ok:
 			push_warning("[Party] PlayFab.party init failed: %s (%s)" % [init.message, init.code])
 			return false
 		print("[Party] PlayFab.party initialized lazily (voice=true text=true transcription=false)")
 
 	if not _pf_party_signals_connected:
-		PlayFab.party.party_error.connect(_on_party_error)
+		AddonApi.singleton("PlayFab").party.party_error.connect(_on_party_error)
 		_pf_party_signals_connected = true
 
 	return true
@@ -206,10 +208,10 @@ func host_party() -> bool:
 
 	var caps: Dictionary = await resolve_chat_capabilities()
 
-	var user: PlayFabUser = _auth.get("playfab_user")
-	var cfg := PlayFabPartyConfig.new()
+	var user = _auth.get("playfab_user")
+	var cfg := AddonApi.instantiate("PlayFabPartyConfig")
 	cfg.max_players = 4
-	cfg.direct_peer_connectivity = PlayFabParty.DIRECT_PEER_CONNECTIVITY_ANY
+	cfg.direct_peer_connectivity = AddonApi.constant("PlayFabParty", "DIRECT_PEER_CONNECTIVITY_ANY")
 	cfg.set_voice_chat_enabled(caps.voice)
 	cfg.set_text_chat_enabled(caps.text)
 	# Microsoft Party requires every user to authenticate with the same
@@ -221,7 +223,7 @@ func host_party() -> bool:
 	# under Party's c_maxInvitationIdentifierStringLength (127).
 	cfg.invitation_id = _lobby.lobby_id if _lobby != null else ""
 
-	var result: PlayFabResult = await PlayFab.party.create_and_join_network_async(user, cfg)
+	var result = await AddonApi.singleton("PlayFab").party.create_and_join_network_async(user, cfg)
 
 	# Rubber-duck issue #1 — the lobby may have disappeared while we were
 	# awaiting create_and_join. Bail out without binding the multiplayer
@@ -229,7 +231,7 @@ func host_party() -> bool:
 	if _abort_party_op or _state != State.HOSTING:
 		if result.ok:
 			print("[Party] Aborting orphaned host network (lobby left mid-await)")
-			var orphan: PlayFabPartyNetwork = result.data
+			var orphan = result.data
 			orphan.leave_async()
 		_abort_party_op = false
 		_is_host = false
@@ -243,7 +245,7 @@ func host_party() -> bool:
 		_set_state(State.READY)
 		return false
 
-	var net: PlayFabPartyNetwork = result.data
+	var net = result.data
 	_attach_network(net)
 	_set_state(State.IN_NETWORK)
 	print("[Party] Network created — waiting for descriptor…")
@@ -273,8 +275,8 @@ func _join_party_network(descriptor: String) -> bool:
 
 	var caps: Dictionary = await resolve_chat_capabilities()
 
-	var user: PlayFabUser = _auth.get("playfab_user")
-	var cfg := PlayFabPartyConfig.new()
+	var user = _auth.get("playfab_user")
+	var cfg := AddonApi.instantiate("PlayFabPartyConfig")
 	cfg.set_voice_chat_enabled(caps.voice)
 	cfg.set_text_chat_enabled(caps.text)
 	# Mirror host_party — Party.AuthenticateLocalUser requires the same
@@ -282,13 +284,13 @@ func _join_party_network(descriptor: String) -> bool:
 	# known to host and client once the lobby is joined, so use it.
 	cfg.invitation_id = _lobby.lobby_id if _lobby != null else ""
 
-	var result: PlayFabResult = await PlayFab.party.join_network_async(user, descriptor, cfg)
+	var result = await AddonApi.singleton("PlayFab").party.join_network_async(user, descriptor, cfg)
 
 	# Same abort-after-await guard as host_party.
 	if _abort_party_op or _state != State.JOINING:
 		if result.ok:
 			print("[Party] Aborting orphaned join network (lobby left mid-await)")
-			var orphan: PlayFabPartyNetwork = result.data
+			var orphan = result.data
 			orphan.leave_async()
 		_abort_party_op = false
 		if _state == State.JOINING:
@@ -318,13 +320,13 @@ func leave_party() -> bool:
 	# Clear the descriptor we published if we're the host leaving the
 	# network. Best-effort: a failure here is logged and ignored.
 	if _is_host and _lobby != null:
-		var pf_user: PlayFabUser = _auth.get("playfab_user")
+		var pf_user = _auth.get("playfab_user")
 		if pf_user != null and _lobby.is_owner(pf_user):
-			var clear: PlayFabResult = await _lobby.set_properties_async({PARTY_DESCRIPTOR_KEY: ""})
+			var clear = await _lobby.set_properties_async({PARTY_DESCRIPTOR_KEY: ""})
 			if not clear.ok:
 				push_warning("[Party] descriptor clear failed: %s" % clear.message)
 
-	var pf: PlayFabResult = await _network.leave_async()
+	var pf = await _network.leave_async()
 	if not pf.ok:
 		push_warning("[Party] leave failed: %s" % pf.message)
 
@@ -348,8 +350,8 @@ func toggle_mute(peer_id: int, muted: bool) -> bool:
 	if _state != State.IN_NETWORK:
 		push_warning("[Party] toggle_mute rejected — not in a network (state=%d)" % _state)
 		return false
-	var peer: PlayFabPartyPeer = _network.local_peer
-	var pf: PlayFabResult = await peer.set_peer_muted_async(peer_id, muted)
+	var peer = _network.local_peer
+	var pf = await peer.set_peer_muted_async(peer_id, muted)
 	if not pf.ok:
 		push_warning("[Party] mute toggle failed: %s" % pf.message)
 	return pf.ok
@@ -361,8 +363,8 @@ func send_chat(text: String) -> bool:
 	if _state != State.IN_NETWORK:
 		push_warning("[Party] send_chat rejected — not in a network (state=%d)" % _state)
 		return false
-	var peer: PlayFabPartyPeer = _network.local_peer
-	var pf: PlayFabResult = await peer.send_text_async(text)
+	var peer = _network.local_peer
+	var pf = await peer.send_text_async(text)
 	if not pf.ok:
 		push_warning("[Party] send_text failed: %s" % pf.message)
 	return pf.ok
@@ -415,24 +417,24 @@ func ping_message(text: String) -> void:
 # --- Internal helpers ---
 
 func _has_privilege(privilege: int) -> bool:
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return false
-	var pf: GDKResult = await GDK.users.check_privilege_async(user, privilege)
+	var pf = await AddonApi.singleton("GDK").users.check_privilege_async(user, privilege)
 	return pf.ok and bool(pf.data.get("has_privilege", false))
 
 func _check_permission(permission: String, peer_xuid: String) -> bool:
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return false
-	var pf: GDKResult = await GDK.privacy.check_permission_async(
+	var pf = await AddonApi.singleton("GDK").privacy.check_permission_async(
 			user, permission, peer_xuid)
 	return pf.ok and bool(pf.data.get("allowed", false))
 
 # Publishes the network descriptor on the lobby. Rubber-duck issue #3 —
 # re-check before writing so we don't publish a stale descriptor after
 # the host already tore the network down (or the lobby flipped owners).
-func _publish_descriptor_on_lobby(descriptor: String, expected_network: PlayFabPartyNetwork) -> void:
+func _publish_descriptor_on_lobby(descriptor: String, expected_network) -> void:
 	if _state != State.IN_NETWORK:
 		return
 	if not _is_host:
@@ -442,11 +444,11 @@ func _publish_descriptor_on_lobby(descriptor: String, expected_network: PlayFabP
 	if _lobby == null:
 		push_warning("[Party] No lobby to publish descriptor on")
 		return
-	var pf_user: PlayFabUser = _auth.get("playfab_user")
+	var pf_user = _auth.get("playfab_user")
 	if pf_user == null or not _lobby.is_owner(pf_user):
 		return
 	print("[Party] Descriptor ready, publishing on the lobby")
-	var pf: PlayFabResult = await _lobby.set_properties_async({
+	var pf = await _lobby.set_properties_async({
 		PARTY_DESCRIPTOR_KEY: descriptor,
 	})
 	# Re-check after the await so we don't warn about a failure that
@@ -457,7 +459,7 @@ func _publish_descriptor_on_lobby(descriptor: String, expected_network: PlayFabP
 # Rubber-duck issue #4 — centralize lobby signal lifetime so a stale
 # PlayFabLobby ref can't keep delivering PROPERTIES_UPDATED events that
 # trigger a join on the wrong lobby.
-func _attach_lobby(lobby: PlayFabLobby) -> void:
+func _attach_lobby(lobby) -> void:
 	if _lobby == lobby:
 		return
 	_detach_lobby()
@@ -474,13 +476,13 @@ func _detach_lobby() -> void:
 
 # Rubber-duck issue #5 — centralize network signal lifetime + the
 # multiplayer-peer binding so leave/destroy paths share one teardown.
-func _attach_network(net: PlayFabPartyNetwork) -> void:
+func _attach_network(net) -> void:
 	_detach_network()
 	_network = net
 	if _network == null:
 		return
 	_network.state_changed.connect(_on_network_state_changed)
-	var peer: PlayFabPartyPeer = _network.local_peer
+	var peer = _network.local_peer
 	if peer == null:
 		return
 	multiplayer.multiplayer_peer = peer
@@ -514,7 +516,7 @@ func _detach_network() -> void:
 	if _network != null:
 		if _network.state_changed.is_connected(_on_network_state_changed):
 			_network.state_changed.disconnect(_on_network_state_changed)
-		var peer: PlayFabPartyPeer = _network.local_peer
+		var peer = _network.local_peer
 		if peer != null:
 			if peer.text_message_received.is_connected(_on_party_text_received):
 				peer.text_message_received.disconnect(_on_party_text_received)
@@ -527,7 +529,7 @@ func _detach_network() -> void:
 
 # --- Signal handlers ---
 
-func _on_lobby_joined_from_lobby_autoload(lobby: PlayFabLobby) -> void:
+func _on_lobby_joined_from_lobby_autoload(lobby) -> void:
 	_attach_lobby(lobby)
 
 	# Client side: descriptor may already be on the lobby snapshot (host
@@ -553,8 +555,8 @@ func _on_lobby_left_from_lobby_autoload() -> void:
 	if _state == State.IN_NETWORK:
 		await leave_party()
 
-func _on_lobby_state_changed(change: PlayFabLobbyStateChange) -> void:
-	if change.kind != PlayFabLobby.PROPERTIES_UPDATED:
+func _on_lobby_state_changed(change) -> void:
+	if change.kind != AddonApi.constant("PlayFabLobby", "PROPERTIES_UPDATED"):
 		return
 	# Only the not-yet-joined client side cares about descriptor updates.
 	if _is_host or _state != State.READY:
@@ -566,26 +568,26 @@ func _on_lobby_state_changed(change: PlayFabLobbyStateChange) -> void:
 
 	await _join_party_network(descriptor)
 
-func _on_network_state_changed(change: PlayFabPartyNetworkStateChange) -> void:
-	match change.kind:
-		PlayFabParty.NETWORK_CHANGE_DESCRIPTOR_UPDATED:
-			if _is_host and _state == State.IN_NETWORK and _network != null and not _network.descriptor.is_empty():
-				await _publish_descriptor_on_lobby(_network.descriptor, _network)
-		PlayFabParty.NETWORK_CHANGE_PEER_JOINED:
-			var entity := ""
-			if _network != null and _network.local_peer != null:
-				entity = str(_network.local_peer.get_peer_entity_key(change.peer_id))
-			print("[Party] Peer connected: id=%d entity=%s" % [change.peer_id, entity])
-			peer_connected.emit(change.peer_id)
-		PlayFabParty.NETWORK_CHANGE_PEER_LEFT:
-			print("[Party] Peer %d left" % change.peer_id)
-			peer_disconnected.emit(change.peer_id)
-		PlayFabParty.NETWORK_CHANGE_STATE:
-			print("[Party] State → %d (%s)" % [change.state, change.reason])
-		PlayFabParty.NETWORK_CHANGE_ERROR:
-			push_warning("[Party] network error: %s" % change.reason)
-		PlayFabParty.NETWORK_CHANGE_DESTROYED:
-			_handle_network_destroyed(change.reason)
+func _on_network_state_changed(change) -> void:
+	var kind: int = change.kind
+	if kind == AddonApi.constant("PlayFabParty", "NETWORK_CHANGE_DESCRIPTOR_UPDATED"):
+		if _is_host and _state == State.IN_NETWORK and _network != null and not _network.descriptor.is_empty():
+			await _publish_descriptor_on_lobby(_network.descriptor, _network)
+	elif kind == AddonApi.constant("PlayFabParty", "NETWORK_CHANGE_PEER_JOINED"):
+		var entity := ""
+		if _network != null and _network.local_peer != null:
+			entity = str(_network.local_peer.get_peer_entity_key(change.peer_id))
+		print("[Party] Peer connected: id=%d entity=%s" % [change.peer_id, entity])
+		peer_connected.emit(change.peer_id)
+	elif kind == AddonApi.constant("PlayFabParty", "NETWORK_CHANGE_PEER_LEFT"):
+		print("[Party] Peer %d left" % change.peer_id)
+		peer_disconnected.emit(change.peer_id)
+	elif kind == AddonApi.constant("PlayFabParty", "NETWORK_CHANGE_STATE"):
+		print("[Party] State → %d (%s)" % [change.state, change.reason])
+	elif kind == AddonApi.constant("PlayFabParty", "NETWORK_CHANGE_ERROR"):
+		push_warning("[Party] network error: %s" % change.reason)
+	elif kind == AddonApi.constant("PlayFabParty", "NETWORK_CHANGE_DESTROYED"):
+		_handle_network_destroyed(change.reason)
 
 # Rubber-duck issue #2 — centralized DESTROYED dispatch. The destroyed
 # event may arrive:
@@ -627,7 +629,7 @@ func _clear_multiplayer_peer() -> void:
 		return
 	api.multiplayer_peer = null
 
-func _on_party_text_received(peer_id: int, message: PlayFabPartyChatMessage) -> void:
+func _on_party_text_received(peer_id: int, message) -> void:
 	print("[Party] Text from peer %d: \"%s\"" % [peer_id, message.text])
 	chat_received.emit(peer_id, message.text)
 
@@ -654,7 +656,7 @@ func _on_chat_control_added(peer_id: int, _control) -> void:
 	# Re-check after the await — the network may have torn down.
 	if _state != State.IN_NETWORK or _network == null:
 		return
-	var pf: PlayFabResult = await _network.local_peer.set_peer_chat_permissions_async(
+	var pf = await _network.local_peer.set_peer_chat_permissions_async(
 			peer_id, permissions)
 	if not pf.ok:
 		push_warning("[Party] chat permissions for peer %d failed: %s" % [peer_id, pf.message])
@@ -692,5 +694,5 @@ func _xuid_for_peer(peer_id: int) -> String:
 			return String(member.properties.get("xuid", ""))
 	return ""
 
-func _on_party_error(result: PlayFabResult) -> void:
+func _on_party_error(result) -> void:
 	push_warning("[Party] party error: %s (%s)" % [result.message, result.code])

--- a/sample/tutorial_app/shared/addon_api.gd
+++ b/sample/tutorial_app/shared/addon_api.gd
@@ -1,0 +1,19 @@
+extends RefCounted
+
+# Keeps sample scripts parseable before CMake mirrors native addons into this project.
+static func singleton(name: String) -> Object:
+	if Engine.has_singleton(name):
+		return Engine.get_singleton(name)
+	return null
+
+static func instantiate(native_class: String) -> Object:
+	if not ClassDB.class_exists(native_class) or not ClassDB.can_instantiate(native_class):
+		push_error("Native class %s is unavailable. Build and enable the addon first." % native_class)
+		return null
+	return ClassDB.instantiate(native_class)
+
+static func constant(native_class: String, constant_name: String, fallback: int = 0) -> int:
+	if ClassDB.class_exists(native_class) and ClassDB.class_has_integer_constant(native_class, constant_name):
+		return ClassDB.class_get_integer_constant(native_class, constant_name)
+	push_warning("Native constant %s.%s is unavailable. Build and enable the addon first." % [native_class, constant_name])
+	return fallback

--- a/sample/tutorial_app/t02_achievement.gd
+++ b/sample/tutorial_app/t02_achievement.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 2 reference scene — unlock an Xbox achievement.
 ##
 ## Buttons drive each tutorial step in turn:
@@ -38,8 +40,8 @@ func _ready() -> void:
 		_set_buttons_enabled(false)
 		return
 
-	GDK.achievements.achievement_unlocked.connect(_on_achievement_unlocked)
-	GDK.achievements.runtime_error.connect(_on_achievements_runtime_error)
+	AddonApi.singleton("GDK").achievements.achievement_unlocked.connect(_on_achievement_unlocked)
+	AddonApi.singleton("GDK").achievements.runtime_error.connect(_on_achievements_runtime_error)
 
 	_set_buttons_enabled(false)
 	_append("Waiting for sign-in…")
@@ -59,43 +61,43 @@ func _on_push_pressed() -> void:
 	await _push_progress(100)
 
 func _print_cached_achievements() -> void:
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return
 
-	var result: GDKResult = await GDK.achievements.query_player_achievements_async(user)
+	var result = await AddonApi.singleton("GDK").achievements.query_player_achievements_async(user)
 	if not result.ok:
 		_append("[color=orange][Ach] query failed: %s[/color]" % result.message)
 		return
 
-	var cache: Array = GDK.achievements.get_cached_achievements(user)
+	var cache: Array = AddonApi.singleton("GDK").achievements.get_cached_achievements(user)
 	_append("[Ach] %d achievement(s) declared for this title" % cache.size())
 	for entry in cache:
-		var ach: GDKAchievement = entry
+		var ach = entry
 		_append("[Ach]   %s (%s) — %d%%" % [ach.id, ach.name, ach.progress_percent])
 
 func _push_progress(percent: int) -> void:
-	var user: GDKUser = _auth.get("xbox_user")
+	var user = _auth.get("xbox_user")
 	if user == null:
 		return
-	var result: GDKResult = await GDK.achievements.update_achievement_async(
+	var result = await AddonApi.singleton("GDK").achievements.update_achievement_async(
 		user, FIRST_SCORE_ID, percent)
 	if result.ok:
 		_append("[Ach] Updated to %d%% — result ok" % percent)
 	else:
 		_append("[color=orange][Ach] Update to %d%% failed: %s (%s)[/color]" % [percent, result.message, result.code])
 
-func _on_achievement_unlocked(user: GDKUser, achievement_id: String) -> void:
+func _on_achievement_unlocked(user, achievement_id: String) -> void:
 	_unlocked[achievement_id] = true
-	var cache: Array = GDK.achievements.get_cached_achievements(user)
+	var cache: Array = AddonApi.singleton("GDK").achievements.get_cached_achievements(user)
 	for entry in cache:
-		var ach: GDKAchievement = entry
+		var ach = entry
 		if ach.id == achievement_id:
 			_append("[color=green][Ach] Unlocked: %s[/color]" % ach.name)
 			return
 	_append("[color=green][Ach] Unlocked id=%s (not in cache yet)[/color]" % achievement_id)
 
-func _on_achievements_runtime_error(result: GDKResult) -> void:
+func _on_achievements_runtime_error(result) -> void:
 	_append("[color=orange][Ach] Achievements subsystem error: %s (0x%08X)[/color]" % [result.message, result.hresult])
 
 func _set_buttons_enabled(enabled: bool) -> void:

--- a/sample/tutorial_app/t03_leaderboard.gd
+++ b/sample/tutorial_app/t03_leaderboard.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 3 reference scene — record a statistic + read its PlayFab
 ## leaderboard.
 ##
@@ -60,10 +62,10 @@ func _ready() -> void:
 				_auth.call("get_last_error_message")])
 
 func _record_score(score: int) -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
-	var result: PlayFabResult = await PlayFab.statistics.update_statistics_async(user, {
+	var result = await AddonApi.singleton("PlayFab").statistics.update_statistics_async(user, {
 		"statistics": [
 			{"name": STATISTIC_NAME, "scores": [str(score)]},
 		],
@@ -74,10 +76,10 @@ func _record_score(score: int) -> void:
 	_append("[Lead] Recorded score %d to statistic \"%s\"" % [score, STATISTIC_NAME])
 
 func _print_global_top() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
-	var result: PlayFabResult = await PlayFab.leaderboards.get_leaderboard_async(
+	var result = await AddonApi.singleton("PlayFab").leaderboards.get_leaderboard_async(
 			user, LEADERBOARD_NAME, 1, 10)
 	if not result.ok:
 		_append("[color=orange][Lead] get_leaderboard failed: %s[/color]" % result.message)
@@ -96,11 +98,11 @@ func _print_global_top() -> void:
 				_primary_score(row)])
 
 func _print_all_pages() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
 	const PAGE_SIZE := 10
-	var first: PlayFabResult = await PlayFab.leaderboards.get_leaderboard_async(
+	var first = await AddonApi.singleton("PlayFab").leaderboards.get_leaderboard_async(
 			user, LEADERBOARD_NAME, 1, PAGE_SIZE)
 	if not first.ok:
 		_append("[color=orange][Lead] first page failed: %s[/color]" % first.message)
@@ -119,7 +121,7 @@ func _print_all_pages() -> void:
 		next_position += rankings.size()
 		if rankings.is_empty() or next_position > total:
 			break
-		var next_page: PlayFabResult = await PlayFab.leaderboards.get_leaderboard_async(
+		var next_page = await AddonApi.singleton("PlayFab").leaderboards.get_leaderboard_async(
 				user, LEADERBOARD_NAME, next_position, PAGE_SIZE, version)
 		if not next_page.ok:
 			_append("[color=orange][Lead] page %d failed: %s[/color]" % [page_index + 1, next_page.message])
@@ -128,10 +130,10 @@ func _print_all_pages() -> void:
 		page_index += 1
 
 func _print_around_user() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
-	var result: PlayFabResult = await PlayFab.leaderboards.get_leaderboard_around_user_async(
+	var result = await AddonApi.singleton("PlayFab").leaderboards.get_leaderboard_around_user_async(
 			user, LEADERBOARD_NAME, 3)
 	if not result.ok:
 		_append("[color=orange][Lead] around_user failed: %s[/color]" % result.message)
@@ -151,10 +153,10 @@ func _print_around_user() -> void:
 				marker])
 
 func _print_xbox_friend_leaderboard() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
-	var result: PlayFabResult = await PlayFab.leaderboards.get_friend_leaderboard_async(
+	var result = await AddonApi.singleton("PlayFab").leaderboards.get_friend_leaderboard_async(
 			user, LEADERBOARD_NAME, true)
 	if not result.ok:
 		_append("[color=orange][Lead] friend leaderboard failed: %s[/color]" % result.message)

--- a/sample/tutorial_app/t04_game_saves.gd
+++ b/sample/tutorial_app/t04_game_saves.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 4 reference scene — PlayFab Game Saves.
 ##
 ## Buttons drive each tutorial step:
@@ -65,14 +67,14 @@ func _ready() -> void:
 				_auth.call("get_last_error_message")])
 
 func _add_to_game_saves() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
 	if not user.has_local_user_handle:
 		_append("[color=red][Save] PlayFab session is custom-id; Game Saves needs Xbox.[/color]")
 		return
 
-	var result: PlayFabResult = await PlayFab.game_saves.add_user_with_ui_async(user)
+	var result = await AddonApi.singleton("PlayFab").game_saves.add_user_with_ui_async(user)
 	if not result.ok:
 		_append("[color=orange][Save] Add user failed: %s (%s)[/color]" % [result.message, result.code])
 		return
@@ -106,35 +108,35 @@ func _write_save(highscore: int) -> void:
 	_append("[Save] Wrote save: highscore=%d" % highscore)
 
 func _upload(description: String) -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
 
 	if not description.is_empty():
-		var desc_result: PlayFabResult = await PlayFab.game_saves.set_save_description_async(user, description)
+		var desc_result = await AddonApi.singleton("PlayFab").game_saves.set_save_description_async(user, description)
 		if not desc_result.ok:
 			_append("[color=orange][Save] Description set failed: %s[/color]" % desc_result.message)
 
-	var result: PlayFabResult = await PlayFab.game_saves.upload_with_ui_async(user, false)
+	var result = await AddonApi.singleton("PlayFab").game_saves.upload_with_ui_async(user, false)
 	if result.ok:
 		_append("[Save] Upload complete")
 	else:
 		_append("[color=orange][Save] Upload failed: %s (%s)[/color]" % [result.message, result.code])
 
 func _print_cloud_state() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
 
-	var connected: PlayFabResult = PlayFab.game_saves.is_connected_to_cloud(user)
+	var connected = AddonApi.singleton("PlayFab").game_saves.is_connected_to_cloud(user)
 	if connected.ok:
 		_append("[Save] Cloud connected: %s" % str(connected.data))
 
-	var folder_size: PlayFabResult = PlayFab.game_saves.get_folder_size(user)
+	var folder_size = AddonApi.singleton("PlayFab").game_saves.get_folder_size(user)
 	if folder_size.ok:
 		_append("[Save] Folder size on disk: %d bytes" % int(folder_size.data))
 
-	var quota: PlayFabResult = PlayFab.game_saves.get_remaining_quota(user)
+	var quota = AddonApi.singleton("PlayFab").game_saves.get_remaining_quota(user)
 	if quota.ok:
 		_append("[Save] Remaining quota: %d bytes" % int(quota.data))
 
@@ -143,7 +145,7 @@ func _on_resolve_pressed() -> void:
 	# as a single chooser instead of a hard-wired "rollback" button.
 	# Pre-flight: refuse to open if PlayFab isn't ready or the session
 	# isn't Xbox-backed (Game Saves only supports Xbox sign-ins).
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null or not user.has_local_user_handle:
 		_append("[color=red][Save] Resolve unavailable — sign in with an Xbox account first.[/color]")
 		return
@@ -151,27 +153,27 @@ func _on_resolve_pressed() -> void:
 
 func _on_resolve_action(action: StringName) -> void:
 	_resolve_dialog.hide()
-	var option: int = PlayFabGameSaves.ADD_USER_OPTION_NONE
+	var option: int = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_NONE")
 	var label := ""
 	match str(action):
 		ACTION_KEEP_CLOUD:
-			option = PlayFabGameSaves.ADD_USER_OPTION_NONE
+			option = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_NONE")
 			label = "keep cloud version"
 		ACTION_LAST_KNOWN_GOOD:
-			option = PlayFabGameSaves.ADD_USER_OPTION_ROLLBACK_TO_LAST_KNOWN_GOOD
+			option = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_ROLLBACK_TO_LAST_KNOWN_GOOD")
 			label = "rolled back to last known good"
 		ACTION_LAST_CONFLICT:
-			option = PlayFabGameSaves.ADD_USER_OPTION_ROLLBACK_TO_LAST_CONFLICT
+			option = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_ROLLBACK_TO_LAST_CONFLICT")
 			label = "rolled back to last conflict"
 		_:
 			return
 	await _apply_resolution(option, label)
 
 func _apply_resolution(option: int, label: String) -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
-	var result: PlayFabResult = await PlayFab.game_saves.add_user_with_ui_async(user, option)
+	var result = await AddonApi.singleton("PlayFab").game_saves.add_user_with_ui_async(user, option)
 	if not result.ok:
 		_append("[color=orange][Save] Resolution failed (%s): %s[/color]" % [label, result.message])
 		return

--- a/sample/tutorial_app/t05_lobby.gd
+++ b/sample/tutorial_app/t05_lobby.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 5 reference scene — host / join / leave a PlayFab lobby.
 ##
 ## Demonstrates the Lobby autoload's host/join/leave flow with manual
@@ -55,7 +57,7 @@ func _ready() -> void:
 	_set_buttons_enabled(true)
 	_leave_btn.disabled = true
 
-func _on_lobby_joined(lobby: PlayFabLobby) -> void:
+func _on_lobby_joined(lobby) -> void:
 	_append("[color=green]Joined lobby %s[/color]" % lobby.lobby_id)
 	# Surface the connection string in the same LineEdit the client
 	# pastes into, so the host can select-and-copy it (Ctrl+C) and hand
@@ -104,9 +106,9 @@ func _on_lobby_state_changed(state) -> void:
 	_loadout_btn.disabled = not in_lobby
 	_map_btn.disabled = not in_lobby
 
-func _refresh_members(lobby: PlayFabLobby) -> void:
+func _refresh_members(lobby) -> void:
 	_members.clear()
-	for member: PlayFabLobbyMember in lobby.members:
+	for member in lobby.members:
 		var marker := " (local)" if member.is_local else ""
 		_members.add_item("%s%s" % [member.user_id, marker])
 

--- a/sample/tutorial_app/t06_mpa.gd
+++ b/sample/tutorial_app/t06_mpa.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 6 reference scene — Multiplayer Activity + presence + invites.
 ##
 ## Layered on top of the T5 Lobby autoload: pull the live friends list
@@ -71,7 +73,7 @@ func _on_refresh_pressed() -> void:
 		_friends_list.set_item_disabled(0, true)
 		_append("[i]No friends returned by Social Manager. Confirm sign-in and that the title has the Social capability.[/i]")
 		return
-	for friend: GDKSocialUser in friends:
+	for friend in friends:
 		var label := "%s  —  %s" % [_format_gamertag(friend), friend.xuid]
 		var idx := _friends_list.add_item(label)
 		_friends_list.set_item_metadata(idx, friend.xuid)
@@ -100,7 +102,7 @@ func _selected_xuids() -> PackedStringArray:
 			out.append(meta)
 	return out
 
-func _format_gamertag(friend: GDKSocialUser) -> String:
+func _format_gamertag(friend) -> String:
 	if not friend.gamertag.is_empty():
 		return friend.gamertag
 	if not friend.display_name.is_empty():

--- a/sample/tutorial_app/t07_party.gd
+++ b/sample/tutorial_app/t07_party.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 7 — PlayFab Party demo scene.
 ##
 ## Demonstrates the Party autoload's host/join/leave flow on top of the
@@ -139,7 +141,7 @@ func _on_ping_pressed() -> void:
 	else:
 		_append_log("[ping failed — not in a network]")
 
-func _on_lobby_joined(lobby: PlayFabLobby) -> void:
+func _on_lobby_joined(lobby) -> void:
 	_status_label.text = "Lobby ready: %s" % lobby.lobby_id
 	# Surface the connection string in the same LineEdit the client
 	# pastes into so the host can select-and-copy it (Ctrl+C) and hand
@@ -152,7 +154,7 @@ func _on_lobby_joined(lobby: PlayFabLobby) -> void:
 	_join_lobby_id.grab_focus()
 	_leave_button.disabled = false
 	# Host: trigger Party network create now that the lobby owns us.
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user != null and lobby.is_owner(user):
 		await _party_node.host_party()
 
@@ -174,7 +176,7 @@ func _on_lobby_disconnected() -> void:
 	_ping_button.disabled = true
 	_network_label.text = "Network: (none)"
 
-func _on_network_joined(network: PlayFabPartyNetwork) -> void:
+func _on_network_joined(network) -> void:
 	_network_label.text = "Network: %s" % network.network_id
 	_send_button.disabled = false
 	_ping_button.disabled = false

--- a/sample/tutorial_app/t08_integration/panel_achievements.gd
+++ b/sample/tutorial_app/t08_integration/panel_achievements.gd
@@ -1,5 +1,7 @@
 extends VBoxContainer
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 Step 2 — Achievements panel.
 ##
 ## Mirrors the T2 happy path: buttons for the canonical progress curve
@@ -42,8 +44,8 @@ func _exit_tree() -> void:
 	if _auth != null and _auth.state_changed.is_connected(_on_auth_state_changed):
 		_auth.state_changed.disconnect(_on_auth_state_changed)
 	if _initialized and Engine.has_singleton("GDK"):
-		if GDK.achievements.achievement_unlocked.is_connected(_on_achievement_unlocked):
-			GDK.achievements.achievement_unlocked.disconnect(_on_achievement_unlocked)
+		if AddonApi.singleton("GDK").achievements.achievement_unlocked.is_connected(_on_achievement_unlocked):
+			AddonApi.singleton("GDK").achievements.achievement_unlocked.disconnect(_on_achievement_unlocked)
 
 func _on_auth_state_changed(_state) -> void:
 	if _initialized or _auth == null:
@@ -56,14 +58,14 @@ func _initialize_after_sign_in() -> void:
 		return
 	_initialized = true
 
-	GDK.achievements.achievement_unlocked.connect(_on_achievement_unlocked)
+	AddonApi.singleton("GDK").achievements.achievement_unlocked.connect(_on_achievement_unlocked)
 	_progress_25.pressed.connect(_push_progress.bind(25))
 	_progress_50.pressed.connect(_push_progress.bind(50))
 	_progress_75.pressed.connect(_push_progress.bind(75))
 	_unlock.pressed.connect(_push_progress.bind(100))
 
-	var user: GDKUser = _auth.get("xbox_user")
-	var result: GDKResult = await GDK.achievements.query_player_achievements_async(user)
+	var user = _auth.get("xbox_user")
+	var result = await AddonApi.singleton("GDK").achievements.query_player_achievements_async(user)
 	if not is_inside_tree():
 		return
 	if result.ok:
@@ -74,8 +76,8 @@ func _initialize_after_sign_in() -> void:
 		_status.text = "Query failed: %s" % result.message
 
 func _push_progress(percent: int) -> void:
-	var user: GDKUser = _auth.get("xbox_user")
-	var result: GDKResult = await GDK.achievements.update_achievement_async(
+	var user = _auth.get("xbox_user")
+	var result = await AddonApi.singleton("GDK").achievements.update_achievement_async(
 			user, ACHIEVEMENT_ID, percent)
 	if not is_inside_tree():
 		return
@@ -86,7 +88,7 @@ func _push_progress(percent: int) -> void:
 		_status.text = "Update failed: %s" % result.message
 		push_warning("[Ach] %s" % _status.text)
 
-func _on_achievement_unlocked(user: GDKUser, achievement_id: String) -> void:
+func _on_achievement_unlocked(user, achievement_id: String) -> void:
 	if achievement_id != ACHIEVEMENT_ID:
 		return
 	_status.text = "Unlocked %s for %s" % [achievement_id, user.gamertag]
@@ -94,8 +96,8 @@ func _on_achievement_unlocked(user: GDKUser, achievement_id: String) -> void:
 	_refresh_status()
 
 func _refresh_status() -> void:
-	var user: GDKUser = _auth.get("xbox_user")
-	var cached: Array = GDK.achievements.get_cached_achievements(user)
+	var user = _auth.get("xbox_user")
+	var cached: Array = AddonApi.singleton("GDK").achievements.get_cached_achievements(user)
 	for ach in cached:
 		if ach.id == ACHIEVEMENT_ID:
 			var verb: String = "Unlocked" if ach.progress_percent >= 100 else "In progress"

--- a/sample/tutorial_app/t08_integration/panel_game_saves.gd
+++ b/sample/tutorial_app/t08_integration/panel_game_saves.gd
@@ -1,5 +1,7 @@
 extends VBoxContainer
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 Step 4 — Game Saves panel.
 ##
 ## Adds the local PlayFab user to Game Saves, writes a timestamped blob
@@ -63,8 +65,8 @@ func _initialize_after_sign_in() -> void:
 		return
 	_initialized = true
 
-	var user: PlayFabUser = _auth.get("playfab_user")
-	var result: PlayFabResult = await PlayFab.game_saves.add_user_with_ui_async(user)
+	var user = _auth.get("playfab_user")
+	var result = await AddonApi.singleton("PlayFab").game_saves.add_user_with_ui_async(user)
 	if not is_inside_tree():
 		return
 	if not result.ok:
@@ -84,7 +86,7 @@ func _on_write_pressed() -> void:
 	if _save_folder.is_empty():
 		return
 	var path: String = "%s/%s" % [_save_folder, SAVE_FILE]
-	var xbox: GDKUser = _auth.get("xbox_user")
+	var xbox = _auth.get("xbox_user")
 	var gamertag: String = xbox.gamertag if xbox != null else "(unknown)"
 	var payload: String = "saved=%s timestamp=%s" % [
 			gamertag, Time.get_datetime_string_from_system()]
@@ -95,8 +97,8 @@ func _on_write_pressed() -> void:
 	f.store_string(payload)
 	f.close()
 	var bytes: int = payload.length()
-	var user: PlayFabUser = _auth.get("playfab_user")
-	var upload: PlayFabResult = await PlayFab.game_saves.upload_with_ui_async(user, false)
+	var user = _auth.get("playfab_user")
+	var upload = await AddonApi.singleton("PlayFab").game_saves.upload_with_ui_async(user, false)
 	if not is_inside_tree():
 		return
 	if upload.ok:
@@ -125,24 +127,24 @@ func _on_resolve_pressed() -> void:
 
 func _on_resolve_action(action: StringName) -> void:
 	_resolve_dialog.hide()
-	var option: int = PlayFabGameSaves.ADD_USER_OPTION_NONE
+	var option: int = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_NONE")
 	var label := ""
 	match str(action):
 		ACTION_KEEP_CLOUD:
-			option = PlayFabGameSaves.ADD_USER_OPTION_NONE
+			option = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_NONE")
 			label = "keep cloud version"
 		ACTION_LAST_KNOWN_GOOD:
-			option = PlayFabGameSaves.ADD_USER_OPTION_ROLLBACK_TO_LAST_KNOWN_GOOD
+			option = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_ROLLBACK_TO_LAST_KNOWN_GOOD")
 			label = "rolled back to last known good"
 		ACTION_LAST_CONFLICT:
-			option = PlayFabGameSaves.ADD_USER_OPTION_ROLLBACK_TO_LAST_CONFLICT
+			option = AddonApi.constant("PlayFabGameSaves", "ADD_USER_OPTION_ROLLBACK_TO_LAST_CONFLICT")
 			label = "rolled back to last conflict"
 		_:
 			return
-	var user: PlayFabUser = _auth.get("playfab_user")
+	var user = _auth.get("playfab_user")
 	if user == null:
 		return
-	var result: PlayFabResult = await PlayFab.game_saves.add_user_with_ui_async(user, option)
+	var result = await AddonApi.singleton("PlayFab").game_saves.add_user_with_ui_async(user, option)
 	if not is_inside_tree():
 		return
 	if not result.ok:

--- a/sample/tutorial_app/t08_integration/panel_leaderboard.gd
+++ b/sample/tutorial_app/t08_integration/panel_leaderboard.gd
@@ -1,5 +1,7 @@
 extends VBoxContainer
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 Step 3 — Leaderboards panel.
 ##
 ## Top-10 + around-user views side by side; submit button drives the
@@ -60,8 +62,8 @@ func _initialize_after_sign_in() -> void:
 
 func _on_submit_pressed() -> void:
 	_scratch_score += 10
-	var user: PlayFabUser = _auth.get("playfab_user")
-	var result: PlayFabResult = await PlayFab.statistics.update_statistics_async(user, {
+	var user = _auth.get("playfab_user")
+	var result = await AddonApi.singleton("PlayFab").statistics.update_statistics_async(user, {
 		"statistics": [
 			{"name": STATISTIC_NAME, "scores": [str(_scratch_score)]},
 		],
@@ -77,8 +79,8 @@ func _on_submit_pressed() -> void:
 	await _refresh_views()
 
 func _refresh_views() -> void:
-	var user: PlayFabUser = _auth.get("playfab_user")
-	var top: PlayFabResult = await PlayFab.leaderboards.get_leaderboard_async(
+	var user = _auth.get("playfab_user")
+	var top = await AddonApi.singleton("PlayFab").leaderboards.get_leaderboard_async(
 			user, LEADERBOARD_NAME, 1, 10)
 	if not is_inside_tree():
 		return
@@ -94,7 +96,7 @@ func _refresh_views() -> void:
 	else:
 		_top10.text = "Top-10 failed: %s" % top.message
 
-	var around: PlayFabResult = await PlayFab.leaderboards.get_leaderboard_around_user_async(
+	var around = await AddonApi.singleton("PlayFab").leaderboards.get_leaderboard_around_user_async(
 			user, LEADERBOARD_NAME, 3)
 	if not is_inside_tree():
 		return

--- a/sample/tutorial_app/t08_integration/panel_lobby.gd
+++ b/sample/tutorial_app/t08_integration/panel_lobby.gd
@@ -1,5 +1,7 @@
 extends VBoxContainer
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 Step 5 — Lobby panel.
 ##
 ## Host / join (from a pasted connection string) / leave with member
@@ -44,8 +46,8 @@ func _exit_tree() -> void:
 	if not _initialized:
 		return
 	if Engine.has_singleton("PlayFab"):
-		if PlayFab.multiplayer.state_changed.is_connected(_refresh):
-			PlayFab.multiplayer.state_changed.disconnect(_refresh)
+		if AddonApi.singleton("PlayFab").multiplayer.state_changed.is_connected(_refresh):
+			AddonApi.singleton("PlayFab").multiplayer.state_changed.disconnect(_refresh)
 	if _lobby_node != null and _lobby_node.lobby_disconnected.is_connected(_on_lobby_disconnected):
 		_lobby_node.lobby_disconnected.disconnect(_on_lobby_disconnected)
 	if _lobby_node != null and _lobby_node.state_changed.is_connected(_on_lobby_state_changed):
@@ -64,7 +66,7 @@ func _initialize_after_sign_in() -> void:
 	_host.pressed.connect(_on_host_pressed)
 	_join.pressed.connect(_on_join_pressed)
 	_leave.pressed.connect(_on_leave_pressed)
-	PlayFab.multiplayer.state_changed.connect(_refresh)
+	AddonApi.singleton("PlayFab").multiplayer.state_changed.connect(_refresh)
 	_lobby_node.lobby_disconnected.connect(_on_lobby_disconnected)
 	# Drive in-progress feedback off the Lobby autoload so the status
 	# label flips to "Hosting…" / "Joining…" / "Leaving…" the moment the
@@ -78,7 +80,7 @@ func _on_host_pressed() -> void:
 	await _lobby_node.host_lobby()
 	if not is_inside_tree():
 		return
-	var current: PlayFabLobby = _lobby_node.call("get_current_lobby")
+	var current = _lobby_node.call("get_current_lobby")
 	if current != null:
 		_connection_string.text = current.connection_string
 	_refresh()
@@ -100,7 +102,7 @@ func _on_leave_pressed() -> void:
 	_refresh()
 
 func _refresh(_change = null) -> void:
-	var current: PlayFabLobby = _lobby_node.call("get_current_lobby")
+	var current = _lobby_node.call("get_current_lobby")
 	if current == null:
 		_status.text = "Not in a lobby"
 		_members.text = ""
@@ -110,7 +112,7 @@ func _refresh(_change = null) -> void:
 			current.member_count,
 			current.max_member_count]
 	var lines := PackedStringArray()
-	for member: PlayFabLobbyMember in current.members:
+	for member in current.members:
 		lines.append("- %s%s" % [member.user_id, " (you)" if member.is_local else ""])
 	_members.text = "\n".join(lines)
 

--- a/sample/tutorial_app/t08_integration/panel_mpa.gd
+++ b/sample/tutorial_app/t08_integration/panel_mpa.gd
@@ -1,5 +1,7 @@
 extends VBoxContainer
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 Step 6 — Multiplayer Activity panel.
 ##
 ## Reactive view of the activity advertised by the Lobby autoload.
@@ -50,13 +52,13 @@ func _exit_tree() -> void:
 	if not _initialized:
 		return
 	if Engine.has_singleton("GDK"):
-		if GDK.multiplayer_activity.invite_accepted.is_connected(_on_invite_accepted):
-			GDK.multiplayer_activity.invite_accepted.disconnect(_on_invite_accepted)
-		if GDK.multiplayer_activity.pending_invite_received.is_connected(_on_pending_invite):
-			GDK.multiplayer_activity.pending_invite_received.disconnect(_on_pending_invite)
+		if AddonApi.singleton("GDK").multiplayer_activity.invite_accepted.is_connected(_on_invite_accepted):
+			AddonApi.singleton("GDK").multiplayer_activity.invite_accepted.disconnect(_on_invite_accepted)
+		if AddonApi.singleton("GDK").multiplayer_activity.pending_invite_received.is_connected(_on_pending_invite):
+			AddonApi.singleton("GDK").multiplayer_activity.pending_invite_received.disconnect(_on_pending_invite)
 	if Engine.has_singleton("PlayFab"):
-		if PlayFab.multiplayer.state_changed.is_connected(_refresh_state):
-			PlayFab.multiplayer.state_changed.disconnect(_refresh_state)
+		if AddonApi.singleton("PlayFab").multiplayer.state_changed.is_connected(_refresh_state):
+			AddonApi.singleton("PlayFab").multiplayer.state_changed.disconnect(_refresh_state)
 	if _lobby_node != null:
 		if _lobby_node.invite_pending_confirmation.is_connected(_on_invite_pending_confirmation):
 			_lobby_node.invite_pending_confirmation.disconnect(_on_invite_pending_confirmation)
@@ -78,9 +80,9 @@ func _initialize_after_sign_in() -> void:
 	_picker.pressed.connect(_on_picker_pressed)
 	_invite_dialog.confirmed.connect(_on_invite_dialog_confirmed)
 	_invite_dialog.canceled.connect(_on_invite_dialog_canceled)
-	GDK.multiplayer_activity.invite_accepted.connect(_on_invite_accepted)
-	GDK.multiplayer_activity.pending_invite_received.connect(_on_pending_invite)
-	PlayFab.multiplayer.state_changed.connect(_refresh_state)
+	AddonApi.singleton("GDK").multiplayer_activity.invite_accepted.connect(_on_invite_accepted)
+	AddonApi.singleton("GDK").multiplayer_activity.pending_invite_received.connect(_on_pending_invite)
+	AddonApi.singleton("PlayFab").multiplayer.state_changed.connect(_refresh_state)
 	# Item 3 / B3 — prompt before MPA invite tears down current session.
 	_lobby_node.invite_pending_confirmation.connect(_on_invite_pending_confirmation)
 	_lobby_node.invite_pending_cleared.connect(_on_invite_pending_cleared)
@@ -89,7 +91,7 @@ func _initialize_after_sign_in() -> void:
 	await _on_refresh_pressed()
 
 func _refresh_state(_change = null) -> void:
-	var current: PlayFabLobby = _lobby_node.call("get_current_lobby")
+	var current = _lobby_node.call("get_current_lobby")
 	if current == null:
 		_state.text = "No lobby — activity not advertised"
 		return
@@ -111,8 +113,8 @@ func _on_refresh_pressed() -> void:
 		_friends.add_item("(no friends found)")
 		_friends.set_item_disabled(0, true)
 		return
-	for friend: GDKSocialUser in list:
-		var label := friend.gamertag if not friend.gamertag.is_empty() else friend.display_name
+	for friend in list:
+		var label: String = friend.gamertag if not friend.gamertag.is_empty() else friend.display_name
 		if label.is_empty():
 			label = friend.xuid
 		var idx := _friends.item_count

--- a/sample/tutorial_app/t08_integration/panel_party.gd
+++ b/sample/tutorial_app/t08_integration/panel_party.gd
@@ -1,5 +1,7 @@
 extends VBoxContainer
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 Step 7 — PlayFab Party panel.
 ##
 ## Peer roster + broadcast text chat + per-peer mute toggle on top of
@@ -22,8 +24,8 @@ extends VBoxContainer
 
 var _auth: Node = null
 var _party_node: Node = null
-var _network: PlayFabPartyNetwork = null
-var _peer: PlayFabPartyPeer = null
+var _network = null
+var _peer = null
 var _initialized: bool = false
 
 func _ready() -> void:
@@ -86,7 +88,7 @@ func _initialize_after_sign_in() -> void:
 	var label: String = "connected" if _network != null else "idle — no network"
 	print("[Pty] party panel ready (%s)" % label)
 
-func _attach_network(network: PlayFabPartyNetwork) -> void:
+func _attach_network(network) -> void:
 	if network == _network:
 		return
 	if _network != null and _network.state_changed.is_connected(_on_network_state_changed):
@@ -136,7 +138,7 @@ func _on_send_pressed() -> void:
 	var text: String = _chat_input.text.strip_edges()
 	if text.is_empty() or _peer == null:
 		return
-	var result: PlayFabResult = await _peer.send_text_async(text)
+	var result = await _peer.send_text_async(text)
 	if not is_inside_tree():
 		return
 	if result.ok:
@@ -151,16 +153,16 @@ func _on_mute_remotes_toggled(button_pressed: bool) -> void:
 	for peer_id in _peer.get_peers():
 		_peer.set_peer_muted_async(peer_id, button_pressed)
 
-func _on_network_state_changed(_change: PlayFabPartyNetworkStateChange) -> void:
+func _on_network_state_changed(_change) -> void:
 	_refresh_peers()
 
-func _on_chat_control_added(_peer_id: int, _control: PlayFabPartyChatControl) -> void:
+func _on_chat_control_added(_peer_id: int, _control) -> void:
 	_refresh_peers()
 
 func _on_chat_control_removed(_peer_id: int) -> void:
 	_refresh_peers()
 
-func _on_text_received(peer_id: int, message: PlayFabPartyChatMessage) -> void:
+func _on_text_received(peer_id: int, message) -> void:
 	var label: String = "?"
 	if _peer != null:
 		var entity: Dictionary = _peer.get_peer_entity_key(peer_id)

--- a/sample/tutorial_app/t08_integration/t08_integration.gd
+++ b/sample/tutorial_app/t08_integration/t08_integration.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://shared/addon_api.gd")
+
 ## Tutorial 8 — Integration tech demo (capstone).
 ##
 ## Root wiring layer: HUD strip (identity + runtime-error indicator +
@@ -35,11 +37,11 @@ func _ready() -> void:
 	_on_auth_state_changed(_auth.call("get_state"))
 
 	if Engine.has_singleton("GDK"):
-		GDK.runtime_error.connect(_on_runtime_error.bind("gdk"))
-		GDK.achievements.runtime_error.connect(_on_runtime_error.bind("achievements"))
+		AddonApi.singleton("GDK").runtime_error.connect(_on_runtime_error.bind("gdk"))
+		AddonApi.singleton("GDK").achievements.runtime_error.connect(_on_runtime_error.bind("achievements"))
 	if Engine.has_singleton("PlayFab"):
-		PlayFab.multiplayer.multiplayer_error.connect(_on_pf_runtime_error.bind("multiplayer"))
-		PlayFab.party.party_error.connect(_on_pf_runtime_error.bind("party"))
+		AddonApi.singleton("PlayFab").multiplayer.multiplayer_error.connect(_on_pf_runtime_error.bind("multiplayer"))
+		AddonApi.singleton("PlayFab").party.party_error.connect(_on_pf_runtime_error.bind("party"))
 
 	# Make sure sign_in fires for cold T8 entry even without other listeners.
 	await _auth.call("sign_in")
@@ -48,8 +50,8 @@ func _on_auth_state_changed(_state) -> void:
 	if _auth == null:
 		return
 	if _auth.call("is_signed_in"):
-		var xbox: GDKUser = _auth.get("xbox_user")
-		var pf: PlayFabUser = _auth.get("playfab_user")
+		var xbox = _auth.get("xbox_user")
+		var pf = _auth.get("playfab_user")
 		if xbox != null and pf != null:
 			var entity_id: String = str(pf.entity_key.get("id", ""))
 			_identity.text = "%s ↔ PlayFab:%s" % [xbox.gamertag, entity_id.left(8)]
@@ -74,10 +76,10 @@ func _on_retry_pressed() -> void:
 func _on_back_pressed() -> void:
 	get_tree().change_scene_to_file("res://shared/tutorial_picker.tscn")
 
-func _on_runtime_error(result: GDKResult, source: String) -> void:
+func _on_runtime_error(result, source: String) -> void:
 	_error.text = "[%s] %s" % [source, result.message]
 	push_warning("[Hud] runtime error from %s: %s" % [source, result.message])
 
-func _on_pf_runtime_error(result: PlayFabResult, source: String) -> void:
+func _on_pf_runtime_error(result, source: String) -> void:
 	_error.text = "[%s] %s" % [source, result.message]
 	push_warning("[Hud] PlayFab runtime error from %s: %s" % [source, result.message])

--- a/sample/tutorial_gameinput/addon_api.gd
+++ b/sample/tutorial_gameinput/addon_api.gd
@@ -1,0 +1,19 @@
+extends RefCounted
+
+# Keeps sample scripts parseable before CMake mirrors native addons into this project.
+static func singleton(name: String) -> Object:
+	if Engine.has_singleton(name):
+		return Engine.get_singleton(name)
+	return null
+
+static func instantiate(native_class: String) -> Object:
+	if not ClassDB.class_exists(native_class) or not ClassDB.can_instantiate(native_class):
+		push_error("Native class %s is unavailable. Build and enable the addon first." % native_class)
+		return null
+	return ClassDB.instantiate(native_class)
+
+static func constant(native_class: String, constant_name: String, fallback: int = 0) -> int:
+	if ClassDB.class_exists(native_class) and ClassDB.class_has_integer_constant(native_class, constant_name):
+		return ClassDB.class_get_integer_constant(native_class, constant_name)
+	push_warning("Native constant %s.%s is unavailable. Build and enable the addon first." % [native_class, constant_name])
+	return fallback

--- a/sample/tutorial_gameinput/main.gd
+++ b/sample/tutorial_gameinput/main.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const AddonApi = preload("res://addon_api.gd")
+
 ## GameInput action bridge — standalone tutorial sample.
 ##
 ## Builds a GameInputActionMap programmatically (matching the Step 2
@@ -23,7 +25,7 @@ const PLAYER_GRAVITY := 1200.0
 const PLAYER_FLOOR_Y := 320.0
 
 var _player_velocity_y: float = 0.0
-var _mapper: GameInputMapper = null
+var _mapper = null
 
 func _ready() -> void:
 	if not Engine.has_singleton("GameInput"):
@@ -33,50 +35,50 @@ func _ready() -> void:
 		_action_state.text = ""
 		return
 
-	if not GameInput.is_initialized():
+	if not AddonApi.singleton("GameInput").is_initialized():
 		push_warning("[Pad] GameInput runtime not available — gamepad input disabled.")
 		_runtime_status.text = "GameInput runtime NOT initialized (set game_input/runtime/initialize_on_startup=true)."
 	else:
 		_runtime_status.text = "GameInput runtime initialized."
 
-	_mapper = GameInputMapper.new()
+	_mapper = AddonApi.instantiate("GameInputMapper")
 	_mapper.name = "GamepadMapper"
 	_mapper.action_map = _build_default_map()
 	add_child(_mapper)
 
-	GameInput.device_connected.connect(_on_device_connected)
-	GameInput.device_disconnected.connect(_on_device_disconnected)
+	AddonApi.singleton("GameInput").device_connected.connect(_on_device_connected)
+	AddonApi.singleton("GameInput").device_disconnected.connect(_on_device_disconnected)
 
 	# Seed the UI with whatever was connected before _ready.
 	_refresh_devices()
-	_append_hotplug("Seeded with %d device(s) at startup" % GameInput.get_connected_device_count())
+	_append_hotplug("Seeded with %d device(s) at startup" % AddonApi.singleton("GameInput").get_connected_device_count())
 
 	# Position the player on the floor.
 	_player.position = Vector2(get_viewport_rect().size.x * 0.5, PLAYER_FLOOR_Y)
 
-func _build_default_map() -> GameInputActionMap:
-	var map := GameInputActionMap.new()
+func _build_default_map():
+	var map := AddonApi.instantiate("GameInputActionMap")
 
-	var accept := GameInputBinding.new()
+	var accept := AddonApi.instantiate("GameInputBinding")
 	accept.action = &"ui_accept"
-	accept.source = GameInputDevice.SRC_BTN_A
+	accept.source = AddonApi.constant("GameInputDevice", "SRC_BTN_A")
 	map.add_binding(accept)
 
-	var jump := GameInputBinding.new()
+	var jump := AddonApi.instantiate("GameInputBinding")
 	jump.action = &"jump"
-	jump.source = GameInputDevice.SRC_BTN_A
+	jump.source = AddonApi.constant("GameInputDevice", "SRC_BTN_A")
 	map.add_binding(jump)
 
-	var left := GameInputBinding.new()
+	var left := AddonApi.instantiate("GameInputBinding")
 	left.action = &"move_left"
-	left.source = GameInputDevice.SRC_AXIS_LEFT_X
+	left.source = AddonApi.constant("GameInputDevice", "SRC_AXIS_LEFT_X")
 	left.is_axis = true
 	left.axis_invert = true
 	map.add_binding(left)
 
-	var right := GameInputBinding.new()
+	var right := AddonApi.instantiate("GameInputBinding")
 	right.action = &"move_right"
-	right.source = GameInputDevice.SRC_AXIS_LEFT_X
+	right.source = AddonApi.constant("GameInputDevice", "SRC_AXIS_LEFT_X")
 	right.is_axis = true
 	map.add_binding(right)
 
@@ -113,7 +115,7 @@ func _process(_delta: float) -> void:
 			]
 	)
 
-func _on_device_connected(device: GameInputDevice) -> void:
+func _on_device_connected(device) -> void:
 	_append_hotplug("connected: id=%d (%s)" % [device.get_device_id(), device.get_display_name()])
 	_refresh_devices()
 
@@ -122,11 +124,11 @@ func _on_device_disconnected(device_id: int) -> void:
 	_refresh_devices()
 
 func _refresh_devices() -> void:
-	var count: int = GameInput.get_connected_device_count()
+	var count: int = AddonApi.singleton("GameInput").get_connected_device_count()
 	_device_count.text = "Connected gamepads: %d" % count
 
 	var lines := PackedStringArray()
-	for device in GameInput.get_devices(GameInput.DEVICE_GAMEPAD):
+	for device in AddonApi.singleton("GameInput").get_devices(AddonApi.constant("GameInput", "DEVICE_GAMEPAD")):
 		lines.append("- id=%d %s" % [device.get_device_id(), device.get_display_name()])
 	if lines.is_empty():
 		lines.append("- (none — plug in a gamepad)")


### PR DESCRIPTION
## Summary

- Fixed the parse-gate blocker in `sample/tutorial_app` and `sample/tutorial_gameinput`.
- Root cause: tutorial scripts referenced native GDK/PlayFab/GameInput typed symbols directly while sample addon mirrors are CMake-generated and git-ignored, so fresh worktrees parse before those symbols exist.
- Added sample-local `AddonApi` helpers and routed singleton/class/constant access through `Engine` / `ClassDB` so samples parse before mirrors are built.

## Before

```text
== [1/7] Parse gate (check_gd_scripts_headless.ps1) ==
   FAIL: check_gd_scripts_headless.ps1 exited 1

[sample\tutorial_app] ...\autoload\auth.gd
Parse Error: Could not find type "GDKUser" in the current scope.
Parse Error: Could not find type "PlayFabUser" in the current scope.

[sample\tutorial_gameinput] ...\main.gd
Parse Error: Could not find type "GameInputMapper" in the current scope.
Parse Error: Identifier "GameInput" not declared in the current scope.
```

## After / validation

```text
pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\check_gd_scripts_headless.ps1
Checking addons (34 scripts)
Checking sample\tutorial_app (20 scripts)
Checking sample\tutorial_gameinput (2 scripts)
Checking tests\godot\mp_orchestrator (31 scripts)
Checking tests\godot\mp_test_client (8 scripts)
Checking tests\godot\playfab_multiplayer_worker (1 script)
Headless GDScript validation passed.
```

```text
pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1 -OutDir build\test-results-after
== [1/7] Parse gate (check_gd_scripts_headless.ps1) ==
   PASS: OK
== [2/7] CMake build (debug) ==
   FAIL: cmake --build failed (exit 1).
```

Leftover failure is after the formerly-blocking parse stage and appears unrelated/pre-existing:

```text
addons\godot_gameinput\src\gameinput_mapper.cpp(184,5): error C3927: '->': trailing return type is not allowed after a non-function declarator
```

Live tests were not run (`-Live` not used).
