### PR TITLE
docs(gameinput): fix ADT-identified documentation gaps

### DIFF
--- a/addons/godot_gameinput/doc_classes/GameInputDevice.xml
+++ b/addons/godot_gameinput/doc_classes/GameInputDevice.xml
@@ -43,7 +43,7 @@
 		<method name="supports_haptics" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the device reports one or more haptic-feedback motors (distinct from rumble). The current addon does not yet send haptic patterns; this is exposed so games can detect capability ahead of a future API.
+				Returns [code]true[/code] if [code]IGameInputDevice::GetHapticInfo()[/code] succeeds and reports at least one haptic location. This is distinct from rumble support exposed by [method supports_vibration]. The current addon does not yet send haptic patterns; this is exposed so games can detect capability ahead of a future API.
 			</description>
 		</method>
 		<method name="get_device_info" qualifiers="const">

--- a/addons/godot_gameinput/doc_classes/GameInputMapper.xml
+++ b/addons/godot_gameinput/doc_classes/GameInputMapper.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[GameInputMapper] is a [Node] that resolves a target [GameInputDevice] (either by id via [member target_device_id] or as the primary device of [member target_kind_mask]) every [code]_process[/code] frame, fetches its [GameInputReading], and walks [member action_map] calling [code]Input.action_press(action, strength)[/code] or [code]Input.action_release(action)[/code] on each press / release edge so the rest of your game can keep using the standard [code]Input.is_action_pressed("jump")[/code] APIs without knowing GameInput exists. On every press / release transition the mapper additionally pushes an [InputEventAction] through [code]Input.parse_input_event[/code] so event-driven listeners — Viewport GUI focus traversal for [code]ui_*[/code] actions, [code]_gui_input[/code] handlers, [code]_input[/code] / [code]_unhandled_input[/code] — actually see the action fire, since [code]Input.action_press[/code] alone updates polled state but does not deliver an [InputEvent].
+		Current v1 limitation: the runtime reading path calls [code]GetCurrentReading(GameInputKindGamepad, ...)[/code], so mapper-readable state is gamepad-only today. [constant KIND_KEYBOARD] and [constant KIND_MOUSE] remain reserved for future raw keyboard / mouse support, but they are not yet usable action-bridge targets.
 		To avoid double-firing when Godot's built-in joypad backend is already wired to deliver the same action via an [InputEventJoypadButton] / [InputEventJoypadMotion] in the project's [code]InputMap[/code] (e.g., the default [code]ui_accept[/code] mapping that includes joypad button A), the mapper checks each binding once against the action's [code]InputMap[/code] events and skips its own synthetic [InputEventAction] when a matching native joypad event is found. The polled state via [code]Input.action_press[/code] is still refreshed every frame either way. The check is per-binding, cached, invalidated whenever [member action_map] or a binding on that map changes, and refreshed once per frame so runtime [code]InputMap[/code] edits made after the cache fills tolerate at most one frame of staleness.
 		The mapper calls [method GameInput.poll] defensively at the start of each frame; that call is per-frame idempotent so multiple [GameInputMapper] instances in the same scene do not refresh device state more than once per frame.
 		Action names listed in [member GameInputBinding.action] must already exist in the project's [code]InputMap[/code]. Missing actions emit a single [code]push_warning[/code] per [GameInputMapper] instance per action (debounced via an internal set) and the binding is then ignored. Whenever the mapper stops driving a held binding — exiting the tree, swapping or mutating the active map, retargeting the mapper, losing the target device, or failing to obtain a fresh reading — it releases every action it previously held so Godot's polled action state cannot get stuck pressed.
@@ -62,7 +63,7 @@
 			The [GameInputActionMap] this mapper iterates each frame. When [code]null[/code] the mapper is a no-op.
 		</member>
 		<member name="target_kind_mask" type="int" setter="set_target_kind_mask" getter="get_target_kind_mask" default="1">
