### PR TITLE
test(gdk-package): gate enumeration-dependent block on packaged-app identity (closes #43)

### DIFF
--- a/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
+++ b/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
@@ -322,6 +322,26 @@ func pending_unless_live_write() -> bool:
 
 
 
+# Pending the current test unless package enumeration is available on this
+# host (i.e. the test process is running inside a registered MSIX / packaged
+# app identity). On a loose / unpackaged dev host, XPackageEnumeratePackages
+# fails legitimately and the more-specific downstream error codes
+# (package_not_found) cannot be reached. Returns true when the test was
+# marked pending — caller should `return` immediately after.
+func pending_unless_package_enumeration_available(package_service: Object) -> bool:
+	if package_service == null:
+		pending("GDK.package service unavailable")
+		return true
+	var result = package_service.enumerate_packages()
+	if result == null or not result.ok:
+		var msg := "null result"
+		if result != null:
+			msg = str(result.message)
+		pending("Package enumeration unavailable (running as loose/unpackaged app): %s" % msg)
+		return true
+	return false
+
+
 # Returns "<prefix>-<unique_run_id>" so live write tests can derive
 # correlated, run-stable ids from one shared run id.
 func with_unique_id(prefix: String) -> String:

--- a/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
+++ b/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
@@ -322,22 +322,28 @@ func pending_unless_live_write() -> bool:
 
 
 
-# Pending the current test unless package enumeration is available on this
-# host (i.e. the test process is running inside a registered MSIX / packaged
-# app identity). On a loose / unpackaged dev host, XPackageEnumeratePackages
-# fails legitimately and the more-specific downstream error codes
-# (package_not_found) cannot be reached. Returns true when the test was
-# marked pending — caller should `return` immediately after.
+# Pending the current test unless the host is running with a packaged-app
+# identity. On a loose / unpackaged dev host (no MSIX identity registered),
+# XPackageEnumeratePackages legitimately fails, get_current_process_package_identifier()
+# returns `package_identifier_unavailable`, and the more-specific downstream
+# error codes (package_not_found) cannot be reached.
+#
+# We probe via `get_current_process_package_identifier()` rather than
+# `enumerate_packages()` so that genuine enumeration regressions on packaged
+# hosts continue to surface as test failures instead of being silently
+# converted to PENDING. Any non-identifier-unavailable failure mode (null
+# result, transient enumeration error, etc.) is intentionally left to the
+# caller to assert against and fail loudly.
+#
+# Returns true when the test was marked pending — caller should `return`
+# immediately after.
 func pending_unless_package_enumeration_available(package_service: Object) -> bool:
 	if package_service == null:
 		pending("GDK.package service unavailable")
 		return true
-	var result = package_service.enumerate_packages()
-	if result == null or not result.ok:
-		var msg := "null result"
-		if result != null:
-			msg = str(result.message)
-		pending("Package enumeration unavailable (running as loose/unpackaged app): %s" % msg)
+	var identifier_result = package_service.get_current_process_package_identifier()
+	if identifier_result != null and not identifier_result.ok and str(identifier_result.code) == "package_identifier_unavailable":
+		pending("Skipped: running as loose/unpackaged app (no packaged identity)")
 		return true
 	return false
 

--- a/tests/godot/gdk/tests/test_package.gd
+++ b/tests/godot/gdk/tests/test_package.gd
@@ -144,6 +144,12 @@ func test_package_runtime_metadata_and_missing_packages() -> void:
 	if pending_unless_package_enumeration_available(package_service):
 		return
 	var packages_result = package_service.enumerate_packages()
+	assert_not_null(packages_result, "enumerate_packages() returns GDKResult on packaged host")
+	if packages_result == null:
+		return
+	assert_true(packages_result.ok, "enumerate_packages() succeeds on packaged host: %s" % str(packages_result.message))
+	if not packages_result.ok:
+		return
 	assert_true(packages_result.data is Array, "enumerate_packages() returns Array payload")
 
 	const MISSING_ID := "gdk.tests.missing.id"

--- a/tests/godot/gdk/tests/test_package.gd
+++ b/tests/godot/gdk/tests/test_package.gd
@@ -112,10 +112,6 @@ func test_package_runtime_metadata_and_missing_packages() -> void:
 		pending("Package service runtime behavior: %s" % init_result.message)
 		return
 
-	var packages_result = package_service.enumerate_packages()
-	assert_result_ok(packages_result, "enumerate_packages()")
-	if packages_result != null and packages_result.ok:
-		assert_true(packages_result.data is Array, "enumerate_packages() returns Array payload")
 	assert_result_error(
 		package_service.enumerate_packages(99, get_class_constant("GDKPackage", "ENUMERATION_SCOPE_THIS_AND_RELATED")),
 		"invalid_package_kind",
@@ -144,6 +140,11 @@ func test_package_runtime_metadata_and_missing_packages() -> void:
 		load_result,
 		"invalid_package_identifier",
 		"load_resource_pack_async() rejects blank identifiers")
+
+	if pending_unless_package_enumeration_available(package_service):
+		return
+	var packages_result = package_service.enumerate_packages()
+	assert_true(packages_result.data is Array, "enumerate_packages() returns Array payload")
 
 	const MISSING_ID := "gdk.tests.missing.id"
 	assert_result_error(


### PR DESCRIPTION
Fixes #43 - test_package.gd failed 5 asserts on every loose / unpackaged dev box because it required XPackageEnumeratePackages to succeed before checking downstream missing-id error codes.

## Root cause

The C++ contract is correct: on a loose host, XPackageEnumeratePackages legitimately fails (no MSIX identity), the helper returns package_enumeration_failed, and downstream lookups all propagate that upstream failure rather than reaching the package_not_found branch. The runtime cannot tell "missing package id" from "no package identity available", so the test was asserting a state it could not reach.

## Fix

- Adds pending_unless_package_enumeration_available(package_service) to gdk_test_base.gd alongside the existing pending_unless_live() helper.
- Uses it in test_package.gd to gate the enumeration-dependent block.
- Leaves the argument-validation asserts unconditional - they don't depend on enumeration succeeding.
- C++ contract is unchanged.

## Validation

- Parse gate green
- cmake --build build --preset debug - clean build
- tools\run_all_tests.ps1 -Hosts tests\godot\gdk - test_package block reports PENDING on this unpackaged box; arg-validation asserts continue to run

Closes #43
