### PR TITLE
docs(gdk): fix ADT-identified documentation gaps

### DIFF
--- a/addons/godot_gdk/doc_classes/GDK.xml
+++ b/addons/godot_gdk/doc_classes/GDK.xml
@@ -12,7 +12,7 @@
 			<return type="GDKResult" />
 			<param index="0" name="config" type="Variant" default="null" />
 			<description>
-				Initializes the GDK runtime. Optionally pass a configuration Variant. Returns a [GDKResult] indicating success or failure.
+				Initializes the GDK runtime. When [param config] is a [Dictionary], the Xbox services bootstrap accepts the first matching SCID override key in this order: [code]scid[/code], [code]service_configuration_id[/code], [code]xbox_live/scid[/code], then nested [code]xbox_live.scid[/code]. If no override is supplied, the addon derives the current-title SCID from [code]XGameGetXboxTitleId()[/code]. Calling this again while the runtime is already active returns [code]GDKResult.code == "already_initialized"[/code], so repeated startup paths should guard with [method is_initialized].
 			</description>
 		</method>
 		<method name="shutdown">
@@ -24,7 +24,7 @@
 		<method name="is_available" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the GDK runtime is available on the current platform.
+				Returns [code]true[/code] when this build was compiled with [code]_GAMING_DESKTOP[/code] support. Non-Gaming-Desktop builds return [code]false[/code].
 			</description>
 		</method>
 		<method name="is_initialized" qualifiers="const">

--- a/addons/godot_gdk/doc_classes/GDKGameUI.xml
+++ b/addons/godot_gdk/doc_classes/GDKGameUI.xml
@@ -18,7 +18,7 @@
 			<param index="5" name="default_button" type="String" default="&quot;first&quot;" />
 			<param index="6" name="cancel_button" type="String" default="&quot;first&quot;" />
 			<description>
-				Shows a system message dialog. Await the returned completion [Signal] directly; on success, [code]GDKResult.data[/code] contains [code]selected_button[/code] and [code]selected_button_index[/code].
+				Shows a system message dialog. [param default_button] and [param cancel_button] accept [code]first[/code]/[code]0[/code], [code]second[/code]/[code]1[/code], or [code]third[/code]/[code]2[/code]. Validation failures return [code]invalid_title[/code], [code]invalid_message[/code], [code]invalid_button_label[/code], [code]invalid_default_button[/code], [code]invalid_cancel_button[/code], or [code]invalid_button_layout[/code]. Await the returned completion [Signal] directly; on success, [code]GDKResult.data[/code] contains [code]selected_button[/code] and [code]selected_button_index[/code].
 			</description>
 		</method>
 		<method name="set_notification_position_hint">

--- a/addons/godot_gdk/doc_classes/GDKMultiplayerActivity.xml
+++ b/addons/godot_gdk/doc_classes/GDKMultiplayerActivity.xml
@@ -51,7 +51,7 @@
 			<param index="2" name="allow_cross_platform_join" type="bool" default="true" />
 			<param index="3" name="connection_string" type="String" default="&quot;&quot;" />
 			<description>
-				Sends multiplayer invites to the specified users.
+				Sends multiplayer invites to the specified users. When [param connection_string] is empty, the service reuses the cached local activity connection string set by [method set_activity_async]. If neither path yields a non-empty value, the completion fails with [code]GDKResult.code == "missing_connection_string"[/code].
 			</description>
 		</method>
 		<method name="show_invite_ui_async">

--- a/addons/godot_gdk/doc_classes/GDKPackage.xml
+++ b/addons/godot_gdk/doc_classes/GDKPackage.xml
@@ -4,7 +4,7 @@
 		Package and DLC content service accessed via GDK.package.
 	</brief_description>
 	<description>
