### PR TITLE
fix(gameinput): fence in-flight device callbacks before DLL unload (closes #41)

### DIFF
--- a/addons/godot_gameinput/src/gameinput_singleton.cpp
+++ b/addons/godot_gameinput/src/gameinput_singleton.cpp
@@ -151,7 +151,7 @@ void CALLBACK GameInput::_on_device_callback(
         GameInputDeviceStatus current_status,
         GameInputDeviceStatus previous_status) {
     auto *self = static_cast<GameInput *>(context);
-    if (!self || !device || !self->m_accepting_callbacks.load(std::memory_order_acquire)) {
+    if (!self || !device) {
         return;
     }
 
@@ -160,7 +160,8 @@ void CALLBACK GameInput::_on_device_callback(
     // releasing IGameInput / freeing the singleton. v3's UnregisterCallback
     // does NOT fence pending callbacks the way v1's timeout parameter did.
     self->m_callbacks_in_flight.fetch_add(1, std::memory_order_acquire);
-    if (self->m_shutting_down.load(std::memory_order_acquire)) {
+    if (!self->m_accepting_callbacks.load(std::memory_order_acquire) ||
+            self->m_shutting_down.load(std::memory_order_acquire)) {
         self->m_callbacks_in_flight.fetch_sub(1, std::memory_order_release);
         return;
     }

--- a/addons/godot_gameinput/src/gameinput_singleton.cpp
+++ b/addons/godot_gameinput/src/gameinput_singleton.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <thread>
 #include <type_traits>
 
 namespace godot {
@@ -154,27 +155,40 @@ void CALLBACK GameInput::_on_device_callback(
         return;
     }
 
+    // Hold an in-flight reference for the duration of this callback so
+    // shutdown() can wait until we're out of the singleton's data before
+    // releasing IGameInput / freeing the singleton. v3's UnregisterCallback
+    // does NOT fence pending callbacks the way v1's timeout parameter did.
+    self->m_callbacks_in_flight.fetch_add(1, std::memory_order_acquire);
+    if (self->m_shutting_down.load(std::memory_order_acquire)) {
+        self->m_callbacks_in_flight.fetch_sub(1, std::memory_order_release);
+        return;
+    }
+
     bool was_connected = (previous_status & GameInputDeviceConnected) != 0;
     bool is_connected  = (current_status  & GameInputDeviceConnected) != 0;
 
     if (is_connected == was_connected) {
+        self->m_callbacks_in_flight.fetch_sub(1, std::memory_order_release);
         return;
     }
 
     PendingDeviceEvent ev;
     ev.kind = is_connected ? PendingEventKind::Connected : PendingEventKind::Disconnected;
     ev.native_device = device;
-    // AddRef so the pointer is valid until the main thread processes it.
     device->AddRef();
 
     {
         std::lock_guard<std::mutex> lock(self->m_event_mutex);
         if (!self->m_accepting_callbacks.load(std::memory_order_acquire)) {
             device->Release();
+            self->m_callbacks_in_flight.fetch_sub(1, std::memory_order_release);
             return;
         }
         self->m_pending_events.push_back(ev);
     }
+
+    self->m_callbacks_in_flight.fetch_sub(1, std::memory_order_release);
 }
 
 void GameInput::_release_pending_events_locked() {
@@ -346,14 +360,27 @@ void GameInput::shutdown() {
 
     m_accepting_callbacks.store(false, std::memory_order_release);
 
+    // 1. Signal "no new work" so any callback that observes this bails
+    //    before touching singleton state.
+    m_shutting_down.store(true, std::memory_order_release);
+
+    // 2. Unregister. GameInput v3 dropped the timeout parameter that v1
+    //    accepted here and does not fence in-flight callbacks; the fence is
+    //    enforced below by m_callbacks_in_flight.
     if (m_game_input && m_device_callback_token) {
-        // UnregisterCallback blocks until in-flight callbacks finish; StopCallback does not.
         bool unregistered = m_game_input->UnregisterCallback(m_device_callback_token);
         if (!unregistered) {
             UtilityFunctions::push_warning(
                 "GameInput: UnregisterCallback() failed; late callbacks will be ignored.");
         }
         m_device_callback_token = 0;
+    }
+
+    // 3. Wait for any callback currently inside the body to exit. After
+    //    UnregisterCallback returns, no NEW callbacks will start, so this
+    //    spin is bounded by the longest in-flight body.
+    while (m_callbacks_in_flight.load(std::memory_order_acquire) != 0) {
+        std::this_thread::yield();
     }
 
     // Stop rumble + release every device cleanly.
@@ -380,6 +407,7 @@ void GameInput::shutdown() {
 
     m_initialized = false;
     m_last_polled_frame = UINT64_MAX;
+    m_shutting_down.store(false, std::memory_order_release);
     UtilityFunctions::print("GameInput: shutdown");
 }
 

--- a/addons/godot_gameinput/src/gameinput_singleton.h
+++ b/addons/godot_gameinput/src/gameinput_singleton.h
@@ -70,6 +70,8 @@ private:
     bool m_warned_uninitialized = false;
     bool m_warned_create_failed = false;
 
+    std::atomic<bool> m_shutting_down{false};
+    std::atomic<int32_t> m_callbacks_in_flight{0};
     std::atomic<int64_t> m_next_device_id{1};
     uint64_t m_last_polled_frame = UINT64_MAX;
 

--- a/addons/godot_gameinput/src/register_types.cpp
+++ b/addons/godot_gameinput/src/register_types.cpp
@@ -71,6 +71,7 @@ void uninitialize_godot_gameinput_extension(ModuleInitializationLevel p_level) {
     Engine::get_singleton()->unregister_singleton("GameInput");
 
     if (gameinput_singleton) {
+        gameinput_singleton->shutdown();
         memdelete(gameinput_singleton);
         gameinput_singleton = nullptr;
     }


### PR DESCRIPTION
Fixes the deterministic 0xC0000005 crash on godot --headless --path sample\tutorial_gameinput --import from a clean .godot cache, reported in #41.

## Root cause

GameInput v3 IGameInput::UnregisterCallback does not fence pending callbacks (v1's timeout parameter was removed in v3 - see gameinput_singleton.cpp:275). shutdown() was unregistering, then immediately releasing devices and m_game_input. The addon DLL would then unload during DEINITIALIZATION_SCENE while a worker-thread callback was still executing _on_device_callback - faulting on the next dereference of the singleton or its mutex.

## Fix

Adds an in-flight callback fence:
- m_shutting_down + m_callbacks_in_flight (atomics) on the singleton
- _on_device_callback bumps the counter, bails if shutdown observed
- shutdown() sets the flag, UnregisterCallback, then spin-waits for in-flight callbacks before releasing IGameInput
- register_types.cpp calls shutdown() explicitly before memdelete

## Validation

- cmake --build build --preset debug - clean build
- tools\run_all_tests.ps1 -Hosts tests\godot\gameinput - GUT host green (53 tests, 46 passing, 7 pending)
- Parse gate green

The original crash repro requires the specific dev box environment from the issue (clean .godot cache + sample import); could not reproduce locally. The fix is a defensive correctness change based on the v3 UnregisterCallback semantics documented in the inline comment at gameinput_singleton.cpp:275.

Closes #41
