### PR TITLE
fix(gdk-mp-activity): null-user check precedes xbox-services check (closes #42)

### DIFF
--- a/addons/godot_gdk/src/gdk_multiplayer_activity.cpp
+++ b/addons/godot_gdk/src/gdk_multiplayer_activity.cpp
@@ -1061,19 +1061,23 @@ Ref<GDKResult> GDKMultiplayerActivity::duplicate_context_for_user_internal(
         return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
     }
 
+    // Null-user check runs BEFORE the xbox-services check so callers get the
+    // more specific "invalid_user" code on a bare dev box where the runtime
+    // initialized but no Xbox Live user is signed in. Matches the ordering
+    // used by gdk_presence.cpp set_presence_async (runtime -> user -> services).
+    if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+        return GDKResult::error_result(
+                E_INVALIDARG,
+                "invalid_user",
+                "A signed-in GDKUser is required for multiplayer activity.");
+    }
+
     GDKXboxServices *xbox_services = get_xbox_services_internal();
     if (xbox_services == nullptr || !xbox_services->is_initialized()) {
         return GDKResult::error_result(
                 E_FAIL,
                 "xbox_services_not_initialized",
                 "Xbox services are unavailable. Ensure the title has a TitleId before using multiplayer activity.");
-    }
-
-    if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
-        return GDKResult::error_result(
-                E_INVALIDARG,
-                "invalid_user",
-                "A signed-in GDKUser is required for multiplayer activity.");
     }
 
     HRESULT hr = xbox_services->duplicate_context_for_user(p_user, r_context, r_xbox_user_id);


### PR DESCRIPTION
Fixes #42 - on a bare dev box where GDK.initialize() succeeded but no Xbox Live user is signed in, GDK.multiplayer_activity.get_activities_async / update_recent_players / flush_recent_players_async returned xbox_services_not_initialized for null-user calls instead of the more specific invalid_user.

## Root cause

duplicate_context_for_user_internal() in gdk_multiplayer_activity.cpp checked the guards in order: runtime -> xbox_services -> user. The xbox_services guard fired first on a bare box, masking the null-user condition. The canonical ordering used by sibling services like gdk_presence.cpp set_presence_async is runtime -> user -> xbox_services.

## Fix

Three-line reorder of the guards in the shared helper. All three affected APIs (get_activities_async, update_recent_players, flush_recent_players_async) delegate to this one helper.

## Why not re-tier the test instead

The assertion is contract-tier input validation. tests/godot/README.md explicitly forbids contract-tier tests depending on live state. Hiding the assertion behind pending_unless_live() would mask the real input-validation bug on every bare dev box.

## Validation

- cmake --build build --preset debug - clean build
- tools\run_all_tests.ps1 -Hosts tests\godot\gdk - GDK host green; null-user asserts in test_multiplayer_activity.gd now return invalid_user
- Parse gate green

Closes #42