-		Wraps the PC GDK [code]XPackage[/code] package metadata, install-progress, and content-mounting flows. Use [method enumerate_packages] and [method find_package_by_identifier] to discover content packages. Use [method load_resource_pack_async] for Godot-native DLC packaged as [code].pck[/code] or [code].zip[/code] files; on success the resource pack is loaded into [code]res://[/code] and the backing package mount is retained by the service until [method GDK.shutdown]. Use [method mount_package_async] only for loose package files that must be accessed by absolute paths through [FileAccess], [DirAccess], image loading, or similar Godot runtime APIs.
+		Wraps the PC GDK [code]XPackage[/code] package metadata, install-progress, and content-mounting flows. Use [method enumerate_packages] and [method find_package_by_identifier] to discover content packages; both return dictionaries with [code]package_identifier[/code], [code]store_id[/code], [code]display_name[/code], [code]description[/code], [code]publisher[/code], [code]title_id[/code], [code]installing[/code], [code]age_restricted[/code], [code]kind[/code], [code]kind_name[/code], [code]index[/code], and [code]count[/code]. Use [method load_resource_pack_async] for Godot-native DLC packaged as [code].pck[/code] or [code].zip[/code] files; on success the resource pack is loaded into [code]res://[/code] and the backing package mount is retained by the service until [method GDK.shutdown]. Use [method mount_package_async] only for loose package files that must be accessed by absolute paths through [FileAccess], [DirAccess], image loading, or similar Godot runtime APIs.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -14,7 +14,7 @@
 			<param index="0" name="package_kind" type="int" default="1" />
 			<param index="1" name="scope" type="int" default="1" />
 			<description>
-				Enumerates installed packages and returns them in [code]GDKResult.data[/code] as an [Array] of package [Dictionary] values. Package identifiers are current-session values and should not be persisted.
+				Enumerates installed packages and returns them in [code]GDKResult.data[/code] as an [Array] of package [Dictionary] values. Each dictionary includes [code]package_identifier[/code], [code]store_id[/code], [code]display_name[/code], [code]description[/code], [code]publisher[/code], [code]title_id[/code], [code]installing[/code], [code]age_restricted[/code], [code]kind[/code], [code]kind_name[/code], [code]index[/code], and [code]count[/code]. Package identifiers are current-session values and should not be persisted.
 			</description>
 		</method>
 		<method name="find_package_by_identifier">
@@ -23,7 +23,7 @@
 			<param index="1" name="package_kind" type="int" default="1" />
 			<param index="2" name="scope" type="int" default="1" />
 			<description>
-				Finds one installed package by package identifier. Returns [code]package_not_found[/code] when no package matches.
+				Finds one installed package by package identifier. On success, [code]GDKResult.data[/code] is one package dictionary with the same keys returned by [method enumerate_packages]. Returns [code]package_not_found[/code] when no package matches.
 			</description>
 		</method>
 		<method name="get_current_process_package_identifier">
@@ -46,7 +46,7 @@
 			<param index="2" name="replace_files" type="bool" default="false" />
 			<param index="3" name="offset" type="int" default="0" />
 			<description>
-				Mounts a content package, resolves a package-relative [code].pck[/code] or [code].zip[/code] file, and calls [method ProjectSettings.load_resource_pack]. Await the returned completion [Signal] to receive a [GDKResult]. On success, [code]GDKResult.data[/code] is a [Dictionary] with [code]resource_pack[/code] ([GDKPackageResourcePack]) and [code]already_loaded[/code] ([bool]). The service retains the backing package mount until [method GDK.shutdown] because Godot exposes resource-pack loading but no matching unload API. If the runtime shuts down while the mount is pending, the completion resolves with [code]GDKResult.code == "cancelled"[/code].
+				Mounts a content package, resolves a package-relative [code].pck[/code] or [code].zip[/code] file, and calls [method ProjectSettings.load_resource_pack]. [param pack_relative_path] must stay inside the mounted package; empty paths, absolute paths, [code].[/code]/[code]..[/code] segments, and non-[code].pck[/code]/[code].zip[/code] extensions are rejected. A typical title-owned value is something like [code]content/dlc/episode1.pck[/code]. Await the returned completion [Signal] to receive a [GDKResult]. On success, [code]GDKResult.data[/code] is a [Dictionary] with [code]resource_pack[/code] ([GDKPackageResourcePack]) and [code]already_loaded[/code] ([bool]). The service retains the backing package mount until [method GDK.shutdown] because Godot exposes resource-pack loading but no matching unload API. If the runtime shuts down while the mount is pending, the completion resolves with [code]GDKResult.code == "cancelled"[/code].
 			</description>
 		</method>
 		<method name="get_loaded_resource_packs" qualifiers="const">

--- a/addons/godot_gdk/doc_classes/GDKPrivacy.xml
+++ b/addons/godot_gdk/doc_classes/GDKPrivacy.xml
@@ -4,7 +4,7 @@
 		Xbox Services privacy service accessed via GDK.privacy.
 	</brief_description>
 	<description>