-			Bitfield of [enum KindFlags] values used to pick the primary device when [member target_device_id] is [code]-1[/code]. Defaults to [constant KIND_GAMEPAD]. Despite its enum, the field accepts an OR-ed combination so a mapper can be retargeted at, for example, [code]KIND_GAMEPAD | KIND_KEYBOARD[/code].
+			Bitfield of [enum KindFlags] values used to pick the primary device when [member target_device_id] is [code]-1[/code]. Defaults to [constant KIND_GAMEPAD]. Despite its enum, the field accepts an OR-ed combination so a mapper can be retargeted at, for example, [code]KIND_GAMEPAD | KIND_KEYBOARD[/code]. In v1, only gamepad targets currently produce mapper-readable state.
 		</member>
 		<member name="target_device_id" type="int" setter="set_target_device_id" getter="get_target_device_id" default="-1">
 			Specific [GameInputDevice] id to drive, or [code]-1[/code] (the default) to use the primary device matching [member target_kind_mask]. Use this for split-screen / per-player mapper instances by storing the id reported by [signal GameInput.device_connected].
@@ -73,10 +74,10 @@
 			Bit flag for gamepad-style devices. Mirrors [constant GameInput.DEVICE_GAMEPAD] and is the default value of [member target_kind_mask].
 		</constant>
 		<constant name="KIND_KEYBOARD" value="2" enum="KindFlags">
-			Bit flag for keyboard devices. Mirrors [constant GameInput.DEVICE_KEYBOARD].
+			Bit flag for keyboard devices. Mirrors [constant GameInput.DEVICE_KEYBOARD]. Exposed for target selection, but not yet a usable mapper reading target in v1.
 		</constant>
 		<constant name="KIND_MOUSE" value="4" enum="KindFlags">
-			Bit flag for mouse devices. Mirrors [constant GameInput.DEVICE_MOUSE].
+			Bit flag for mouse devices. Mirrors [constant GameInput.DEVICE_MOUSE]. Exposed for target selection, but not yet a usable mapper reading target in v1.
 		</constant>
 	</constants>
 </class>

--- a/docs/gameinput/manual-tests.md
+++ b/docs/gameinput/manual-tests.md
@@ -4,17 +4,11 @@ The headless test suite under `tests/godot/gameinput/tests/` covers everything t
 can be verified without a real controller. This document covers the pieces
 that need a human + hardware in the loop.
 
-> **Sample-dependent steps are temporarily inert.** The repository is
-> mid-revamp; samples are returning in PR 3 of the tutorial-driven
-> sample series (`sample/tutorial_app/` for the action-bridge demo
-> and `sample/tutorial_gameinput/` as a standalone scene). The
-> checklist below references the historical sample names —
-> `gdk_launch_point` for the scenario shell and `multiplayer_pong`
-> for the rumble-on-event verification — and will be re-pointed at
-> the new samples once they land. Until then, GameInput hardware
-> testing falls back to the GUT host plus your own minimal Godot
-> project that calls `GameInput.initialize()` and exercises the
-> action bridge.
+> Recommended manual-test host: `sample/tutorial_gameinput/`. It ships as the
+> standalone GameInput sample and covers initialize / shutdown, device listing,
+> primary-device inspection, rumble pulse / stop, live device count, and
+> hot-plug event logging. If you prefer a minimal custom host, wire one up
+> with [Tutorial — GameInput action bridge](../tutorials/gameinput-action-bridge.md).
 
 ## Setup
 
@@ -25,9 +19,9 @@ that need a human + hardware in the loop.
     cmake --build build --preset debug
     ```
 
-2. Open the GameInput-using Godot project of your choice. Until the
-   samples land (PR 3), this means a project you wired up
-   following [Tutorial — GameInput action bridge](../tutorials/gameinput-action-bridge.md).
+2. Open `sample/tutorial_gameinput/` or another GameInput-using Godot project.
+   For a minimal custom host, wire one up by following
+   [Tutorial — GameInput action bridge](../tutorials/gameinput-action-bridge.md).
 
 ## Per-feature checklist
 
@@ -116,9 +110,8 @@ After any change to the GameInput addon C++:
   pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1 -Hosts @('tests\godot\gameinput')
   ```
   Expected output ends with `Overall: pass`.
