### PR TITLE
test(tiers): implement requires_live/_write helpers + -AllowLiveWrites switch (closes #45)

### DIFF
--- a/addons/godot_gdk/tests_support/bases/gameinput_test_base.gd
+++ b/addons/godot_gdk/tests_support/bases/gameinput_test_base.gd
@@ -56,18 +56,29 @@ func assert_has_signal_named(obj: Object, signal_name: String, test_name: String
 
 # ── TestEnv convenience wrappers ─────────────────────────────────────────
 
+# Tier=live_read. Returns true when LIVE_TESTS=1 is set (the test should
+# proceed). Returns false when not set (and marks the current test pending
+# with a clear reason — caller should `return` immediately after).
 func requires_live() -> bool:
-	if TestEnv.live_tests_enabled():
-		return true
-	pending("Skipped without LIVE_TESTS=1")
-	return false
+	if not TestEnv.live_tests_enabled():
+		pending("Tier=live_read: skipped without LIVE_TESTS=1. Run via `tools\\run_all_tests.ps1 -Live`.")
+		return false
+	return true
 
 
+# Tier=live_write. Returns true when both LIVE_TESTS=1 and LIVE_WRITE_TESTS=1
+# are set. Tests that write state persisting in the live PlayFab title
+# (create lobby, post leaderboard entry, save Game Save, …) MUST gate on
+# this rather than on requires_live(), so they only run when the developer
+# has explicitly opted into the live-write tier against a sandbox title.
 func requires_live_write() -> bool:
-	if TestEnv.live_write_tests_enabled():
-		return true
-	pending("Skipped without LIVE_TESTS=1 and LIVE_WRITE_TESTS=1")
-	return false
+	if not TestEnv.live_tests_enabled():
+		pending("Tier=live_write: skipped without LIVE_TESTS=1.")
+		return false
+	if not TestEnv.live_write_tests_enabled():
+		pending("Tier=live_write: skipped without LIVE_WRITE_TESTS=1. Run via `tools\\run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId <sandbox-title>` against a sandbox title.")
+		return false
+	return true
 
 
 func pending_unless_live() -> bool:

--- a/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
+++ b/addons/godot_gdk/tests_support/bases/gdk_test_base.gd
@@ -292,20 +292,29 @@ func disconnect_signal_handlers(obj: Object, signal_names: Array) -> void:
 
 # ── TestEnv convenience wrappers ─────────────────────────────────────────
 
-# Returns true when LIVE_TESTS=1 is set; otherwise marks the current test pending.
+# Tier=live_read. Returns true when LIVE_TESTS=1 is set (the test should
+# proceed). Returns false when not set (and marks the current test pending
+# with a clear reason — caller should `return` immediately after).
 func requires_live() -> bool:
-	if TestEnv.live_tests_enabled():
-		return true
-	pending("Skipped without LIVE_TESTS=1")
-	return false
+	if not TestEnv.live_tests_enabled():
+		pending("Tier=live_read: skipped without LIVE_TESTS=1. Run via `tools\\run_all_tests.ps1 -Live`.")
+		return false
+	return true
 
 
-# Returns true when both LIVE_TESTS=1 and LIVE_WRITE_TESTS=1 are set.
+# Tier=live_write. Returns true when both LIVE_TESTS=1 and LIVE_WRITE_TESTS=1
+# are set. Tests that write state persisting in the live PlayFab title
+# (create lobby, post leaderboard entry, save Game Save, …) MUST gate on
+# this rather than on requires_live(), so they only run when the developer
+# has explicitly opted into the live-write tier against a sandbox title.
 func requires_live_write() -> bool:
-	if TestEnv.live_write_tests_enabled():
-		return true
-	pending("Skipped without LIVE_TESTS=1 and LIVE_WRITE_TESTS=1")
-	return false
+	if not TestEnv.live_tests_enabled():
+		pending("Tier=live_write: skipped without LIVE_TESTS=1.")
+		return false
+	if not TestEnv.live_write_tests_enabled():
+		pending("Tier=live_write: skipped without LIVE_WRITE_TESTS=1. Run via `tools\\run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId <sandbox-title>` against a sandbox title.")
+		return false
+	return true
 
 
 # Pending the current test unless LIVE_TESTS=1 is set. Returns true when

--- a/addons/godot_gdk/tests_support/bases/test_env.gd
+++ b/addons/godot_gdk/tests_support/bases/test_env.gd
@@ -27,10 +27,15 @@ static func live_tests_enabled() -> bool:
 	return OS.get_environment(LIVE_TESTS_ENV) == "1"
 
 
-# True if LIVE_WRITE_TESTS=1 in the process environment. Use in addition to
-# LIVE_TESTS for tests that create or mutate persistent live-service state.
+# True if LIVE_TESTS=1 AND LIVE_WRITE_TESTS=1 are both set. Tests gated by
+# this must run against a dedicated sandbox PlayFab title (never against
+# a shared title id and never against production). The orchestrator
+# enforces -AllowLiveWrites implies -Live and prints the active sandbox
+# title id when both are set.
 static func live_write_tests_enabled() -> bool:
-	return live_tests_enabled() and OS.get_environment(LIVE_WRITE_TESTS_ENV) == "1"
+	if not live_tests_enabled():
+		return false
+	return OS.get_environment(LIVE_WRITE_TESTS_ENV) == "1"
 
 
 # Generate a unique-per-run id of the form `gdkfleet-YYYYMMDDHHmmss-XXXX`.

--- a/tests/godot/README.md
+++ b/tests/godot/README.md
@@ -8,8 +8,6 @@ This directory contains the Godot test hosts (one per addon) that the repo-root 
 
 Each host has its addon mirrored in by CMake when you run `cmake --build build --preset debug`. The shared test bases live at `addons\godot_gdk\tests_support\bases\` and are mirrored into each host as `addons\godot_gdk_tests\`.
 
-> **Status:** the test-tier contract is documented and in active rollout. The Party single-leave regression suite already uses `requires_live_write()`; the helpers (`requires_live()` / `requires_live_write()`) are available on every test base, and `tools\run_all_tests.ps1 -Live -AllowLiveWrites` forwards both `LIVE_TESTS=1` and `LIVE_WRITE_TESTS=1` to Godot children. Older live-write suites that still call `pending_unless_live()` are being migrated to `requires_live_write()` so the orchestrator's `-AllowLiveWrites` gate covers every mutating suite.
-
 The repo-root orchestrator now owns both GUT hosts and the PlayFab Multiplayer multi-process orchestrator. Use `tools\run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId <sandbox> -PlayFabMatchmakingQueue <queue>` for the full live MP sweep.
 
 ## Test Tiers
@@ -42,7 +40,7 @@ func before_all() -> void:
 
 ### `live_write`
 
-- Requires both `LIVE_TESTS=1` and `LIVE_WRITE_TESTS=1`. Opt in via `tools\run_all_tests.ps1 -Live -AllowLiveWrites`.
+- Requires both `LIVE_TESTS=1` and `LIVE_WRITE_TESTS=1`. Opt in via `tools\run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId <sandbox-title>`.
 - Writes state that persists in the live PlayFab title (create lobby, post leaderboard entry, save Game Save, …).
 - **Must run against a dedicated sandbox PlayFab title.** Never run against a shared title id and never against a production title id. The orchestrator prints the active title id when `-AllowLiveWrites` is set so it cannot be missed in a CI log.
 - Declares the tier by calling `requires_live_write()` at the top of `before_all` / `before_each`. When either flag is missing, the helper marks the test pending.
@@ -64,16 +62,16 @@ func before_each() -> void:
 | ------------------------------------------------ | :----------: | :----------------: | :------------------------------------------------------------- |
 | `run_all_tests.ps1`                              |      —       |         —          | `contract` runs. `live_read` and `live_write` mark pending.    |
 | `run_all_tests.ps1 -Live`                        |    `1`       |         —          | `contract` and `live_read` run. `live_write` marks pending.    |
-| `run_all_tests.ps1 -Live -AllowLiveWrites`       |    `1`       |       `1`          | All three tiers run. Banner prints the active title id.        |
+| `run_all_tests.ps1 -Live -AllowLiveWrites -PlayFabTitleId <sandbox-title>` |    `1`       |       `1`          | All three tiers run. Banner prints the active sandbox title id. |
 
-`-AllowLiveWrites` without `-Live` is invalid — the orchestrator refuses it.
+`-AllowLiveWrites` without `-Live`, or without `-PlayFabTitleId <sandbox-title>`, is invalid — the orchestrator refuses it.
 
 ## Authoring a New Test
 
 1. Pick the tier honestly. Default to `contract`; promote to `live_read` only if the test cannot be meaningfully asserted offline; promote to `live_write` only if persistent state mutation is the point.
 2. Place the test under `tests\godot\<addon>\tests\` as `test_<scenario>.gd`.
 3. `extends` the matching base — `gdk_test_base.gd` / `playfab_test_base.gd` / `gameinput_test_base.gd`.
-4. For `live_read` and `live_write` tests, call the matching helper at the top of `before_all` (or `before_each` for per-test gating) and return when it reports the test pending. The GDK and PlayFab bases expose `requires_live()` / `requires_live_write()` (and the equivalent `pending_unless_live()` / `pending_unless_live_write()` aliases for legacy callers); the GameInput base currently exposes only `pending_unless_live()` / `pending_unless_live_write()` — use those there.
+4. For `live_read` and `live_write` tests, call `requires_live()` / `requires_live_write()` at the top of `before_all` (or `before_each` for per-test gating) and return when it reports the test pending. The bases also expose `pending_unless_live()` / `pending_unless_live_write()` aliases for legacy callers.
 5. Run the orchestrator at least once offline (`tools\run_all_tests.ps1`) to confirm the new test marks pending instead of failing when live access is missing.
 
 ## PlayFab Multiplayer Orchestrator

--- a/tests/godot/playfab/tests/test_leaderboards_live.gd
+++ b/tests/godot/playfab/tests/test_leaderboards_live.gd
@@ -2,10 +2,9 @@ extends "res://addons/godot_gdk_tests/playfab_test_base.gd"
 ## Wave 4 — Live PlayFab Leaderboards contract with eventual-consistency
 ## settling.
 ##
-## Read-only checks (`get_leaderboard_async`, `get_leaderboard_around_user_async`,
-## `get_friend_leaderboard_async`) are gated by `pending_unless_live()` +
-## `pending_unless_playfab_available()`. The submit + read-back round-trip is
-## live-only because it mutates a backing leaderboard.
+## All checks in this file are gated by `requires_live_write()` +
+## `pending_unless_playfab_available()` because the submit + read-back
+## round-trip mutates a backing leaderboard in the configured PlayFab title.
 ##
 ## Eventual consistency: PlayFab leaderboards do not always reflect a freshly
 ## submitted score on the next read. We use `TestEnv.poll_until` with the
@@ -29,7 +28,7 @@ func _begin_live_session() -> Dictionary:
 		"playfab": null,
 	}
 
-	if pending_unless_live():
+	if not requires_live_write():
 		return outcome
 	if pending_unless_playfab_available():
 		return outcome

--- a/tools/run_all_tests.ps1
+++ b/tools/run_all_tests.ps1
@@ -32,10 +32,10 @@
     -AllowLiveWrites is also specified.
 
 .PARAMETER AllowLiveWrites
-    Requires -Live and sets LIVE_WRITE_TESTS=1 in the child env for live tests
-    that create lobbies, write leaderboards, save Game Saves, or otherwise
-    mutate the configured sandbox title. Prints the active PlayFab title id so
-    live writes are visibly scoped to an explicit sandbox title.
+    Requires -Live and -PlayFabTitleId. Sets LIVE_WRITE_TESTS=1 in the child
+    env for live tests that create lobbies, write leaderboards, save Game Saves,
+    or otherwise mutate the configured sandbox title. Prints the active PlayFab
+    title id so live writes are visibly scoped to an explicit sandbox title.
 
 .PARAMETER SkipBuild
     Skips the CMake build stage. The doctest exe and the GUT mirrored copies
@@ -62,6 +62,7 @@
 .PARAMETER PlayFabTitleId
     Optional PlayFab title id forwarded to Godot children as PLAYFAB_TITLE_ID.
     The PlayFab test base applies it to ProjectSettings['playfab/runtime/title_id'].
+    Required when -AllowLiveWrites is set; must identify a dedicated sandbox title.
 
 .PARAMETER PlayFabCustomId
     Optional pre-existing PlayFab custom id forwarded to Godot children as
@@ -76,6 +77,10 @@
 
 .PARAMETER VerboseOutput
     Streams child stdout/stderr to the host console as it arrives.
+
+.NOTES
+    -AllowLiveWrites is a sandbox-only live-write tier. It is refused unless
+    -Live and -PlayFabTitleId are both set.
 
 .OUTPUTS
     Writes <OutDir>\run-summary.json and <OutDir>\run-summary.md.
@@ -907,16 +912,16 @@ function Write-RunSummary {
 
 function Main {
     if ($AllowLiveWrites -and -not $Live) {
-        throw '-AllowLiveWrites requires -Live so LIVE_TESTS=1 and LIVE_WRITE_TESTS=1 travel together.'
+        throw "-AllowLiveWrites requires -Live. Aborting before any test starts."
+    }
+    if ($AllowLiveWrites -and [string]::IsNullOrWhiteSpace($PlayFabTitleId)) {
+        throw "-AllowLiveWrites requires -PlayFabTitleId <sandbox title id>. Refusing to run write-tier tests against an unspecified title."
     }
 
     $startedAt = (Get-Date).ToUniversalTime()
     $godotExe  = Get-GodotExecutable
     $godotVer  = Get-GodotVersion -GodotExe $godotExe
 
-    # Resolve the effective sandbox title id once so -AllowLiveWrites can
-    # require it (otherwise the safety banner could print "<unset>" if the
-    # title id is configured only inside a Godot ProjectSettings).
     $effectivePlayFabTitleId = if (-not [string]::IsNullOrWhiteSpace($PlayFabTitleId)) {
         $PlayFabTitleId.Trim()
     } elseif (-not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('PLAYFAB_TITLE_ID'))) {
@@ -924,17 +929,11 @@ function Main {
     } else {
         ''
     }
-    if ($AllowLiveWrites -and [string]::IsNullOrWhiteSpace($effectivePlayFabTitleId)) {
-        throw '-AllowLiveWrites requires -PlayFabTitleId or PLAYFAB_TITLE_ID so the sandbox title is explicit; refusing to write live state to an unknown title.'
-    }
 
     $childEnv = @{}
     if ($Live) { $childEnv['LIVE_TESTS'] = '1' }
     if ($AllowLiveWrites) { $childEnv['LIVE_WRITE_TESTS'] = '1' }
     if (-not [string]::IsNullOrWhiteSpace($effectivePlayFabTitleId)) {
-        # Propagate the resolved title id so the child env matches the
-        # banner regardless of whether it came from -PlayFabTitleId or the
-        # parent environment.
         $childEnv['PLAYFAB_TITLE_ID'] = $effectivePlayFabTitleId
     }
     if (-not [string]::IsNullOrWhiteSpace($PlayFabCustomId)) {
@@ -956,22 +955,18 @@ function Main {
         Join-Path $script:RepoRoot $OutDir
     }
 
-    $effectivePlayFabTitleId = if (-not [string]::IsNullOrWhiteSpace($PlayFabTitleId)) { $PlayFabTitleId.Trim() } else { ([Environment]::GetEnvironmentVariable('PLAYFAB_TITLE_ID') ?? '').Trim() }
-    if ($AllowLiveWrites -and [string]::IsNullOrWhiteSpace($effectivePlayFabTitleId)) {
-        throw '-AllowLiveWrites requires -PlayFabTitleId or PLAYFAB_TITLE_ID so the sandbox title is explicit.'
-    }
     Write-Host "run_all_tests.ps1: Godot = $godotExe ($godotVer)" -ForegroundColor Cyan
     Write-Host "                   Live  = $Live   AllowLiveWrites = $AllowLiveWrites   SkipBuild = $SkipBuild" -ForegroundColor Cyan
     Write-Host "                   PlayFabTitleId = $(if (-not [string]::IsNullOrWhiteSpace($effectivePlayFabTitleId)) { $effectivePlayFabTitleId } else { 'unset' })   PlayFabCustomId = $(if ($childEnv.ContainsKey('PLAYFAB_CUSTOM_ID') -or -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('PLAYFAB_CUSTOM_ID'))) { 'set' } else { 'unset' })   PlayFabMatchmakingQueue = $(if ($childEnv.ContainsKey('PLAYFAB_MULTIPLAYER_MATCH_QUEUE') -or -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('PLAYFAB_MULTIPLAYER_MATCH_QUEUE'))) { 'set' } else { 'unset' })" -ForegroundColor Cyan
-    if ($AllowLiveWrites) {
-        Write-Host "                   LIVE WRITES ENABLED for sandbox title '$effectivePlayFabTitleId'" -ForegroundColor Yellow
-    }
     Write-Host "                   Hosts = $($hostList -join ', ')" -ForegroundColor Cyan
     Write-Host "                   ParseProjects = $(if ($parseProjectList.Count -gt 0) { $parseProjectList -join ', ' } else { 'all' })" -ForegroundColor Cyan
     Write-Host "                   ParseExcludeProjects = $(if ($parseExcludeProjectList.Count -gt 0) { $parseExcludeProjectList -join ', ' } else { 'none' })" -ForegroundColor Cyan
     Write-Host "                   OutDir= $outDirAbsolute" -ForegroundColor Cyan
     if ($AllowLiveWrites) {
-        Write-Host "                   LIVE WRITES ENABLED for sandbox title $liveWriteTitle" -ForegroundColor Yellow
+        Write-Host "" -ForegroundColor Yellow
+        Write-Host "[run_all_tests] === LIVE WRITE TIER ENABLED ===" -ForegroundColor Yellow
+        Write-Host "[run_all_tests] Active PlayFab title id: $effectivePlayFabTitleId" -ForegroundColor Yellow
+        Write-Host "[run_all_tests] This MUST be a dedicated sandbox title. Never run against a shared or production title id." -ForegroundColor Yellow
     }
     Write-Host ''
 


### PR DESCRIPTION
Implements the remaining test-tier contract called out by tests/godot/README.md and closes #45.

## What ships

- test_env.gd - tightens live_write_tests_enabled() documentation around the LIVE_TESTS + LIVE_WRITE_TESTS contract.
- gdk_test_base.gd / gameinput_test_base.gd - make requires_live() and requires_live_write() pending reasons explicit and point callers at the correct runner flags.
- tools\run_all_tests.ps1 - refuses -AllowLiveWrites without -Live or without -PlayFabTitleId, sets LIVE_WRITE_TESTS=1 only for the opt-in tier, and prints a sandbox-only banner with the active title id.
- test_leaderboards_live.gd - migrated from pending_unless_live() to requires_live_write().
- tests/godot/README.md - removes the active-rollout status banner and documents the required -PlayFabTitleId for live writes.

## What stays

Read-only *_live.gd tests stay on pending_unless_live() (semantically equivalent to requires_live()). Migrating them to the new name is a separate cosmetic pass.

## Validation

- Parse gate green
- cmake --build build --preset debug - clean build
- Bare run_all_tests.ps1 - contract tests run, both live tiers pend
- run_all_tests.ps1 -AllowLiveWrites - orchestrator throws before any test starts
- run_all_tests.ps1 -Live -AllowLiveWrites (no title id) - orchestrator throws
- Live-write run against a real sandbox title was NOT exercised here.

Closes #45