-		Wraps Xbox Services privacy permission checks and avoid/mute list queries. Methods return one-shot completion [Signal] values that emit [GDKResult].
+		Wraps Xbox Services privacy permission checks and avoid/mute list queries. Methods return one-shot completion [Signal] values that emit [GDKResult]. Supported permission strings are [code]communicate_using_text[/code], [code]communicate_using_video[/code], [code]communicate_using_voice[/code], [code]view_target_profile[/code], [code]view_target_game_history[/code], [code]view_target_video_history[/code], [code]view_target_music_history[/code], [code]view_target_exercise_info[/code], [code]view_target_presence[/code], [code]view_target_video_status[/code], [code]view_target_music_status[/code], [code]play_multiplayer[/code], [code]view_target_user_created_content[/code], [code]broadcast_with_twitch[/code], [code]write_comment[/code], [code]share_item[/code], and [code]share_target_content_to_external_networks[/code]. Anonymous user types are [code]cross_network_user[/code] and [code]cross_network_friend[/code].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -15,7 +15,7 @@
 			<param index="1" name="permission" type="String" />
 			<param index="2" name="target_xuid" type="String" />
 			<description>
-				Checks whether [param user] has [param permission] with the target XUID. Await the returned completion [Signal] directly; on success, [member GDKResult.data] is a [Dictionary] describing the allowed state and deny reasons.
+				Checks whether [param user] has [param permission] with the target XUID. Await the returned completion [Signal] directly; on success, [member GDKResult.data] is a [Dictionary] with [code]allowed[/code], [code]target_xuid[/code], [code]target_user_type[/code], [code]permission[/code], and [code]reasons[/code]. Unknown permission strings fail with [code]GDKResult.code == "invalid_permission"[/code].
 			</description>
 		</method>
 		<method name="check_permission_for_anonymous_user_async">
@@ -24,7 +24,7 @@
 			<param index="1" name="permission" type="String" />
 			<param index="2" name="anonymous_user_type" type="String" />
 			<description>
-				Checks whether [param user] has [param permission] with an anonymous user type such as [code]cross_network_user[/code] or [code]cross_network_friend[/code].
+				Checks whether [param user] has [param permission] with an anonymous user type such as [code]cross_network_user[/code] or [code]cross_network_friend[/code]. Unknown permission strings fail with [code]invalid_permission[/code]; unknown anonymous user types fail with [code]invalid_anonymous_user_type[/code].
 			</description>
 		</method>
 		<method name="batch_check_permission_async">
@@ -33,7 +33,7 @@
 			<param index="1" name="permission" type="String" />
 			<param index="2" name="target_xuids" type="PackedStringArray" />
 			<description>
-				Checks one permission against multiple target XUIDs. On success, [member GDKResult.data] is an [Array] of result dictionaries.
+				Checks one permission against multiple target XUIDs. On success, [member GDKResult.data] is an [Array] of result dictionaries using the same [code]allowed[/code]/[code]reasons[/code] shape as [method check_permission_async]. Unknown permission strings fail with [code]invalid_permission[/code].
 			</description>
 		</method>
 		<method name="get_avoid_list_async">

--- a/addons/godot_gdk/doc_classes/GDKSocial.xml
+++ b/addons/godot_gdk/doc_classes/GDKSocial.xml
@@ -68,7 +68,7 @@
 			<param index="3" name="reason" type="String" default="&quot;&quot;" />
 			<param index="4" name="evidence_id" type="String" default="&quot;&quot;" />
 			<description>
-				Submits one Xbox Services reputation feedback item for [param target_xuid]. Await the returned completion [Signal] directly.
+				Submits one Xbox Services reputation feedback item for [param target_xuid]. Supported [param feedback_type] values are [code]fair_play_kills_teammates[/code], [code]fair_play_cheater[/code], [code]fair_play_tampering[/code], [code]fair_play_quitter[/code], [code]fair_play_kicked[/code], [code]communications_inappropriate_video[/code], [code]communications_abusive_voice[/code], [code]inappropriate_user_generated_content[/code], [code]positive_skilled_player[/code], [code]positive_helpful_player[/code], [code]positive_high_quality_user_generated_content[/code], [code]comms_phishing[/code], [code]comms_picture_message[/code], [code]comms_spam[/code], [code]comms_text_message[/code], [code]comms_voice_message[/code], [code]fair_play_console_ban_request[/code], [code]fair_play_idler[/code], [code]fair_play_user_ban_request[/code], [code]user_content_gamerpic[/code], [code]user_content_personal_info[/code], [code]fair_play_unsporting[/code], and [code]fair_play_leaderboard_cheater[/code]. Unknown feedback types fail with [code]invalid_feedback_type[/code]. Await the returned completion [Signal] directly.
 			</description>
 		</method>
 		<method name="submit_batch_reputation_feedback_async">