-- [ ] Any GameInput-using Godot project (yours or, once PR 3 lands, the
-  tutorial samples) launches without `ERROR:` lines mentioning `gameinput`
-  in editor output.
+- [ ] Any GameInput-using Godot project (your own or `sample/tutorial_gameinput/`)
+  launches without `ERROR:` lines mentioning `gameinput` in editor output.
 - [ ] `GameInput` singleton appears in **Project → Project Settings →
   Globals** (or wherever Godot lists engine singletons in your version).
 

--- a/docs/gameinput/plugin.md
+++ b/docs/gameinput/plugin.md
@@ -2,7 +2,9 @@
 
 `godot_gameinput` is a standalone GDExtension addon that brings the Microsoft
 GameInput API to Godot 4.x on Windows. It works independently of the
-`godot_gdk` addon — you can ship one, both, or neither.
+`godot_gdk` addon — you can ship one, both, or neither. Target machines still
+need a compatible GameInput runtime/redist installed (for example
+`GameInputRedist.msi`).
 
 The addon gives GDScript first-class access to:
 
@@ -24,7 +26,7 @@ The addon gives GDScript first-class access to:
 | `GameInputDevice.get_device_info()` | Shipped (issue #23, device-info half) |
 | `GameInputBinding` / `GameInputActionMap` / `GameInputMapper` | Shipped |
 | `EditorPlugin` autoload installer + Project Settings | Shipped |
-| Sample integration (`sample/tutorial_app/` action-bridge scene + `sample/tutorial_gameinput/`) | Returning in PR 3 of the tutorial-driven sample revamp |
+| Sample integration (`sample/tutorial_gameinput/` standalone sample; `sample/tutorial_app/` panel deferred) | Standalone sample shipped; `tutorial_app` panel deferred |
 | Headless test suite | Shipped |
 | Manual hardware checklist ([docs/gameinput/manual-tests.md](manual-tests.md)) | Shipped |
 | Reading callbacks (event-driven) | Deferred — see issue list |
@@ -53,13 +55,13 @@ project's `addons/godot_gameinput/` by the build's sample-sync step.
 3. Project → Project Settings → Plugins → enable **Godot GameInput**.
 
 Enabling the plugin installs an autoload called `GameInputBootstrap` that
-reads two project settings and runs the lifecycle for you:
+reads project settings and runs the lifecycle for you:
 
 | Setting | Default | Behaviour |
 | --- | --- | --- |
 | `game_input/runtime/initialize_on_startup` | `false` | When `true`, the bootstrap calls `GameInput.initialize()` on `_ready`. |
 | `game_input/runtime/auto_poll` | `true` | When `true`, the bootstrap calls `GameInput.poll()` from `_process`. |
-| `game_input/mapper/default_action_map` | `""` | Path to a `.tres` `GameInputActionMap`. When set, the bootstrap spawns a `GameInputMapper` named `DefaultMapper` as its own child and assigns the loaded resource — so your project's `InputMap` can be driven from a GameInput action map without dropping a Mapper node into any scene. The same path is used as the fallback `action_map` for any user-placed `GameInputMapper` whose `action_map` property is null. |
+| `game_input/mapper/default_action_map` | `""` | Path to a `.tres` `GameInputActionMap`. When set, the bootstrap spawns a `GameInputMapper` named `DefaultMapper` as its own child and assigns the loaded resource — so your project's `InputMap` can be driven from a GameInput action map without dropping a Mapper node into any scene. User-placed `GameInputMapper` nodes do not consult this setting; assign their `action_map` explicitly. |
 
 Disabling the plugin removes the autoload — there is no orphaned state.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -288,10 +288,12 @@ per-player key (a `GDKUser` or a custom id).
 
 ### `godot_gameinput`
 
+Example override (the registered default for `runtime/initialize_on_startup` is `false`):
+
 ```ini
 [game_input]
 
-runtime/initialize_on_startup=true   ; bootstrap calls GameInput.initialize() at startup
+runtime/initialize_on_startup=true   ; example override: bootstrap calls GameInput.initialize() at startup
 runtime/auto_poll=true               ; bootstrap calls GameInput.poll() in _process (default)
 mapper/default_action_map=""         ; optional path to a GameInputActionMap .tres
 ```

--- a/spec/gdext-gameinput.md
+++ b/spec/gdext-gameinput.md
@@ -193,7 +193,7 @@ Raw API is still the right fit for low-level systems. The mapper exists so GDScr
 
 | Setting | Default | Purpose |
 | --- | --- | --- |
-| `game_input/mapper/default_action_map` | `""` | When set to a `GameInputActionMap` resource path (e.g. `res://input/actions.tres`), the bootstrap autoload spawns a `GameInputMapper` named `DefaultMapper` as its child and assigns the loaded resource to it. Lets a project drive its `InputMap` from a GameInput action map without adding any nodes to its scenes. Also serves as the fallback `action_map` for any user-placed `GameInputMapper` whose `action_map` property is null. |
+| `game_input/mapper/default_action_map` | `""` | When set to a `GameInputActionMap` resource path (e.g. `res://input/actions.tres`), the bootstrap autoload spawns a `GameInputMapper` named `DefaultMapper` as its child and assigns the loaded resource to it. Lets a project drive its `InputMap` from a GameInput action map without adding any nodes to its scenes. This applies only to the bootstrap-spawned `DefaultMapper`; a user-placed `GameInputMapper` whose `action_map` is null does **not** load this setting. |
 
 > **Note:** `game_input/runtime/embed_dispatch` was dropped — GameInput
 > dispatches callbacks on its own worker thread and we don't manually drive


### PR DESCRIPTION
## Summary

Documentation-only fixes for the **GameInput** addon, surfaced by an Adversarial Documentation Testing (ADT) run (Spec Writer → Blind Implementer → Adversarial Evaluator, per *Adversarial Documentation Testing at Scale*). The pipeline gave a blind implementer only the docs, then compared its assumptions against the registered C++ API.

**ADT result for GameInput:** SER ~1.0 (public symbol coverage is complete), but RA ≈ 0.45 — a blind implementer was misled by a doc-vs-runtime mismatch and several ambiguities. 7 actionable gaps (1 critical).

## Changes

- **(critical) Fix false `default_action_map` fallback claim.** Docs said `game_input/mapper/default_action_map` is a fallback for any user-placed `GameInputMapper` whose `action_map` is null. Source shows only the bootstrap-spawned `DefaultMapper` reads that setting. (`docs/gameinput/plugin.md`, `spec/gdext-gameinput.md`, `GameInputMapper.xml`)
- **Document the v1 gamepad-only reading path.** Runtime calls `GetCurrentReading(GameInputKindGamepad, ...)`; `KIND_KEYBOARD` / `KIND_MOUSE` are reserved but not yet usable mapper targets.
- **Tighten `supports_haptics()`** to the real rule: `GetHapticInfo()` success + `locationCount > 0`, distinct from rumble.
- **Add a GameInput runtime/redist prerequisite note** (standalone from `godot_gdk` does not remove the `GameInputRedist.msi` requirement).
- **Reconcile contradictory sample-status text** to the shipped `sample/tutorial_gameinput` standalone sample (`plugin.md`, `manual-tests.md`).
- **Mark the `initialize_on_startup=true` getting-started snippet as an example override** (the registered default is `false`).

## Corrected API usage (after this PR)

```gdscript
# A user-placed GameInputMapper must have its action_map assigned explicitly —
# game_input/mapper/default_action_map only feeds the bootstrap DefaultMapper.
var mapper := GameInputMapper.new()
mapper.action_map = load("res://input/actions.tres")
add_child(mapper)
```

## Validation

Docs-only (`.md` + `.xml`); no `.gd`/`.cpp`/`.h` touched, so the parse gate and test orchestrator are not applicable. All changed `doc_classes` XML validated well-formed. Claims were verified against `gameinput_singleton.cpp`, `gameinput_bootstrap.gd`, and the editor plugin before editing.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;