@@ -76,7 +76,7 @@
 			<param index="0" name="user" type="GDKUser" />
 			<param index="1" name="feedback_items" type="Array" />
 			<description>
-				Submits reputation feedback for multiple users. Each item is a [Dictionary] with [code]target_xuid[/code] and [code]feedback_type[/code], plus optional [code]reason[/code] and [code]evidence_id[/code].
+				Submits reputation feedback for multiple users. Each item is a [Dictionary] with [code]target_xuid[/code] and [code]feedback_type[/code], plus optional [code]reason[/code] and [code]evidence_id[/code]. Empty arrays fail with [code]invalid_feedback_items[/code]; non-dictionary items or dictionaries missing [code]target_xuid[/code]/[code]feedback_type[/code] fail with [code]invalid_feedback_item[/code]; unknown feedback types fail with [code]invalid_feedback_type[/code].
 			</description>
 		</method>
 	</methods>

--- a/addons/godot_gdk/doc_classes/GDKStoreLicenseStatus.xml
+++ b/addons/godot_gdk/doc_classes/GDKStoreLicenseStatus.xml
@@ -4,7 +4,7 @@
 		Typed wrapper for XStore license-acquire status.
 	</brief_description>
 	<description>
-		Represents one license status record returned by [method GDKStore.query_license_status_async] or [method GDKStore.refresh_entitlements_async].
+		Represents one license status record returned by [method GDKStore.query_license_status_async] or [method GDKStore.refresh_entitlements_async]. The addon copies [code]store_id[/code], [code]licensable_sku[/code], and the raw native [code]XStoreCanAcquireLicenseResult.status[/code] integer into this wrapper without remapping the status value.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -23,7 +23,7 @@
 		<method name="get_status" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the native XStore license status enum value as an integer.
+				Returns the raw [code]XStoreCanAcquireLicenseResult.status[/code] value as an integer.
 			</description>
 		</method>
 	</methods>
@@ -35,7 +35,7 @@
 			SKU value returned by XStore.
 		</member>
 		<member name="status" type="int" setter="" getter="get_status">
-			Native XStore license status enum value.
+			Raw [code]XStoreCanAcquireLicenseResult.status[/code] value.
 		</member>
 	</members>
 	<signals></signals>

--- a/addons/godot_gdk/doc_classes/GDKUsers.xml
+++ b/addons/godot_gdk/doc_classes/GDKUsers.xml
@@ -37,7 +37,7 @@
 			<param index="0" name="user" type="GDKUser" />
 			<param index="1" name="privilege" type="int" />
 			<description>
-				Checks whether the [param user] has the specified [param privilege]. Await the returned completion [Signal] directly; the emitted [GDKResult] data contains the privilege-check dictionary.
+				Checks whether the [param user] has the specified raw [param privilege] integer. The addon forwards that integer directly to the native [code]XUserCheckPrivilege()[/code] call and does not bind named privilege constants. Await the returned completion [Signal] directly; on success, [code]GDKResult.data[/code] contains [code]privilege[/code], [code]has_privilege[/code], [code]deny_reason[/code], [code]deny_reason_value[/code], and [code]needs_user_issue_resolution[/code].
 			</description>
 		</method>
 		<method name="resolve_privilege_with_ui_async">
@@ -45,7 +45,7 @@
 			<param index="0" name="user" type="GDKUser" />
 			<param index="1" name="privilege" type="int" />
 			<description>
-				Attempts to resolve the specified [param privilege] for the [param user] by showing system UI if needed. Await the returned completion [Signal] directly; the emitted [GDKResult] data contains the resolution payload.
+				Attempts to resolve the specified raw [param privilege] integer for the [param user] by showing system UI if needed. Await the returned completion [Signal] directly; on success, [code]GDKResult.data[/code] currently echoes [code]privilege[/code].
 			</description>
 		</method>
 		<method name="resolve_issue_with_ui_async">

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -17,9 +17,9 @@ accessed as namespaces under this root.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `initialize(config := null)` | `GDKResult` | Start the GDK runtime. `config` is optional and reserved for future use. |
+| `initialize(config := null)` | `GDKResult` | Start the GDK runtime. See [Initialization config](#initialization-config). Re-initializing returns `already_initialized`; guard repeated startup with `GDK.is_initialized()`. |
 | `shutdown()` | `void` | Clean up the runtime |
-| `is_available()` | `bool` | Whether the GDK runtime is available on this platform |
+| `is_available()` | `bool` | Whether this build was compiled with `_GAMING_DESKTOP` support |
 | `is_initialized()` | `bool` | Whether the runtime has been initialized |
 | `dispatch()` | `int` | Pump async completions and manager state manually when `gdk/runtime/embed_dispatch` is disabled or when deterministic control is needed |
 | `get_users()` | `GDKUsers` | Access the users service |
@@ -72,6 +72,37 @@ func _process(_delta):
     GDK.dispatch()
 ```
 
+### Initialization config
+
+When `config` is a `Dictionary`, the Xbox services bootstrap accepts the first
+matching SCID override it finds in this order:
+
+1. `config["scid"]`
+2. `config["service_configuration_id"]`
+3. `config["xbox_live/scid"]`
+4. `config["xbox_live"]["scid"]`
+
+If no override is supplied, the addon derives the default SCID from
+`XGameGetXboxTitleId()` as the current-title SCID. Calling `initialize()` again
+while the runtime is still active returns `GDKResult.code == "already_initialized"`,
+so repeated startup paths should guard with `GDK.is_initialized()`.
+
+```gdscript
+if not GDK.is_initialized():
+    var init_result: GDKResult = GDK.initialize({
+        "xbox_live": {
+            "scid": "00000000-0000-0000-0000-00001234ABCD"
+        }
+    })
+    if not init_result.ok:
+        push_error(init_result.code)
+```
+
+Before wiring service calls, gather your title-owned stat names, leaderboard
+identifiers, presence string IDs, Store IDs, DLC pack paths, sandbox IDs, and
+peer test-account XUIDs from the checklist in
+[Sample setup](sample-setup.md#title-owned-values-checklist).
+
 ## System service: `GDK.system`
 
 `GDK.system` is a `RefCounted` service object returned by `GDK.get_system()`.
@@ -122,6 +153,26 @@ if sandbox_result.ok:
 |--------|-------------|
 | `user_changed(user: GDKUser, change_kind: String)` | The single user lifecycle/state event. `change_kind` is `added`, `removed`, `signed_in_again`, `gamertag`, `gamer_picture`, or `privileges`; for `removed`, `user` identifies the removed user and is no longer present in `get_users()` |
 
+### Privilege payloads
+
+`check_privilege_async()` passes the raw integer you supply directly to
+`XUserCheckPrivilege()`, and `resolve_privilege_with_ui_async()` forwards it to
+`XUserResolvePrivilegeWithUiAsync()`. The addon does not bind named privilege
+constants.
+
+Successful `check_privilege_async()` payloads use these keys:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `privilege` | `int` | Echo of the requested privilege id |
+| `has_privilege` | `bool` | Whether the user currently has the privilege |
+| `deny_reason` | `String` | `none`, `purchase_required`, `restricted`, `banned`, or `unknown` |
+| `deny_reason_value` | `int` | Raw native `XUserPrivilegeDenyReason` integer |
+| `needs_user_issue_resolution` | `bool` | `true` when the check returned `user_issue_resolution_required` |
+
+Successful `resolve_privilege_with_ui_async()` payloads currently echo only
+`privilege`.
+
 ### Usage
 
 ```gdscript
@@ -148,6 +199,13 @@ func _on_user_changed(user: GDKUser, change_kind: String):
 | `show_player_profile_card_async(requesting_user, target_xuid)` | `Signal` | Show the profile card UI for a target XUID |
 | `show_player_picker_async(requesting_user, prompt, selectable_xuids, preselected_xuids, min_selection_count, max_selection_count)` | `Signal` | Show player picker UI; success data includes `selected_xuids` and `selection_count` |
 | `resolve_privilege_with_ui_async(user, privilege)` | `Signal` | Forward to users-service privilege remediation UI flow |
+
+### Validation
+
+`default_button` and `cancel_button` accept `first`/`0`, `second`/`1`, or
+`third`/`2`. Validation failures return `invalid_title`, `invalid_message`,
+`invalid_button_label`, `invalid_default_button`, `invalid_cancel_button`, or
+`invalid_button_layout`.
 
 ## `GDKUser`
 
@@ -289,6 +347,48 @@ Script-visible wrapper around a cached achievement.
 - `load_resource_pack_async()` is the Godot-native DLC path; mounts for loaded resource packs stay service-owned until `GDK.shutdown()`.
 - If shutdown cancels an in-flight package mount/resource-pack load, the completion signal resolves with `GDKResult.code == "cancelled"`.
 
+### Package dictionary keys
+
+`enumerate_packages()` and `find_package_by_identifier()` return dictionaries
+with these keys:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `package_identifier` | `String` | Runtime package identifier for follow-up mount/load calls |
+| `store_id` | `String` | Store product ID reported by the package metadata |
+| `display_name` | `String` | Package display name |
+| `description` | `String` | Package description |
+| `publisher` | `String` | Package publisher string |
+| `title_id` | `String` | Title ID string reported by the package metadata |
+| `installing` | `bool` | Whether the package is still installing |
+| `age_restricted` | `bool` | Whether the package is age restricted |
+| `kind` | `int` | Raw native package-kind value |
+| `kind_name` | `String` | `game` or `content` |
+| `index` | `int` | Package index within the current enumeration result |
+| `count` | `int` | Total package count reported for the enumeration result |
+
+### Resource-pack path example
+
+The package dictionary tells you which content package to mount. The
+`pack_relative_path` is still title-owned: it must point to a `.pck` or `.zip`
+inside that mounted package, and the runtime rejects empty paths, absolute
+paths, `.`/`..`, and other extensions.
+
+```gdscript
+var packages_result: GDKResult = GDK.package.enumerate_packages()
+if packages_result.ok and not packages_result.data.is_empty():
+    var package_info: Dictionary = packages_result.data[0]
+    var load_result: GDKResult = await GDK.package.load_resource_pack_async(
+            package_info["package_identifier"],
+            "content/dlc/episode1.pck")
+    if load_result.ok:
+        var pack_info: Dictionary = load_result.data
+        print(pack_info["resource_pack"].pack_path)
+```
+
+See [Sample setup](sample-setup.md#title-owned-values-checklist) for the
+title-owned values you need to supply for DLC/package flows.
+
 ## Stats service: `GDK.stats`
 
 `GDK.stats` is a `RefCounted` service object returned by `GDK.get_stats()`.
@@ -419,7 +519,9 @@ Supported permission strings are normalized case-insensitively and include
 `share_target_content_to_external_networks`.
 
 Anonymous user type values are `cross_network_user` and
-`cross_network_friend`.
+`cross_network_friend`. Invalid permission inputs return
+`GDKResult.code == "invalid_permission"`; invalid anonymous-user inputs return
+`GDKResult.code == "invalid_anonymous_user_type"`.
 
 ### Usage
 
@@ -526,11 +628,37 @@ and broadcast fields when Xbox Services reports them.
 | `submit_batch_reputation_feedback_async(user, feedback_items)` | `Signal` | Submit multiple reputation feedback items |
 
 Batch reputation feedback items are dictionaries with `target_xuid` and
-`feedback_type`, plus optional `reason` and `evidence_id`. Supported feedback
-types are the `XblReputationFeedbackType` names in snake_case, such as
-`fair_play_cheater`, `fair_play_quitter`, `communications_abusive_voice`,
-`comms_text_message`, `positive_skilled_player`, `positive_helpful_player`,
-and `user_content_gamerpic`.
+`feedback_type`, plus optional `reason` and `evidence_id`. Supported
+`feedback_type` values are:
+
+- `fair_play_kills_teammates`
+- `fair_play_cheater`
+- `fair_play_tampering`
+- `fair_play_quitter`
+- `fair_play_kicked`
+- `communications_inappropriate_video`
+- `communications_abusive_voice`
+- `inappropriate_user_generated_content`
+- `positive_skilled_player`
+- `positive_helpful_player`
+- `positive_high_quality_user_generated_content`
+- `comms_phishing`
+- `comms_picture_message`
+- `comms_spam`
+- `comms_text_message`
+- `comms_voice_message`
+- `fair_play_console_ban_request`
+- `fair_play_idler`
+- `fair_play_user_ban_request`
+- `user_content_gamerpic`
+- `user_content_personal_info`
+- `fair_play_unsporting`
+- `fair_play_leaderboard_cheater`
+
+Validation failures return `invalid_feedback_type` for unknown feedback types,
+`invalid_feedback_items` for empty batch arrays, `invalid_feedback_item` when a
+batch item is not a dictionary or is missing `target_xuid`/`feedback_type`, and
+`invalid_xuid` for malformed XUID strings.
 
 ### Signals
 
@@ -662,7 +790,11 @@ Typed wrapper around an `XStore` license-acquire result.
 |----------|------|-------------|
 | `store_id` | `String` | Store product ID used for the query |
 | `licensable_sku` | `String` | SKU value returned by `XStore` |
-| `status` | `int` | Native `XStore` license status enum value |
+| `status` | `int` | Raw `XStoreCanAcquireLicenseResult.status` value returned by `XStoreCanAcquireLicenseForStoreIdResult()` |
+
+The addon stores `status` unchanged from the native `XStoreCanAcquireLicenseResult`
+payload; interpret the integer with the matching GDK SDK enum/reference for
+your installed SDK version.
 
 ## Profile service: `GDK.profile`
 
@@ -868,14 +1000,38 @@ on callback events, your title owns privacy/compliance review for that metadata.
 
 Invite dictionaries match `GDK.activation` and include `raw_uri`, `activation_type`, `scheme`, `action`, and decoded query fields such as `sender_xuid`.
 
+### Invite sequencing
+
+`send_invites_async()` resolves its connection string in this order:
+
+1. Use the explicit `connection_string` argument when it is non-empty.
+2. Otherwise reuse the cached local activity connection string set by
+   `set_activity_async()`.
+3. If neither path yields a non-empty value, the call fails with
+   `GDKResult.code == "missing_connection_string"`.
+
 ### Usage
 
 ```gdscript
 var mpa = GDK.multiplayer_activity
 
-# Set your activity
-await mpa.set_activity_async(user, "myserver://connect?session=abc",
-        "followed", 4, 1)
+# Set your activity first so empty-string invites can reuse the cached
+# connection string for this local user.
+var set_result: GDKResult = await mpa.set_activity_async(
+        user,
+        "myserver://connect?session=abc",
+        "followed",
+        4,
+        1)
+if set_result.ok:
+    await mpa.send_invites_async(user, PackedStringArray([other_xuid]))
+
+# You can also pass an explicit connection string without caching one first.
+await mpa.send_invites_async(
+        user,
+        PackedStringArray([other_xuid]),
+        true,
+        "myserver://connect?session=override")
 
 # Fetch another player's activity
 var result = await mpa.get_activities_async(user, [other_xuid])

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -123,7 +123,7 @@ Godot loads the native library through:
 
 - `addons\godot_gdk\godot_gdk.gdextension`
 
-That file maps platform/config combinations to the built DLL path inside `addons\godot_gdk\bin\`.
+That file maps platform/config combinations to the built DLL path inside `addons\godot_gdk\bin\`. At runtime, `GDK.is_available()` simply reflects whether this build was compiled with `_GAMING_DESKTOP`; non-Gaming-Desktop builds return `false`.
 
 ## Editor loading path
 

--- a/docs/gdk/sample-setup.md
+++ b/docs/gdk/sample-setup.md
@@ -34,6 +34,29 @@ runtime autoload installed and registers the `Xbox GDK (PC)` export platform.
 | Sandbox ID | Xbox Live Setup | `XDKS.1` |
 | Publisher CN | Product identity page | `CN=XXXXXXXX-XXXX-...` |
 
+## Title-owned values checklist
+
+Keep these title-specific values in one place before wiring the sample or your
+own game code:
+
+- **Stats and leaderboard identifiers:** the exact stat names your title writes
+  with `GDK.stats`, plus any leaderboard/stat relationships your gameplay uses.
+- **Rich presence values:** the state/string IDs and token values your title
+  configured for `GDK.presence` or multiplayer activity surfaces.
+- **Store product IDs:** the product IDs you pass to `GDK.store` queries and
+  purchase UI flows.
+- **DLC package layout:** each content package's expected `pack_relative_path`
+  to the `.pck`/`.zip` you load with `GDK.package.load_resource_pack_async()`.
+  The runtime-discovered `package_identifier` comes from
+  `enumerate_packages()`/`find_package_by_identifier()`, but the pack-relative
+  path is title-owned.
+- **Sandbox + test accounts:** the active sandbox ID, the test accounts
+  provisioned into that sandbox, and the PC sandbox currently selected on the
+  development machine.
+- **Peer-XUID prerequisites:** additional signed-in test accounts/XUIDs for
+  invites, recent-player updates, profile-card UI, reputation feedback, and any
+  other peer-targeted Xbox service flow.
+
 ## Option A: Configure via CLI (recommended)
 
 From the repository root, build the mirrored sample addons and run the setup

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -350,7 +350,7 @@ func _on_social_group_updated(group: GDKSocialGroup) -> void:
 #### Root API
 
 ```gdscript
-GDK.initialize(config: GDKConfig = null) -> GDKResult
+GDK.initialize(config: Variant = null) -> GDKResult
 GDK.shutdown() -> void
 GDK.is_available() -> bool
 GDK.is_initialized() -> bool
@@ -401,7 +401,9 @@ and `GDK.achievements.runtime_error`).
 
 #### Runtime behavior
 
-- `initialize()` sets up the GDK runtime and the shared `XTaskQueue`.
+- `initialize()` sets up the GDK runtime and the shared `XTaskQueue`. When `config` is a `Dictionary`, Xbox services accepts the first SCID override found at `scid`, `service_configuration_id`, `xbox_live/scid`, or nested `xbox_live.scid`; otherwise it derives the current-title SCID from `XGameGetXboxTitleId()`.
+- Calling `initialize()` again without `shutdown()` returns `GDKResult.code == "already_initialized"`, so startup helpers should guard with `GDK.is_initialized()`.
+- `is_available()` reflects the compile-time `_GAMING_DESKTOP` gate exposed by `GDKRuntime::is_available()`.
 - `dispatch()` manually dispatches pending completions when automatic dispatch is disabled or when deterministic control is needed.
 - `gdk/runtime/embed_dispatch` defaults to `true` and enables automatic per-frame dispatch from the main thread.
 


### PR DESCRIPTION
## Summary

Documentation-only fixes for the **GDK** addon, surfaced by an Adversarial Documentation Testing (ADT) run (Spec Writer → Blind Implementer → Adversarial Evaluator). A blind implementer built against docs only; its assumptions were compared to the registered C++ API (`_bind_methods`).

**ADT result for GDK:** SER ≈ 1.0 (near-complete API reference) but RA ≈ 0.47 — a blind implementer had to guess prerequisites, payload shapes, and error contracts. 12 actionable gaps (1 critical).

## Changes

- **(critical) Fix the `GDK.initialize(config)` contradiction.** Docs said the parameter was "reserved for future use"; the runtime actually accepts SCID override keys (`scid`, `service_configuration_id`, `xbox_live/scid`, `xbox_live.scid`) and otherwise derives the SCID from `XGameGetXboxTitleId()`. (`GDK.xml`, `api-reference.md`, `spec/gdext-gdk.md`)
- **Document `already_initialized`** re-init result; recommend guarding with `is_initialized()`.
- **Tie `is_available()` to the compile-time `_GAMING_DESKTOP` gate.**
- **Add a "title-owned values" checklist** (stats, leaderboards, presence ids, Store product ids, DLC `pack_relative_path`, sandbox/test accounts, peer XUIDs) to `sample-setup.md`, linked from `api-reference.md`.
- **Document `send_invites_async()` sequencing** and the `missing_connection_string` failure.
- **Document the package dictionary keys** and `load_resource_pack_async()` path usage.
- **Document privilege result keys, dialog selector inputs + validation errors, privacy/social vocabularies + failure codes, and the raw Store license-status value.**

Several gap-report claims that did not match source (a numeric privilege table, a `none` dialog selector, an `allowed` privilege key) were corrected to the real source behavior (`has_privilege`, etc.) rather than documented as-reported.

## Corrected API usage (after this PR)

```gdscript
# config is consumed today — pass a cross-title SCID override.
var result: GDKResult = GDK.initialize({ "scid": "00000000-0000-0000-0000-0000694f4f4f" })
if result.code == "already_initialized":
    pass # guard repeated startup with GDK.is_initialized()
```

## Validation

Docs-only (`.md` + `.xml`); no `.cpp`/`.h`/`.gd` touched, so the parse gate and test orchestrator are not applicable. All changed `doc_classes` XML validated well-formed. Every claim verified against `addons/godot_gdk/src` before editing.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;
