### PR TITLE
docs: normalize brand naming (Microsoft GDK / XBOX / Godot XBOX)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Godot XBOX Documentation
 
-Welcome to the documentation for the Godot for XBOX on PC repository — a collection of
+Welcome to the documentation for the Godot XBOX repository — a collection of
 Godot 4.x GDExtension addons for Windows gaming integrations around the
 Microsoft public GDK.
 
@@ -119,9 +119,9 @@ docs/
 
 ## Platform setup
 
-- [**Xbox Sandbox and Test Accounts**](platform/xbox-sandbox-and-test-accounts.md)
+- [**XBOX Sandbox and Test Accounts**](platform/xbox-sandbox-and-test-accounts.md)
   — switching the PC into a Partner Center sandbox, signing in the
-  Xbox app with a test account, and the error-code lookup table
+  XBOX app with a test account, and the error-code lookup table
 
 ## Troubleshooting
 

--- a/docs/addon-getting-started.md
+++ b/docs/addon-getting-started.md
@@ -29,7 +29,7 @@ your Godot project's `addons/` directory.
 - [Microsoft GDK](https://github.com/microsoft/GDK/releases) installed
   on every machine that runs the game (`winget install
   Microsoft.Gaming.GDK`). The XBOX runtime DLLs the addons depend on
-  resolve from the GDK install.
+  resolve from the Microsoft GDK install.
 - A PlayFab title (you'll need its title id) for the `godot_playfab`
   addon.
 - A **Partner Center title** with XBOX Live configured, plus at least one
@@ -89,7 +89,7 @@ your Godot project's `addons/` directory.
    - **GodotPlayFab** — installs the `PlayFabBootstrap` autoload.
    - **Godot GameInput** *(optional)* — installs the
      `GameInputBootstrap` autoload.
-   - **GDK Packaging** — registers the **GDK** menu in the editor
+   - **Microsoft GDK Packaging** — registers the **Microsoft GDK** menu in the editor
      menu bar (game config, sandbox switcher, package manager,
      packaging).
 4. Restart the editor when prompted.
@@ -120,8 +120,8 @@ runtime/initialize_on_startup=true
 The endpoint is derived as `https://<titleid>.playfabapi.com` when
 `playfab/runtime/endpoint` is left blank.
 
-While you're in Project Settings, the equivalent GDK toggles are worth
-turning on too so the bootstrap brings the GDK runtime up automatically:
+While you're in Project Settings, the equivalent Microsoft GDK toggles are worth
+turning on too so the bootstrap brings the Microsoft GDK runtime up automatically:
 
 ```ini
 [gdk]
@@ -139,7 +139,7 @@ runtime/initialize_on_startup=true
 `MicrosoftGame.config` is required for XBOX-backed sign-in and for
 packaging. The `godot_gdk_packaging` addon ships a one-click action:
 
-1. From the editor menu bar, open **GDK — Create MicrosoftGame.config**
+1. From the editor menu bar, open **Microsoft GDK — Create MicrosoftGame.config**
    (the item is labeled **Edit MicrosoftGame.config** if a config
    already exists in the project).
 2. A template `MicrosoftGame.config` is written to the project root, and
@@ -166,7 +166,7 @@ the whole team uses the same identity and Partner Center mapping.
 Test accounts only authenticate against the sandbox they were created
 in. To point the PC at a development sandbox:
 
-1. Open **GDK — Change Sandbox…** from the editor menu bar.
+1. Open **Microsoft GDK — Change Sandbox…** from the editor menu bar.
 2. The dialog shows the current sandbox (e.g. `RETAIL`).
 3. Enter your target sandbox id (typically of the form `XDKS.1` or
    `studioname.1`) and click **Set Sandbox**, or click **Switch to
@@ -179,7 +179,7 @@ You can also do this from a terminal with
 
 ## 5. Sign in a user
 
-The recommended flow is **GDK first, PlayFab second**. PlayFab needs an
+The recommended flow is **Microsoft GDK first, PlayFab second**. PlayFab needs an
 authenticated XBOX user as input.
 
 Sign-in is **not** driven from `GDK.users.user_changed` — that signal
@@ -251,7 +251,7 @@ UI path.
 
 Once a primary XBOX user exists, hand it to PlayFab. There is no
 PlayFab equivalent of "silent vs UI" — `sign_in_with_xuser_async`
-authenticates the GDK user directly, no extra prompts.
+authenticates the Microsoft GDK user directly, no extra prompts.
 
 ```gdscript
 func _ensure_playfab_user(XBOX_user: GDKUser) -> PlayFabUser:
@@ -312,11 +312,11 @@ snippets above tells you which step failed.
 | Symptom | Likely cause | Fix |
 |--|--|--|
 | `GDExtension dynamic library not found` | The `bin/` folder didn't make it into the project copy. | Copy `addons/<addon>/` recursively, including `bin/`. |
-| `GDK singleton not registered` | Native DLL failed to load (wrong arch, missing GDK install, missing `libHttpClient.dll`). | Install the Microsoft GDK on the machine that runs the game. |
+| `GDK singleton not registered` | Native DLL failed to load (wrong arch, missing Microsoft GDK install, missing `libHttpClient.dll`). | Install the Microsoft GDK on the machine that runs the game. |
 | Silent sign-in returns `no_default_user` | No test account signed into the XBOX app on the PC, or PC sandbox doesn't match Partner Center. | Sign in a test account via the XBOX app after switching to the right sandbox (step 4). The fallback `add_user_with_ui_async()` will surface the picker. |
-| XBOX Live calls fail with a registration error | `MicrosoftGame.config` is missing, malformed, or has placeholder Title Id / SCID. | Re-run **GDK — Edit MicrosoftGame.config** and fill in real Partner Center values. |
+| XBOX Live calls fail with a registration error | `MicrosoftGame.config` is missing, malformed, or has placeholder Title Id / SCID. | Re-run **Microsoft GDK — Edit MicrosoftGame.config** and fill in real Partner Center values. |
 | `PlayFab.initialize()` fails immediately | `playfab/runtime/title_id` is empty. | Set it in Project Settings (step 2). |
-| `sign_in_with_xuser_async` returns `invalid_xuser` | Passing a null or signed-out GDK user. | Confirm `XBOX_user != null and XBOX_user.signed_in` first. |
+| `sign_in_with_xuser_async` returns `invalid_xuser` | Passing a null or signed-out Microsoft GDK user. | Confirm `XBOX_user != null and XBOX_user.signed_in` first. |
 
 ## Where to go from here
 
@@ -327,8 +327,8 @@ snippets above tells you which step failed.
   a lobby, and bridging a controller through GameInput.
 - Full API reference for `GDK.users`, `GDK.achievements`,
   `GDK.leaderboards`, etc. ships in the editor — press **F1** on any
-  GDK class name.
-- The `godot_gdk_packaging` addon also provides **GDK — Package
+  Microsoft GDK class name.
+- The `godot_gdk_packaging` addon also provides **Microsoft GDK — Package
   Manager…** (list / install / uninstall registered packages) and
   **Project — Export…** integration for building MSIXVC or loose
   packages.

--- a/docs/async-patterns.md
+++ b/docs/async-patterns.md
@@ -7,7 +7,7 @@ relevant) `godot_gameinput`, so once you know it for one method you
 know it for all of them.
 
 This page is the one-page intro the tutorials assume. For the deeper
-implementation view of the GDK side specifically (native runtime
+implementation view of the Microsoft GDK side specifically (native runtime
 queue, `XAsyncBlock` bridge, `XTaskQueueHandle`), see
 [`gdk/async-system.md`](gdk/async-system.md).
 
@@ -15,7 +15,7 @@ queue, `XAsyncBlock` bridge, `XTaskQueueHandle`), see
 
 A method whose name ends in `_async` returns a Godot
 [`Signal`](https://docs.godotengine.org/en/stable/classes/class_signal.html)
-that fires **exactly once** when the underlying GDK / PlayFab /
+that fires **exactly once** when the underlying Microsoft GDK / PlayFab /
 GameInput operation completes:
 
 | Addon           | Example                                                 |
@@ -135,7 +135,7 @@ There are two distinct error surfaces. Tutorials lean on both:
        push_warning("[Ach] subsystem error: %s" % result.message)
    ```
 
-Service-level runtime signals exist on most GDK services that have
+Service-level runtime signals exist on most Microsoft GDK services that have
 their own native callback path (`GDK.achievements`, `GDK.social`,
 `GDK.presence`, `GDK.multiplayer_activity`, …) and on the major
 PlayFab services that wrap a background callback queue
@@ -183,9 +183,9 @@ In normal app code you should never need to call `dispatch()`.
 ## See also
 
 - [`gdk/async-system.md`](gdk/async-system.md) — the deep view of the
-  GDK side (native runtime, `XAsyncBlock` bridge, `XTaskQueueHandle`
+  Microsoft GDK side (native runtime, `XAsyncBlock` bridge, `XTaskQueueHandle`
   ownership, per-service `runtime_error` semantics).
-- [`gdk/api-reference.md`](gdk/api-reference.md) — the full GDK
+- [`gdk/api-reference.md`](gdk/api-reference.md) — the full Microsoft GDK
   surface, organized by service. Every `_async` method is listed
   with its return signal and `Result.data` shape.
 - [`playfab/plugin.md`](playfab/plugin.md) — the PlayFab side,

--- a/docs/gameinput/manual-tests.md
+++ b/docs/gameinput/manual-tests.md
@@ -37,7 +37,7 @@ that need a human + hardware in the loop.
 
 ### Device discovery (one controller)
 
-Plug in any GameInput-compatible gamepad (Xbox Series, Xbox One, Elite,
+Plug in any GameInput-compatible gamepad (XBOX Series, XBOX One, Elite,
 Razer Wolverine, etc.) **before** initializing.
 
 - [ ] After **Initialize GameInput**, state panel reports `Devices: 1`.

--- a/docs/gameinput/plugin.md
+++ b/docs/gameinput/plugin.md
@@ -193,7 +193,7 @@ are the recommended entry points.
 
 `godot_gameinput` is exercised by the `tests\godot\gameinput\` host. Coverage lives under `tests\godot\gameinput\tests\` and includes files such as `test_gameinput_core.gd`, `test_gameinput_device.gd`, `test_gameinput_reading.gd`, `test_gameinput_resource.gd`, `test_gameinput_mapper.gd`, `test_gameinput_mapper_extensions.gd`, and `test_gameinput_threading_smoke.gd`. Bootstrap autoload checks live under `tests\godot\gameinput\tests\bootstrap\`.
 
-GameInput headless tests are deterministic by default and do not require live Xbox or PlayFab credentials. Hardware-specific behavior such as real controllers, rumble feel, and hot-plug should still be checked with [`gameinput/manual-tests.md`](manual-tests.md).
+GameInput headless tests are deterministic by default and do not require live XBOX or PlayFab credentials. Hardware-specific behavior such as real controllers, rumble feel, and hot-plug should still be checked with [`gameinput/manual-tests.md`](manual-tests.md).
 
 Run the standard pipeline from the repository root:
 

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -36,7 +36,7 @@ accessed as namespaces under this root.
 | `get_profile()` | `GDKProfile` | Access the XBOX Services profile service |
 | `get_string_verify()` | `GDKStringVerify` | Access the XBOX Services string verification service |
 | `get_title_storage()` | `GDKTitleStorage` | Access the XBOX Services Title Storage service |
-| `get_error_reporting()` | `GDKErrorReporting` | Access the PC Microsoft GDK `XError` callback/options service |
+| `get_error_reporting()` | `GDKErrorReporting` | Access the Microsoft GDK `XError` callback/options service |
 | `get_launcher()` | `GDKLauncher` | Access the launcher service for URI/store/settings flows |
 | `get_multiplayer_activity()` | `GDKMultiplayerActivity` | Access the multiplayer activity service |
 | `get_capture()` | `GDKCapture` | Access the capture metadata and capture-state service |
@@ -941,7 +941,7 @@ additional pages.
 `GDK.error_reporting` is a `RefCounted` service object returned by
 `GDK.get_error_reporting()`.
 
-This service wraps the public PC Microsoft GDK `XError` callback/options APIs
+This service wraps the public Microsoft GDK `XError` callback/options APIs
 (`XErrorSetCallback`, `XErrorSetOptions`). It does not submit reports to
 external endpoints.
 
@@ -1076,11 +1076,11 @@ Script-visible wrapper around a cached multiplayer activity snapshot.
 | `take_diagnostic_screenshot_async(path_hint: String)` | `Signal` | Take a diagnostic screenshot and return a deferred completion signal. Requires Game Bar. |
 | `create_metadata(reserved_bytes := 0)` | `GDKCaptureMetaData` | Create a script-side metadata write context, or `null` if the runtime is not initialized. `reserved_bytes` is retained for compatibility and ignored. |
 
-### PC Microsoft GDK availability
+### Microsoft GDK availability
 
 All wrapped APIs are available in `_GAMING_DESKTOP` builds via `XAppCapture.h` / `xgameruntime.lib`.
 
-| Native function | PC Microsoft GDK |
+| Native function | Microsoft GDK |
 |---|---|
 | `XAppCaptureEnableRecord` | YES |
 | `XAppCaptureDisableRecord` | YES |
@@ -1163,7 +1163,7 @@ It wraps PC-supported `XLaunchUri` flows.
 ### Manual smoke coverage
 
 Launcher success paths depend on host OS URI handlers and package context and are
-not deterministic for CI. Use a manual smoke pass on a PC Microsoft GDK machine:
+not deterministic for CI. Use a manual smoke pass on a Microsoft GDK machine:
 
 ```gdscript
 var result = GDK.launcher.launch_uri("ms-settings:privacy-microphone")
@@ -1185,7 +1185,7 @@ Normalized result payload returned by all async operations.
 ## Display service: `GDK.display`
 
 `GDK.display` is a `RefCounted` service object returned by `GDK.get_display()`. It
-wraps the PC Microsoft GDK `XDisplay.h` family: HDR mode probe/enable and idle display
+wraps the Microsoft GDK `XDisplay.h` family: HDR mode probe/enable and idle display
 timeout deferrals.
 
 ### Methods

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -1,4 +1,4 @@
-# Godot GDK API reference
+# Godot Microsoft GDK API reference
 
 This document describes the current public GDScript API surface of the
 `godot_gdk` addon. It is built from the actual bound methods and signals in
@@ -17,7 +17,7 @@ accessed as namespaces under this root.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `initialize(config := null)` | `GDKResult` | Start the GDK runtime. See [Initialization config](#initialization-config). Re-initializing returns `already_initialized`; guard repeated startup with `GDK.is_initialized()`. |
+| `initialize(config := null)` | `GDKResult` | Start the Microsoft GDK runtime. See [Initialization config](#initialization-config). Re-initializing returns `already_initialized`; guard repeated startup with `GDK.is_initialized()`. |
 | `shutdown()` | `void` | Clean up the runtime |
 | `is_available()` | `bool` | Whether this build was compiled with `_GAMING_DESKTOP` support |
 | `is_initialized()` | `bool` | Whether the runtime has been initialized |
@@ -36,7 +36,7 @@ accessed as namespaces under this root.
 | `get_profile()` | `GDKProfile` | Access the XBOX Services profile service |
 | `get_string_verify()` | `GDKStringVerify` | Access the XBOX Services string verification service |
 | `get_title_storage()` | `GDKTitleStorage` | Access the XBOX Services Title Storage service |
-| `get_error_reporting()` | `GDKErrorReporting` | Access the PC GDK `XError` callback/options service |
+| `get_error_reporting()` | `GDKErrorReporting` | Access the PC Microsoft GDK `XError` callback/options service |
 | `get_launcher()` | `GDKLauncher` | Access the launcher service for URI/store/settings flows |
 | `get_multiplayer_activity()` | `GDKMultiplayerActivity` | Access the multiplayer activity service |
 | `get_capture()` | `GDKCapture` | Access the capture metadata and capture-state service |
@@ -793,7 +793,7 @@ Typed wrapper around an `XStore` license-acquire result.
 | `status` | `int` | Raw `XStoreCanAcquireLicenseResult.status` value returned by `XStoreCanAcquireLicenseForStoreIdResult()` |
 
 The addon stores `status` unchanged from the native `XStoreCanAcquireLicenseResult`
-payload; interpret the integer with the matching GDK SDK enum/reference for
+payload; interpret the integer with the matching Microsoft GDK SDK enum/reference for
 your installed SDK version.
 
 ## Profile service: `GDK.profile`
@@ -875,7 +875,7 @@ if result.ok and not result.data.acceptable:
 
 `GDK.title_storage` is a `RefCounted` service object returned by
 `GDK.get_title_storage()`. This wraps XBOX Services Title Storage from
-`title_storage_c.h`; it is unrelated to PlayFab Game Saves or GDK
+`title_storage_c.h`; it is unrelated to PlayFab Game Saves or Microsoft GDK
 `XGameSaveFiles`.
 
 ### Methods
@@ -941,7 +941,7 @@ additional pages.
 `GDK.error_reporting` is a `RefCounted` service object returned by
 `GDK.get_error_reporting()`.
 
-This service wraps the public PC GDK `XError` callback/options APIs
+This service wraps the public PC Microsoft GDK `XError` callback/options APIs
 (`XErrorSetCallback`, `XErrorSetOptions`). It does not submit reports to
 external endpoints.
 
@@ -1076,11 +1076,11 @@ Script-visible wrapper around a cached multiplayer activity snapshot.
 | `take_diagnostic_screenshot_async(path_hint: String)` | `Signal` | Take a diagnostic screenshot and return a deferred completion signal. Requires Game Bar. |
 | `create_metadata(reserved_bytes := 0)` | `GDKCaptureMetaData` | Create a script-side metadata write context, or `null` if the runtime is not initialized. `reserved_bytes` is retained for compatibility and ignored. |
 
-### PC GDK availability
+### PC Microsoft GDK availability
 
 All wrapped APIs are available in `_GAMING_DESKTOP` builds via `XAppCapture.h` / `xgameruntime.lib`.
 
-| Native function | PC GDK |
+| Native function | PC Microsoft GDK |
 |---|---|
 | `XAppCaptureEnableRecord` | YES |
 | `XAppCaptureDisableRecord` | YES |
@@ -1163,7 +1163,7 @@ It wraps PC-supported `XLaunchUri` flows.
 ### Manual smoke coverage
 
 Launcher success paths depend on host OS URI handlers and package context and are
-not deterministic for CI. Use a manual smoke pass on a PC GDK machine:
+not deterministic for CI. Use a manual smoke pass on a PC Microsoft GDK machine:
 
 ```gdscript
 var result = GDK.launcher.launch_uri("ms-settings:privacy-microphone")
@@ -1185,7 +1185,7 @@ Normalized result payload returned by all async operations.
 ## Display service: `GDK.display`
 
 `GDK.display` is a `RefCounted` service object returned by `GDK.get_display()`. It
-wraps the PC GDK `XDisplay.h` family: HDR mode probe/enable and idle display
+wraps the PC Microsoft GDK `XDisplay.h` family: HDR mode probe/enable and idle display
 timeout deferrals.
 
 ### Methods

--- a/docs/gdk/async-system.md
+++ b/docs/gdk/async-system.md
@@ -1,12 +1,12 @@
-# Godot GDK async system
+# Godot Microsoft GDK async system
 
-This document explains how the `godot_gdk` async system works today: the shared runtime, the generic async wrappers, the internal `XAsync` bridge, the shared Xbox services scaffold, and the current concrete services built on top of it (`GDK.users`, `GDK.system`, `GDK.game_ui`, `GDK.accessibility`, `GDK.achievements`, `GDK.package`, `GDK.stats`, `GDK.leaderboards`, `GDK.privacy`, `GDK.presence`, `GDK.social`, `GDK.profile`, `GDK.string_verify`, `GDK.title_storage`, `GDK.error_reporting`, `GDK.activation`, `GDK.multiplayer_activity`, `GDK.capture`, `GDK.launcher`, and `GDK.store`).
+This document explains how the `godot_gdk` async system works today: the shared runtime, the generic async wrappers, the internal `XAsync` bridge, the shared XBOX services scaffold, and the current concrete services built on top of it (`GDK.users`, `GDK.system`, `GDK.game_ui`, `GDK.accessibility`, `GDK.achievements`, `GDK.package`, `GDK.stats`, `GDK.leaderboards`, `GDK.privacy`, `GDK.presence`, `GDK.social`, `GDK.profile`, `GDK.string_verify`, `GDK.title_storage`, `GDK.error_reporting`, `GDK.activation`, `GDK.multiplayer_activity`, `GDK.capture`, `GDK.launcher`, and `GDK.store`).
 
 For the plugin-wide view, including build, editor tooling, sample integration, and current scope boundaries, see [`gdk/plugin.md`](plugin.md).
 
 ## Why this exists
 
-GDK async APIs are queue- and callback-driven. Godot script APIs are signal- and `await`-driven.
+Microsoft GDK async APIs are queue- and callback-driven. Godot script APIs are signal- and `await`-driven.
 
 The system in `addons\godot_gdk\src\` exists to bridge those two models without exposing raw `XAsyncBlock`, `XTaskQueueHandle`, or `XUserHandle` values to GDScript.
 
@@ -18,8 +18,8 @@ The current baseline gives us:
 - one normalized result type: `GDKResult`
 - one internal `XAsync` bridge base: `GDKSignalXAsyncContext`
 - one internal one-shot signal helper: `GDKPendingSignal`
-- one internal Xbox services scaffold: `GDKXboxServices`
-- the concrete services that use this pattern across Xbox identity, services,
+- one internal XBOX services scaffold: `GDKXboxServices`
+- the concrete services that use this pattern across XBOX identity, services,
   package metadata, commerce, capture, launcher, error reporting, and
   system metadata (see [API reference](api-reference.md) for the
   full list)
@@ -206,10 +206,10 @@ Fields:
   `GDKStringVerify`, `GDKTitleStorage`,   `GDKErrorReporting`, `GDKLauncher`, `GDKActivation`,
   `GDKMultiplayerActivity`, and `GDKCapture`).
 - `gdk_runtime.cpp` / `gdk_runtime.h`  
-  Shared GDK runtime owner. Creates the queue, retains active pending signals, dispatches completions, and shuts everything down safely. During shutdown it cancels every retained pending signal and queues a cancelled completion so GDScript `await` sites are not stranded by queue teardown.
+  Shared Microsoft GDK runtime owner. Creates the queue, retains active pending signals, dispatches completions, and shuts everything down safely. During shutdown it cancels every retained pending signal and queues a cancelled completion so GDScript `await` sites are not stranded by queue teardown.
 
 - `gdk_xbox_services.cpp` / `gdk_xbox_services.h`
-  Shared Xbox services bootstrap. Derives the current-title SCID from `XGameGetXboxTitleId()`, initializes XSAPI, and caches per-user `XblContextHandle` objects.
+  Shared XBOX services bootstrap. Derives the current-title SCID from `XGameGetXboxTitleId()`, initializes XSAPI, and caches per-user `XblContextHandle` objects.
 
 ### Generic async layer
 
@@ -243,10 +243,10 @@ Fields:
   `GDKPackage`, `GDKPackageMount`, `GDKPackageResourcePack`, and `XPackage` enumeration / mount / DLC resource-pack flows.
 
 - `gdk_stats.cpp` / `gdk_stats.h`  
-  `GDKStats` Xbox Services user statistics with cache + tracking signals.
+  `GDKStats` XBOX Services user statistics with cache + tracking signals.
 
 - `gdk_leaderboards.cpp` / `gdk_leaderboards.h`  
-  `GDKLeaderboards`, `GDKLeaderboard`, `GDKLeaderboardColumn`, `GDKLeaderboardRow`, and read-only Xbox Services leaderboard queries.
+  `GDKLeaderboards`, `GDKLeaderboard`, `GDKLeaderboardColumn`, `GDKLeaderboardRow`, and read-only XBOX Services leaderboard queries.
 
 - `gdk_privacy.cpp` / `gdk_privacy.h`  
   `GDKPrivacy` permission/avoid-list/mute-list reads.
@@ -261,13 +261,13 @@ Fields:
   `GDKStore`, `GDKStoreLicenseStatus`, the per-product license cache, and `XStore` license/refresh/purchase flows.
 
 - `gdk_profile.cpp` / `gdk_profile.h`  
-  `GDKProfile`, `GDKUserProfile`, and Xbox Services profile reads.
+  `GDKProfile`, `GDKUserProfile`, and XBOX Services profile reads.
 
 - `gdk_string_verify.cpp` / `gdk_string_verify.h`  
-  `GDKStringVerify` Xbox Live string verification.
+  `GDKStringVerify` XBOX Live string verification.
 
 - `gdk_title_storage.cpp` / `gdk_title_storage.h`  
-  `GDKTitleStorage`, `GDKTitleStorageBlobMetadata`, `GDKTitleStorageBlobMetadataResult`, and Xbox Services Title Storage blob/quota flows.
+  `GDKTitleStorage`, `GDKTitleStorageBlobMetadata`, `GDKTitleStorageBlobMetadataResult`, and XBOX Services Title Storage blob/quota flows.
 
 - `gdk_error_reporting.cpp` / `gdk_error_reporting.h`  
   `GDKErrorReporting` `XError` callback/options wrapper with `error_reported` mirrored through `GDK.runtime_error`.
@@ -321,7 +321,7 @@ XTaskQueueDispatch(m_task_queue, XTaskQueuePort::Completion, 0)
 
 This keeps Godot-facing state changes tied to the main-thread pump instead of worker-thread callbacks.
 
-For Xbox services features, `GDK.dispatch()` also pumps manager-driven state like `XblAchievementsManagerDoWork()`. So the same per-frame dispatch contract covers both `XAsync` completions and non-`XAsync` service feeds.
+For XBOX services features, `GDK.dispatch()` also pumps manager-driven state like `XblAchievementsManagerDoWork()`. So the same per-frame dispatch contract covers both `XAsync` completions and non-`XAsync` service feeds.
 
 ### 2. One `XAsyncBlock` per XAsync-backed request
 
@@ -353,7 +353,7 @@ void CALLBACK GDKSignalXAsyncContext::_completion_thunk(XAsyncBlock *p_async_blo
 
 The thunk does **not** try to decode results generically.
 
-That is intentional. Each GDK async API has its own result contract:
+That is intentional. Each Microsoft GDK async API has its own result contract:
 
 - some use `*Result()`
 - some use `*ResultSize()` + `*Result()`
@@ -375,9 +375,9 @@ If the runtime did not retain the request, it could be destroyed before completi
 
 When a request completes, `GDKPendingSignal::complete()` runs its release hook and `GDKRuntime::release_pending_signal()` drops the retained reference.
 
-### 4. Xbox services bootstrap is shared
+### 4. XBOX services bootstrap is shared
 
-`GDKXboxServices` exists so Xbox services features can share title metadata and per-user XSAPI context management.
+`GDKXboxServices` exists so XBOX services features can share title metadata and per-user XSAPI context management.
 
 It currently:
 
@@ -402,7 +402,7 @@ This is the current end-to-end flow for `GDK.users.add_default_user_async()`:
    - allocates `AddUserAsyncContext`
    - binds cancellation through `XAsyncCancel`
    - starts `XUserAddAsync(...)`
-5. GDK performs the work on the queue's work port.
+5. Microsoft GDK performs the work on the queue's work port.
 6. Completion lands on the queue's completion port.
 7. The completion only becomes visible when `GDK.dispatch()` pumps the queue.
 8. `GDKSignalXAsyncContext::_completion_thunk()` forwards the raw `XAsyncBlock` to `AddUserAsyncContext::finalize(...)`.
@@ -541,11 +541,11 @@ Today the system covers:
 - shared queue ownership
 - retained pending-signal/result wrappers
 - one reusable `XAsync` context base
-- the full Xbox identity, Xbox services, package/DLC, commerce, capture,
+- the full XBOX identity, XBOX services, package/DLC, commerce, capture,
   launcher, error-reporting, and system-metadata service set listed in
   [Public surface](#public-surface)
 
 All shipped services share the same completion-signal pattern end to end.
 Game Saves are intentionally not part of this addon; they live in
-`godot_playfab` under `PlayFab.game_saves`. Server / admin / private GDK
+`godot_playfab` under `PlayFab.game_saves`. Server / admin / private Microsoft GDK
 surfaces remain out of scope for the public PC client wrappers.

--- a/docs/gdk/build-and-loading.md
+++ b/docs/gdk/build-and-loading.md
@@ -1,4 +1,4 @@
-# Godot GDK build and loading
+# Godot Microsoft GDK build and loading
 
 This document explains how the `godot_gdk` addon is laid out, built, packaged, and loaded by Godot.
 
@@ -21,11 +21,11 @@ contains:
 `addons\godot_gdk\src\` currently contains:
 
 - `gdk.cpp` / `gdk.h` — root singleton
-- `gdk_runtime.cpp` / `gdk_runtime.h` — shared GDK runtime and queue owner
+- `gdk_runtime.cpp` / `gdk_runtime.h` — shared Microsoft GDK runtime and queue owner
 - `gdk_result.cpp` / `gdk_result.h` — normalized result wrapper
 - `gdk_pending_signal.cpp` / `gdk_pending_signal.h` — retained one-shot completion signal helper
 - `gdk_signal_xasync_context.cpp` / `gdk_signal_xasync_context.h` — reusable `XAsyncBlock` bridge base for signal-returning requests
-- `gdk_xbox_services.cpp` / `gdk_xbox_services.h` — shared Xbox services bootstrap and context cache
+- `gdk_xbox_services.cpp` / `gdk_xbox_services.h` — shared XBOX services bootstrap and context cache
 - `gdk_user.cpp` / `gdk_user.h` — users service and user wrapper
 - `gdk_achievement.cpp` / `gdk_achievement.h` — achievements service and achievement wrapper
 - `gdk_package.cpp` / `gdk_package.h` — package metadata and install-state service wrappers
@@ -65,14 +65,14 @@ broader packaging UI lives in the separate `godot_gdk_packaging` addon.
 
 The repository currently ships two tutorial-driven sample projects:
 
-- `sample\tutorial_app\` — integrated tutorial chain (GDK runtime/sign-in,
+- `sample\tutorial_app\` — integrated tutorial chain (Microsoft GDK runtime/sign-in,
   achievements, PlayFab-backed flows, Multiplayer Activity, Party, and the
   final integration scene). This project receives `godot_gdk`, `godot_playfab`,
   and `godot_gdk_packaging` mirrors from the CMake build.
 - `sample\tutorial_gameinput\` — standalone GameInput tutorial sample. It is
-  wired for the GameInput addon and does not consume the GDK runtime addon.
+  wired for the GameInput addon and does not consume the Microsoft GDK runtime addon.
 
-Related GDK runtime/test surfaces:
+Related Microsoft GDK runtime/test surfaces:
 
 - `addons\godot_gdk\runtime\gdk_bootstrap.gd`
 - `tests\godot\gdk\tests\`
@@ -83,11 +83,11 @@ The native addon is built by `addons\godot_gdk\CMakeLists.txt`.
 
 That target currently:
 
-1. resolves the GDK headers and import libs via the shared
+1. resolves the Microsoft GDK headers and import libs via the shared
    `cmake/GDKDependencies.cmake` helper, which dispatches to either the
    `ms-gdk[playfab]` vcpkg port (default) or an installed Microsoft GDK
    on disk (opt-in via the `installed-gdk` preset — see
-   [Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency))
+   [Source for the Microsoft GDK dependency](../getting-started.md#source-for-the-microsoft-gdk-dependency))
 2. builds `godot_gdk` as a shared library
 3. links against:
    - `godot::cpp`
@@ -115,7 +115,7 @@ native C++ sources
 > The same install can also be used as the source of build-time headers
 > and libs in place of vcpkg via the `installed-gdk` preset (which then
 > needs no vcpkg checkout at all) —
-> [Source for the GDK dependency](../getting-started.md#source-for-the-gdk-dependency).
+> [Source for the Microsoft GDK dependency](../getting-started.md#source-for-the-microsoft-gdk-dependency).
 
 ## Runtime loading path
 
@@ -167,7 +167,7 @@ projects exercise different slices of the addon surface.
 
 In practice:
 
-- `tests\godot\gdk\` is the canonical GDK test harness
-- `tests\godot\playfab\` receives `godot_gdk` when `GODOT_PLAYFAB_TEST_HOST_WITH_GDK=ON` so optional Xbox-backed PlayFab compatibility tests can run; turn the option off to keep the PlayFab host custom-ID-only
-- `sample\tutorial_app\` receives the GDK runtime addon and is the integrated tutorial sample for GDK + PlayFab flows
-- `sample\tutorial_gameinput\` is a standalone GameInput sample and is not a GDK runtime consumer
+- `tests\godot\gdk\` is the canonical Microsoft GDK test harness
+- `tests\godot\playfab\` receives `godot_gdk` when `GODOT_PLAYFAB_TEST_HOST_WITH_GDK=ON` so optional XBOX-backed PlayFab compatibility tests can run; turn the option off to keep the PlayFab host custom-ID-only
+- `sample\tutorial_app\` receives the Microsoft GDK runtime addon and is the integrated tutorial sample for Microsoft GDK + PlayFab flows
+- `sample\tutorial_gameinput\` is a standalone GameInput sample and is not a Microsoft GDK runtime consumer

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -1,4 +1,4 @@
-# Godot GDK editor tools
+# Godot Microsoft GDK editor tools
 
 This document explains the current editor-side split between the `godot_gdk`
 runtime addon and the separate `godot_gdk_packaging` tooling addon.
@@ -22,7 +22,7 @@ in the editor's `Project > Export… > Add…` dropdown alongside the
 built-in platforms.
 
 The `godot_gdk_packaging` addon hosts the wider editor workflow
-(top-level **GDK** menu, sandbox switcher, `MicrosoftGame.config`
+(top-level **Microsoft GDK** menu, sandbox switcher, `MicrosoftGame.config`
 flows, tutorial wizard) and the headless packaging CLI.
 
 ## `gdk_editor_plugin.gd`
@@ -71,7 +71,7 @@ working when the underlying packaging primitives change.
 
 ## `godot_gdk_packaging`
 
-The active editor tooling for GDK packaging now lives in
+The active editor tooling for Microsoft GDK packaging now lives in
 `addons\godot_gdk_packaging\editor\`.
 
 Treat the root `addons\godot_gdk_packaging\` tree as the source of truth. The
@@ -81,7 +81,7 @@ addon rather than patching sample copies directly.
 
 That addon owns:
 
-- the top-level **GDK** editor menu
+- the top-level **Microsoft GDK** editor menu
 - headless package, validate, install, and launch actions
 - tutorial/help surfaces
 - `MicrosoftGame.config` helper flows
@@ -94,7 +94,7 @@ When discussing the current editor workflow, treat `godot_gdk` and
 
 ## Relationship to the runtime addon
 
-The GDK runtime addon still matters to the editor story because samples and
+The Microsoft GDK runtime addon still matters to the editor story because samples and
 packaging flows need title identity and synced addon payloads, but the runtime
 addon is no longer the main place to look for packaging UI behavior.
 

--- a/docs/gdk/native-runtime.md
+++ b/docs/gdk/native-runtime.md
@@ -481,7 +481,7 @@ malformed URIs return `invalid_uri`; blocked destinations such as `file:`,
 
 ## Error reporting service
 
-`GDKErrorReporting` wraps the public PC Microsoft GDK `XError` callback and options
+`GDKErrorReporting` wraps the public Microsoft GDK `XError` callback and options
 APIs (`XErrorSetCallback`, `XErrorSetOptions`). It does not submit reports to
 external endpoints.
 

--- a/docs/gdk/native-runtime.md
+++ b/docs/gdk/native-runtime.md
@@ -1,4 +1,4 @@
-# Godot GDK native runtime
+# Godot Microsoft GDK native runtime
 
 This document explains the current native runtime architecture of the `godot_gdk` addon.
 
@@ -17,7 +17,7 @@ The current native implementation has one root singleton and 21 public service n
 - service namespaces: `GDK.users`, `GDK.game_ui`, `GDK.accessibility`, `GDK.achievements`, `GDK.package`, `GDK.stats`, `GDK.leaderboards`, `GDK.privacy`, `GDK.presence`, `GDK.social`, `GDK.store`, `GDK.profile`, `GDK.string_verify`, `GDK.title_storage`, `GDK.error_reporting`, `GDK.launcher`, `GDK.multiplayer_activity`, `GDK.capture`, `GDK.system`, `GDK.display`, and `GDK.activation`
 - wrapper types: `GDKResult`, `GDKUsers`, `GDKUser`, `GDKGameUI`, `GDKAccessibility`, `GDKClosedCaptionProperties`, `GDKAchievements`, `GDKAchievement`, `GDKPackage`, `GDKPackageMount`, `GDKPackageResourcePack`, `GDKStats`, `GDKLeaderboards`, `GDKLeaderboard`, `GDKLeaderboardColumn`, `GDKLeaderboardRow`, `GDKPrivacy`, `GDKPresence`, `GDKPresenceRecord`, `GDKSocial`, `GDKSocialFilter`, `GDKSocialGroup`, `GDKSocialUser`, `GDKStore`, `GDKStoreLicenseStatus`, `GDKProfile`, `GDKUserProfile`, `GDKStringVerify`, `GDKTitleStorage`, `GDKTitleStorageBlobMetadata`, `GDKTitleStorageBlobMetadataResult`, `GDKErrorReporting`, `GDKLauncher`, `GDKMultiplayerActivity`, `GDKMultiplayerActivityInfo`, `GDKCapture`, `GDKCaptureMetaData`, `GDKSystem`, `GDKDisplay`, `GDKDisplayTimeoutDeferral`, and `GDKActivation`
 - internal direct-await helpers: `GDKPendingSignal`, `GDKSignalXAsyncContext`
-- internal Xbox services scaffold: `GDKXboxServices`
+- internal XBOX services scaffold: `GDKXboxServices`
 
 ## Root object: `GDK`
 
@@ -85,9 +85,9 @@ The queue is configured as:
 
 That means native work may happen off-thread, but Godot-visible completion only becomes visible when `GDK.dispatch()` drains the completion queue. By default the addon now calls `GDK.dispatch()` from a native process-frame callback while `gdk/runtime/embed_dispatch` is enabled, and games can fall back to manual dispatch when they disable that setting.
 
-## Xbox services scaffold: `GDKXboxServices`
+## XBOX services scaffold: `GDKXboxServices`
 
-`GDKXboxServices` is the shared native helper for features that sit on top of Xbox services rather than the raw game runtime.
+`GDKXboxServices` is the shared native helper for features that sit on top of XBOX services rather than the raw game runtime.
 
 It is responsible for:
 
@@ -137,7 +137,7 @@ It currently exposes:
 
 It emits:
 
-- `user_changed(user, change_kind)` for all user lifecycle and Xbox-facing state changes. `change_kind` is `added`, `removed`, `signed_in_again`, `gamertag`, `gamer_picture`, or `privileges`.
+- `user_changed(user, change_kind)` for all user lifecycle and XBOX-facing state changes. `change_kind` is `added`, `removed`, `signed_in_again`, `gamertag`, `gamer_picture`, or `privileges`.
 
 `GDKUser` is the script-visible wrapper around a local user. It stores:
 
@@ -184,7 +184,7 @@ this change (`XClosedCaptionGetProperties`, `XClosedCaptionSetEnabled`,
 
 ## Achievements service
 
-`GDKAchievements` is the first service implemented on top of the Xbox services scaffold.
+`GDKAchievements` is the first service implemented on top of the XBOX services scaffold.
 
 It currently owns:
 
@@ -215,7 +215,7 @@ It emits:
 
 ## Presence service
 
-`GDKPresence` is the XAsync-backed presence layer implemented on top of the shared Xbox services scaffold.
+`GDKPresence` is the XAsync-backed presence layer implemented on top of the shared XBOX services scaffold.
 
 It currently exposes:
 
@@ -239,7 +239,7 @@ Important contract details:
 
 - `state` is the configured rich-presence string ID for the current title SCID in Partner Center, not arbitrary text.
 - `rich_presence` can override `scid` and pass `token_ids` / `tokens` for rich-presence formatting.
-- `get_presence_async(xuids)` reads presence by XUID, but it still requires a signed-in primary user because the XSAPI call needs an Xbox services context.
+- `get_presence_async(xuids)` reads presence by XUID, but it still requires a signed-in primary user because the XSAPI call needs an XBOX services context.
 
 ## Social service
 
@@ -269,7 +269,7 @@ Its main wrapper types are:
 
 ## Profile service
 
-`GDKProfile` is the XSAPI-backed profile layer for Xbox Services profile reads.
+`GDKProfile` is the XSAPI-backed profile layer for XBOX Services profile reads.
 
 It currently exposes:
 
@@ -277,8 +277,8 @@ It currently exposes:
 - `get_profiles_async(user, xuids)`
 - `get_profiles_for_social_group_async(user, social_group)`
 
-`GDKUserProfile` is the script-visible wrapper around one Xbox Services profile
-record. Calls duplicate from the shared cached Xbox services context via
+`GDKUserProfile` is the script-visible wrapper around one XBOX Services profile
+record. Calls duplicate from the shared cached XBOX services context via
 `GDKXboxServices::duplicate_context_for_user` (which calls
 `XblContextDuplicateHandle(...)`); methods return typed errors when the
 scaffold isn't initialized.
@@ -303,7 +303,7 @@ linked thunk libs.
 
 ## Stats service
 
-`GDKStats` is the XSAPI-backed user statistics layer wired through the Xbox
+`GDKStats` is the XSAPI-backed user statistics layer wired through the XBOX
 services scaffold.
 
 It currently exposes:
@@ -345,11 +345,11 @@ It emits:
 
 `GDKLeaderboard` carries `query_type`, `total_row_count`, `has_next`, columns,
 and rows. `GDKLeaderboardRow.column_values` carries JSON-encoded column values
-returned by Xbox Services.
+returned by XBOX Services.
 
 ## String verification service
 
-`GDKStringVerify` is the XSAPI-backed wrapper around Xbox Live string
+`GDKStringVerify` is the XSAPI-backed wrapper around XBOX Live string
 verification.
 
 It currently exposes:
@@ -363,9 +363,9 @@ boolean and the first offending substring when available.
 
 ## Title Storage service
 
-`GDKTitleStorage` is the XSAPI-backed Xbox Services Title Storage layer
+`GDKTitleStorage` is the XSAPI-backed XBOX Services Title Storage layer
 wrapping `title_storage_c.h`. It is unrelated to PlayFab Game Saves and the
-GDK `XGameSaveFiles` API.
+Microsoft GDK `XGameSaveFiles` API.
 
 It currently exposes:
 
@@ -481,7 +481,7 @@ malformed URIs return `invalid_uri`; blocked destinations such as `file:`,
 
 ## Error reporting service
 
-`GDKErrorReporting` wraps the public PC GDK `XError` callback and options
+`GDKErrorReporting` wraps the public PC Microsoft GDK `XError` callback and options
 APIs (`XErrorSetCallback`, `XErrorSetOptions`). It does not submit reports to
 external endpoints.
 
@@ -503,7 +503,7 @@ bitwise OR.
 
 `GDKSystem` is the synchronous title/runtime metadata service. It exposes
 PC-supported XGameRuntime metadata reads plus a passthrough to the shared
-Xbox services scaffold.
+XBOX services scaffold.
 
 It currently exposes:
 
@@ -513,7 +513,7 @@ It currently exposes:
 - `is_xbox_services_initialized()`
 
 The service has no native handle of its own; reads are direct calls to
-`XGameGetXboxTitleId`, `XSystemGetXboxLiveSandboxId`, and the Xbox services
+`XGameGetXboxTitleId`, `XSystemGetXboxLiveSandboxId`, and the XBOX services
 scaffold's cached SCID.
 
 ## Display service
@@ -576,7 +576,7 @@ The newer XUser-facing methods now reuse that same flow as well: privilege resol
 
 The current `query_player_achievements_async()` and `update_achievement_async()` paths are the complementary non-`XAsyncBlock` example:
 
-1. `GDKAchievements` ensures Xbox services are initialized from title metadata.
+1. `GDKAchievements` ensures XBOX services are initialized from title metadata.
 2. it registers the user with Achievements Manager through `XblAchievementsManagerAddLocalUser(...)`
 3. it returns a retained completion signal
 4. the op stays pending until `GDK.dispatch()` pumps `XblAchievementsManagerDoWork()`

--- a/docs/gdk/plugin.md
+++ b/docs/gdk/plugin.md
@@ -1,17 +1,17 @@
-# Godot GDK plugin
+# Godot Microsoft GDK plugin
 
 This is the landing page for the `godot_gdk` docs set.
 
-`godot_gdk` is the primary GDExtension addon in this repository. It implements a public-PC GDK service surface — runtime, users, achievements, presence, social, profile, privacy, multiplayer activity, stats, leaderboards, title storage, string verification, package metadata + DLC content access, XStore commerce, GameUI, accessibility, capture, launcher, error reporting, and system metadata — and also ships editor-side setup and export tooling for the broader GDK workflow.
+`godot_gdk` is the primary GDExtension addon in this repository. It implements a public-PC Microsoft GDK service surface — runtime, users, achievements, presence, social, profile, privacy, multiplayer activity, stats, leaderboards, title storage, string verification, package metadata + DLC content access, XStore commerce, GameUI, accessibility, capture, launcher, error reporting, and system metadata — and also ships editor-side setup and export tooling for the broader Microsoft GDK workflow.
 
 ## Current implementation status
 
 ### Implemented now
 
 - root singleton registration through `GDK`
-- shared GDK runtime lifecycle
+- shared Microsoft GDK runtime lifecycle
 - shared async bridge
-- shared Xbox services scaffold
+- shared XBOX services scaffold
 - users service (`GDK.users`)
 - system / runtime metadata service (`GDK.system`)
 - game UI service (`GDK.game_ui`)
@@ -43,15 +43,15 @@ This is the landing page for the `godot_gdk` docs set.
 
 - Game Saves are intentionally not part of `godot_gdk`; they live in
   `godot_playfab` under `PlayFab.game_saves` because the PlayFab Game Saves
-  C API drives the Xbox-backed save flow.
-- Server / admin / private GDK surfaces remain out of scope for the public
+  C API drives the XBOX-backed save flow.
+- Server / admin / private Microsoft GDK surfaces remain out of scope for the public
   PC client wrappers.
 
 ## Testing this addon
 
 `godot_gdk` is exercised by the `tests\godot\gdk\` host. Coverage lives under `tests\godot\gdk\tests\` and includes files such as `test_core.gd`, `test_users.gd`, `test_achievements.gd`, `test_presence.gd`, `test_social.gd`, `test_multiplayer_activity.gd`, `test_system.gd`, `test_result_helpers.gd`, and `test_embed_dispatch.gd`. Startup-only behavior is covered by `tests\godot\gdk\tests\bootstrap\run_*.gd`, and packaging/editor-helper logic is covered under `tests\godot\gdk\tests\packaging\`.
 
-Most deterministic coverage runs in the default orchestrator pass. Live GDK flows are gated by `LIVE_TESTS=1` through `-Live`; any live write coverage should use a test sandbox.
+Most deterministic coverage runs in the default orchestrator pass. Live Microsoft GDK flows are gated by `LIVE_TESTS=1` through `-Live`; any live write coverage should use a test sandbox.
 
 Run the standard pipeline from the repository root:
 
@@ -67,7 +67,7 @@ See [`gdk/sample-and-tests.md`](sample-and-tests.md) for the orchestrator stages
 
 - [`getting-started.md`](../getting-started.md)  
   Adding the addons to your project, configuring project settings,
-  getting to user sign-in (Xbox + PlayFab), and building from source.
+  getting to user sign-in (XBOX + PlayFab), and building from source.
 
 - [`gdk/sample-setup.md`](sample-setup.md)  
   Partner Center configuration, sandbox setup, test accounts, and configuration flow.
@@ -97,7 +97,7 @@ See [`gdk/sample-and-tests.md`](sample-and-tests.md) for the orchestrator stages
 ### Subsystem deep dive
 
 - [`gdk/async-system.md`](async-system.md)  
-  Lower-level explanation of the shared async bridge and how the GDK service
+  Lower-level explanation of the shared async bridge and how the Microsoft GDK service
   wrappers participate in it.
 
 ### Reference

--- a/docs/gdk/plugin.md
+++ b/docs/gdk/plugin.md
@@ -2,7 +2,7 @@
 
 This is the landing page for the `godot_gdk` docs set.
 
-`godot_gdk` is the primary GDExtension addon in this repository. It implements a public-PC Microsoft GDK service surface — runtime, users, achievements, presence, social, profile, privacy, multiplayer activity, stats, leaderboards, title storage, string verification, package metadata + DLC content access, XStore commerce, GameUI, accessibility, capture, launcher, error reporting, and system metadata — and also ships editor-side setup and export tooling for the broader Microsoft GDK workflow.
+`godot_gdk` is the primary GDExtension addon in this repository. It implements a public Microsoft GDK service surface — runtime, users, achievements, presence, social, profile, privacy, multiplayer activity, stats, leaderboards, title storage, string verification, package metadata + DLC content access, XStore commerce, GameUI, accessibility, capture, launcher, error reporting, and system metadata — and also ships editor-side setup and export tooling for the broader Microsoft GDK workflow.
 
 ## Current implementation status
 

--- a/docs/gdk/sample-and-tests.md
+++ b/docs/gdk/sample-and-tests.md
@@ -163,7 +163,7 @@ Update a baseline only when the host's intentional coverage changes. Do not lowe
 `GDK.launcher` success paths invoke OS-level URI handlers (`XLaunchUri`) and are
 not deterministic in CI/headless hosts. Keep automated coverage focused on input
 validation and unsupported-destination errors, then run manual smoke checks on a
-PC Microsoft GDK machine for successful destinations (for example
+Microsoft GDK machine for successful destinations (for example
 `GDK.launcher.launch_uri("ms-settings:privacy-microphone")` and
 `GDK.launcher.launch_uri("ms-windows-store://pdp/?productid=<StoreProductId>")`).
 

--- a/docs/gdk/sample-and-tests.md
+++ b/docs/gdk/sample-and-tests.md
@@ -1,4 +1,4 @@
-# Godot GDK sample and tests
+# Godot Microsoft GDK sample and tests
 
 This document explains how the repo-wide test pipeline validates
 the addons.
@@ -18,7 +18,7 @@ The repository currently ships two tutorial-driven sample projects:
   integration tech demo). The CMake build mirrors `godot_gdk`, `godot_playfab`,
   and `godot_gdk_packaging` into this project.
 - `sample\tutorial_gameinput\` — standalone GameInput tutorial sample. It is
-  wired for the GameInput addon rather than the GDK runtime addon.
+  wired for the GameInput addon rather than the Microsoft GDK runtime addon.
 
 The test hosts under `tests\godot\` remain the automated coverage projects;
 the sample projects are reader-facing tutorial references, not GUT hosts.
@@ -70,7 +70,7 @@ A local run is green when all of the following are true:
 
 | Var | Effect | Default |
 |---|---|---|
-| `LIVE_TESTS=1` | Enables tests that need a live GDK or PlayFab session. | unset |
+| `LIVE_TESTS=1` | Enables tests that need a live Microsoft GDK or PlayFab session. | unset |
 | `LIVE_WRITE_TESTS=1` | Enables sandbox-only tests that write online state. Use only with sandbox titles. | unset |
 | `PLAYFAB_TITLE_ID` | Overrides `playfab/runtime/title_id` inside PlayFab test hosts. Prefer `-PlayFabTitleId` when using the orchestrator. | unset |
 | `PLAYFAB_CUSTOM_ID` | Supplies a pre-existing custom id for PlayFab live sign-in tests. | unset |
@@ -163,7 +163,7 @@ Update a baseline only when the host's intentional coverage changes. Do not lowe
 `GDK.launcher` success paths invoke OS-level URI handlers (`XLaunchUri`) and are
 not deterministic in CI/headless hosts. Keep automated coverage focused on input
 validation and unsupported-destination errors, then run manual smoke checks on a
-PC GDK machine for successful destinations (for example
+PC Microsoft GDK machine for successful destinations (for example
 `GDK.launcher.launch_uri("ms-settings:privacy-microphone")` and
 `GDK.launcher.launch_uri("ms-windows-store://pdp/?productid=<StoreProductId>")`).
 
@@ -175,9 +175,9 @@ PlayFab leaderboard writes may take several seconds to appear in subsequent read
 
 ## Adding a new test
 
-- Put addon coverage in the owning host: GDK and packaging tests in `tests\godot\gdk\tests\`, PlayFab tests in `tests\godot\playfab\tests\`, and GameInput tests in `tests\godot\gameinput\tests\`.
+- Put addon coverage in the owning host: Microsoft GDK and packaging tests in `tests\godot\gdk\tests\`, PlayFab tests in `tests\godot\playfab\tests\`, and GameInput tests in `tests\godot\gameinput\tests\`.
 - Extend the matching shared base: `res://addons/godot_gdk_tests/gdk_test_base.gd`, `res://addons/godot_gdk_tests/playfab_test_base.gd`, or `res://addons/godot_gdk_tests/gameinput_test_base.gd`.
-- Use `await_completion(...)` or `await_completion_state(...)` for async signal waits. PlayFab tests inherit a dual-pump override that dispatches both PlayFab and, when the optional GDK mirror is present, GDK queues.
+- Use `await_completion(...)` or `await_completion_state(...)` for async signal waits. PlayFab tests inherit a dual-pump override that dispatches both PlayFab and, when the optional Microsoft GDK mirror is present, Microsoft GDK queues.
 - Use `pending_unless_live()` for live gates, and derive mutating identifiers with `with_unique_id(...)`.
 - Use `assert_has_method_named(...)` and `assert_has_signal_named(...)` for reflection checks.
 - If a directory tree contains GUT-extending `.gd` files, place an empty `.gut_skip_validation` sentinel at that tree root so `tools\check_gd_scripts_headless.ps1` skips standalone parsing that would otherwise produce UID or GUT class-name warnings.

--- a/docs/gdk/sample-setup.md
+++ b/docs/gdk/sample-setup.md
@@ -1,9 +1,9 @@
-# Godot GDK sample project setup
+# Godot Microsoft GDK sample project setup
 
 The integrated tutorial sample needs your **Partner Center** credentials to
-work with Xbox Live services. The supported setup paths are the repo CLI script
+work with XBOX Live services. The supported setup paths are the repo CLI script
 or manually editing the local config files and Project Settings. The
-`godot_gdk` editor plugin no longer docks a **GDK Setup** panel; it keeps the
+`godot_gdk` editor plugin no longer docks a **Microsoft GDK Setup** panel; it keeps the
 runtime autoload installed and registers the `Xbox GDK (PC)` export platform.
 
 ## Prerequisites
@@ -11,27 +11,27 @@ runtime autoload installed and registers the `Xbox GDK (PC)` export platform.
 1. **Register your title** in the
    [Partner Center dashboard](https://partner.microsoft.com/dashboard).
    If you don't have a publisher account yet, start with the
-   [ID@Xbox program](https://www.xbox.com/en-us/developers/id) and the
+   [ID@XBOX program](https://www.xbox.com/en-us/developers/id) and the
    [Microsoft Game Stack publisher hub](https://developer.microsoft.com/en-us/games/publish/).
-2. **Create test accounts** in Partner Center → Account Settings → Xbox Live
+2. **Create test accounts** in Partner Center → Account Settings → XBOX Live
    → Test Accounts
-3. **Configure achievements** (optional) in Partner Center → Xbox Live →
+3. **Configure achievements** (optional) in Partner Center → XBOX Live →
    Achievements, then publish to your sandbox. See
    [Microsoft GDK — Achievements](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/player-data/achievements/live-achievements-nav)
    for the authoring walkthrough.
-4. Gather these values from Partner Center → Xbox Live → Xbox Live Setup
+4. Gather these values from Partner Center → XBOX Live → XBOX Live Setup
    (see
-   [Configuring Xbox services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
+   [Configuring XBOX services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
    and
    [Setting up sandboxes](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/sandboxes/live-setup-sandbox)):
 
 | Value | Where to find it | Example |
 |-------|-------------------|---------|
-| Title ID | Xbox Live Setup | `6718942c` |
-| MSA App ID | Xbox Live Setup | `93900f42-4313-...` |
+| Title ID | XBOX Live Setup | `6718942c` |
+| MSA App ID | XBOX Live Setup | `93900f42-4313-...` |
 | Store ID | Product identity page | `9XXXXXXXXX` |
-| SCID | Xbox Live Setup | `00000000-0000-0000-0000-000067...` |
-| Sandbox ID | Xbox Live Setup | `XDKS.1` |
+| SCID | XBOX Live Setup | `00000000-0000-0000-0000-000067...` |
+| Sandbox ID | XBOX Live Setup | `XDKS.1` |
 | Publisher CN | Product identity page | `CN=XXXXXXXX-XXXX-...` |
 
 ## Title-owned values checklist
@@ -55,7 +55,7 @@ own game code:
   development machine.
 - **Peer-XUID prerequisites:** additional signed-in test accounts/XUIDs for
   invites, recent-player updates, profile-card UI, reputation feedback, and any
-  other peer-targeted Xbox service flow.
+  other peer-targeted XBOX service flow.
 
 ## Option A: Configure via CLI (recommended)
 
@@ -89,10 +89,10 @@ The generated files are gitignored, so your credentials stay local.
    plugins after the CMake build mirrors them into `sample\tutorial_app\addons\`.
 4. Review **Project → Project Settings** for `gdk/runtime/*` startup settings
    and any PlayFab runtime values needed by the tutorial scenes.
-5. For editor-driven packaging, use **Project → Export… → Add… → Xbox GDK (PC)**.
+5. For editor-driven packaging, use **Project → Export… → Add… → `Xbox GDK (PC)`**.
    For scripted packaging and sandbox actions, use the separate
    `godot_gdk_packaging` addon (`addons\godot_gdk_packaging\gdkpkg.cmd` or its
-   top-level **GDK** editor menu).
+   top-level **Microsoft GDK** editor menu).
 
 ## Set your PC sandbox
 
@@ -110,7 +110,7 @@ The short version:
 
 ## Test account sign-in
 
-The sample uses **Xbox test accounts**, not personal Microsoft accounts:
+The sample uses **XBOX test accounts**, not personal Microsoft accounts:
 
 1. Ensure your PC sandbox matches the sandbox in Partner Center
 2. Launch the sample — it will attempt silent sign-in automatically
@@ -159,11 +159,11 @@ This signs into Partner Center via `XblDevAccount.exe`, then calls
 `XblPlayerDataReset.exe` to wipe achievements, stats, and leaderboards for
 the specified test account. You'll need:
 
-- **Service Config ID (SCID)** — from Partner Center → Xbox Live → Xbox Live
+- **Service Config ID (SCID)** — from Partner Center → XBOX Live → XBOX Live
   Setup
 - **Sandbox ID** — the development sandbox your test account is signed into
-- **XUID** — the Xbox User ID of the test account to reset
+- **XUID** — the XBOX User ID of the test account to reset
 
-> **Note:** Resets only work on Xbox test accounts in a development sandbox,
+> **Note:** Resets only work on XBOX test accounts in a development sandbox,
 > not retail accounts. Restart the game after resetting for changes to take
 > effect.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,7 +86,7 @@ errors in `MicrosoftGame.config`, etc.).
 - [Godot 4.5+](https://godotengine.org/download) (stable, Windows 64-bit)
 - [Microsoft GDK](https://github.com/microsoft/GDK/releases) installed on
   every machine that runs the game (the XBOX runtime DLLs the addons depend
-  on resolve from the GDK install). `winget install Microsoft.Gaming.GDK`.
+  on resolve from the Microsoft GDK install). `winget install Microsoft.Gaming.GDK`.
 
 ### To make XBOX sign-in actually work
 
@@ -282,7 +282,7 @@ runtime/embed_dispatch=true          ; pump async completions in _process (defau
 ```
 
 When `initialize_on_startup` is `true`, the `PlayFabBootstrap` autoload
-calls `PlayFab.initialize()` during `_ready` — the same shape as the GDK
+calls `PlayFab.initialize()` during `_ready` — the same shape as the Microsoft GDK
 bootstrap. Sign-in is still in your code because PlayFab needs a
 per-player key (a `GDKUser` or a custom id).
 
@@ -370,7 +370,7 @@ already signed into the XBOX app on the PC, it returns a non-ok result
 system account picker on screen instead.
 
 For the full method/signal table see
-[GDK API reference → `GDK.users`](gdk/api-reference.md#users-service-gdkusers).
+[Microsoft GDK API reference → `GDK.users`](gdk/api-reference.md#users-service-gdkusers).
 
 > Real XBOX Live sign-in needs Partner Center configuration, the right
 > sandbox set on the PC, and a test account signed into the XBOX app —
@@ -432,7 +432,7 @@ func _sign_in_to_playfab() -> void:
 ```
 
 If you don't have an XBOX account yet (or are testing on a machine
-without GDK Live setup), use the no-XBOX custom-ID path:
+without Microsoft GDK Live setup), use the no-XBOX custom-ID path:
 
 ```gdscript
 var pf_result: PlayFabResult = await PlayFab.users.sign_in_with_custom_id_async(
@@ -440,7 +440,7 @@ var pf_result: PlayFabResult = await PlayFab.users.sign_in_with_custom_id_async(
 ```
 
 `sign_in_with_xuser_async` returns `invalid_xuser` if you pass a null or
-signed-out GDK user, so always confirm `XBOX_user.signed_in` first.
+signed-out Microsoft GDK user, so always confirm `XBOX_user.signed_in` first.
 PlayFab Game Saves additionally require an XBOX-backed PlayFab session
 (custom-id users will get `XBOX_user_required` from `PlayFab.game_saves`
 methods).
@@ -472,10 +472,10 @@ test-account guide.
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `GDExtension dynamic library not found` | The `bin/` folder didn't make it into the project copy | Copy `addons/<addon>/` recursively, including `bin/` |
-| `[GDK] Bootstrap: 'GDK' singleton not registered` | Extension failed to load (wrong Windows arch, missing GDK install, missing `libHttpClient.dll`) | Check that the addon copy preserved `bin/` and that the GDK is installed on the machine that runs the game |
+| `[GDK] Bootstrap: 'GDK' singleton not registered` | Extension failed to load (wrong Windows arch, missing Microsoft GDK install, missing `libHttpClient.dll`) | Check that the addon copy preserved `bin/` and that the Microsoft GDK is installed on the machine that runs the game |
 | Silent sign-in returns `no_default_user` | No test account signed in to the XBOX app on the PC, or the PC sandbox doesn't match Partner Center | Set the sandbox with `XblPCSandbox.exe` and sign a test account into the XBOX app — see [XBOX sandbox and test-account setup](platform/XBOX-sandbox-and-test-accounts.md) |
 | `PlayFab.initialize()` fails immediately | `playfab/runtime/title_id` is empty | Set `playfab/runtime/title_id` in Project Settings (or `project.godot` `[playfab] runtime/title_id="..."`) |
-| `sign_in_with_xuser_async` returns `invalid_xuser` | Passing a null / signed-out GDK user | Verify `XBOX_user != null and XBOX_user.signed_in` before calling |
+| `sign_in_with_xuser_async` returns `invalid_xuser` | Passing a null / signed-out Microsoft GDK user | Verify `XBOX_user != null and XBOX_user.signed_in` before calling |
 | `PlayFab.game_saves` returns `XBOX_user_required` | The PlayFab session was created with a custom id | Use `sign_in_with_xuser_async` for any flow that touches Game Saves |
 
 ---
@@ -485,7 +485,7 @@ test-account guide.
 - [**Tutorials**](tutorials/README.md) — task-oriented walkthroughs
   for sign-in, achievements, leaderboards, Game Saves, lobbies, and
   GameInput. Recommended next stop once you have signed in.
-- [GDK API reference](gdk/api-reference.md) — full list of services
+- [Microsoft GDK API reference](gdk/api-reference.md) — full list of services
   (`GDK.users`, `GDK.achievements`, `GDK.leaderboards`,
   `GDK.multiplayer_activity`, `GDK.store`, `GDK.system`, …)
 - [PlayFab plugin overview](playfab/plugin.md) — `PlayFab.users`,
@@ -561,11 +561,11 @@ cmake --preset gameinput-only
 cmake --build --preset debug-gameinput
 ```
 
-### Source for the GDK dependency
+### Source for the Microsoft GDK dependency
 
-By default, the build resolves the GDK headers and import libs through
+By default, the build resolves the Microsoft GDK headers and import libs through
 the `ms-gdk[playfab]` vcpkg port (`default` preset). This requires only
-a vcpkg checkout — no machine-wide GDK install is needed at build time.
+a vcpkg checkout — no machine-wide Microsoft GDK install is needed at build time.
 
 If you already have a Microsoft GDK installed on disk (most developers
 do, for `makepkg.exe` / `wdapp.exe` / Game Config Editor), the
@@ -582,19 +582,19 @@ cmake --preset installed-gdk -DGDK_INSTALL_DIR="C:/Program Files (x86)/Microsoft
 ```
 
 > **Note:** the `installed-gdk` preset is the only supported way to
-> consume an installed GDK. Setting `-DGDK_DEPENDENCY_SOURCE=installed`
+> consume an installed Microsoft GDK. Setting `-DGDK_DEPENDENCY_SOURCE=installed`
 > on the `default` preset does **not** work — the vcpkg toolchain
 > processes manifest features (and restores `ms-gdk[playfab]`) before
-> the GDK source-selection logic runs. The `installed-gdk` preset
+> the Microsoft GDK source-selection logic runs. The `installed-gdk` preset
 > sidesteps this by not loading the vcpkg toolchain at all.
 
 Installed mode consumes the modern `windows\` subdirectory layout of the
-GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
-`<install>/windows/bin/x64`) that ships in GDK **260400 / April 2026 and
+Microsoft GDK (`<install>/windows/include`, `<install>/windows/lib/x64`,
+`<install>/windows/bin/x64`) that ships in Microsoft GDK **260400 / April 2026 and
 later**. The legacy `GRDK\` peer layout is not supported; use the
-`default` preset (vcpkg) for older GDK versions.
+`default` preset (vcpkg) for older Microsoft GDK versions.
 
-**GameInput in installed mode** — the installed GDK ships GameInput v1
+**GameInput in installed mode** — the installed Microsoft GDK ships GameInput v1
 only, but the `godot_gameinput` addon targets v3. The `installed-gdk`
 preset solves this by setting `GAMEINPUT_SOURCE=nuget`, which fetches
 the `Microsoft.GameInput` NuGet package directly from nuget.org via
@@ -622,7 +622,7 @@ Source-selection options:
 The build resolves its native dependencies via vcpkg manifest mode. CMake
 reads `vcpkg.json` + `vcpkg-configuration.json` at the repo root and pulls
 in the `ms-gdk[playfab]` and `gameinput` ports for you. There is no
-machine-wide GDK install required for compilation — set `VCPKG_ROOT` and
+machine-wide Microsoft GDK install required for compilation — set `VCPKG_ROOT` and
 run the `default` preset.
 
 If you ever need to point at a specific vcpkg toolchain file (for example,
@@ -681,7 +681,7 @@ included `.vscode/c_cpp_properties.json`. If you see red squiggles on
 
 1. Ensure you've **built at least once** — godot-cpp headers are generated
    during the first build into `build/godot-cpp/gen/include/`, and vcpkg
-   stages the GDK + GameInput headers into `build/vcpkg_installed/`.
+   stages the Microsoft GDK + GameInput headers into `build/vcpkg_installed/`.
 2. Ensure `VCPKG_ROOT` is set in your environment so the IntelliSense
    include paths resolve. If you point IntelliSense at a different vcpkg
    install than the build uses, update `.vscode/c_cpp_properties.json` to

--- a/docs/packaging/editor-menu.md
+++ b/docs/packaging/editor-menu.md
@@ -1,6 +1,6 @@
-# Godot GDK Packaging — Editor `GDK` Menu
+# Godot Microsoft GDK Packaging — Editor `GDK` Menu
 
-The `godot_gdk_packaging` addon adds a top-level **GDK** menu to the
+The `godot_gdk_packaging` addon adds a top-level **Microsoft GDK** menu to the
 Godot editor. The menu is editor tooling only: it does not add a runtime
 autoload or engine singleton, and it is separate from the headless
 `gdkpkg` runner documented in [Packaging Plugin](plugin.md).
@@ -18,8 +18,8 @@ The menu is assembled by
 7. GameConfigEditor Reference
 8. Achievements Guide
 9. PlayFab Game Manager
-10. PlayFab IDs from Xbox Live
-11. PlayFab + GDK Quickstart
+10. PlayFab IDs from XBOX Live
+11. PlayFab + Microsoft GDK Quickstart
 
 ## Prerequisites shared by all menu entries
 
@@ -27,7 +27,7 @@ The menu is assembled by
 - Open the project whose packaging state you want to inspect or change.
 - Install the Microsoft GDK when you want to run local tools such as
   `GameConfigEditor.exe`, `XblPCSandbox.exe`, `wdapp.exe`, or `makepkg.exe`.
-  The addon discovers the GDK from `GDK_BIN` first, then from the default
+  The addon discovers the Microsoft GDK from `GDK_BIN` first, then from the default
   `C:\Program Files (x86)\Microsoft GDK\bin` location.
 
 Documentation links also require network access and whatever Microsoft,
@@ -47,7 +47,7 @@ when you need a quick reminder of the packaging workflow without leaving the
 editor.
 
 **Required prerequisites:** The addon must be enabled and the Godot editor
-must have a base editor window. The wizard itself does not require the GDK to
+must have a base editor window. The wizard itself does not require the Microsoft GDK to
 be installed because it is informational.
 
 **Expected output / side effects:** A modal wizard window opens. Navigating or
@@ -61,25 +61,25 @@ commands that perform the build and packaging work.
 **What it does:** The label changes based on whether the project already has a
 MicrosoftGame.config. When the file is missing, the menu creates a starter
 `MicrosoftGame.config`, best-effort creates placeholder images under
-`storelogos\` when the GDK default PNG asset is available, asks Godot's file
+`storelogos\` when the Microsoft GDK default PNG asset is available, asks Godot's file
 system to rescan, then launches `GameConfigEditor.exe`. When the file already
 exists, it launches `GameConfigEditor.exe` against the current config.
 
-**When to use it:** Use it when bootstrapping a GDK project identity, editing
-store logos, or updating the executable, identity, product, or Xbox Live fields
+**When to use it:** Use it when bootstrapping a Microsoft GDK project identity, editing
+store logos, or updating the executable, identity, product, or XBOX Live fields
 inside the config.
 
 **Required prerequisites:** Install the Microsoft GDK so
 `GameConfigEditor.exe` is available. The project directory must be writable
 when creating the initial template. Partner Center sign-in is not required just
-to create or edit the local file, but store association and Xbox Live IDs must
+to create or edit the local file, but store association and XBOX Live IDs must
 come from your Partner Center title when you are preparing a real package.
 
 **Expected output / side effects:** Template creation writes
 `MicrosoftGame.config` and a `storelogos\` folder in the project if they do not
 exist, then best-effort populates the placeholder logo files when
 `GameConfigEditorDependencies\default480x480.png` is available in the selected
-GDK bin directory. Editing through GameConfigEditor may rewrite the config and
+Microsoft GDK bin directory. Editing through GameConfigEditor may rewrite the config and
 logo files. If the editor executable is missing or fails to launch, the Godot
 output panel shows an error.
 
@@ -90,13 +90,13 @@ entry.
 
 ### Change Sandbox…
 
-**What it does:** Opens the GDK Sandbox Switcher dialog. The dialog reads the
+**What it does:** Opens the Microsoft GDK Sandbox Switcher dialog. The dialog reads the
 current PC sandbox with `XblPCSandbox.exe /get`, can switch to a target
 sandbox with `/set <sandbox-id> /noApps`, and can switch back to RETAIL with
 `/retail /noApps`.
 
-**When to use it:** Use it before testing Xbox Live services with development
-sandboxes, or before returning the PC to retail Xbox Live services.
+**When to use it:** Use it before testing XBOX Live services with development
+sandboxes, or before returning the PC to retail XBOX Live services.
 
 **Required prerequisites:** Install the Microsoft GDK so
 `XblPCSandbox.exe` is available. Switching sandboxes is machine-wide and
@@ -105,11 +105,11 @@ Partner Center title that your developer account can access.
 
 **Expected output / side effects:** The dialog displays the current sandbox,
 confirms any switch, and reports success or failure. A successful switch changes
-the PC's machine-wide Xbox sandbox for every user, Xbox tool, and Xbox-aware
-app on the machine. Switch back to RETAIL before using retail Xbox Live
+the PC's machine-wide XBOX sandbox for every user, XBOX tool, and XBOX-aware
+app on the machine. Switch back to RETAIL before using retail XBOX Live
 services.
 
-**Deeper docs:** See [Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
+**Deeper docs:** See [XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
 for account and sandbox setup. The headless equivalent is the `sandbox` verb in
 [Packaging Plugin](plugin.md#verbs).
 
@@ -202,13 +202,13 @@ title, publishing them to a development sandbox, or validating achievement
 unlock flows with test accounts.
 
 **Required prerequisites:** Network access. Following the guide requires a
-Partner Center title, access to Xbox Live configuration for that title, a
+Partner Center title, access to XBOX Live configuration for that title, a
 development sandbox, and a matching test account.
 
 **Expected output / side effects:** The browser opens a Microsoft Learn page.
 No local project files change.
 
-**Deeper docs:** See [Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
+**Deeper docs:** See [XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
 for the local sandbox and test-account prerequisites.
 
 ### PlayFab Game Manager
@@ -229,16 +229,16 @@ Changes happen only if you modify title data in the portal.
 **Deeper docs:** See [PlayFab title prerequisites](../playfab/prerequisites.md)
 for the title configuration expected by this repository's PlayFab tutorials.
 
-### PlayFab IDs from Xbox Live
+### PlayFab IDs from XBOX Live
 
-**What it does:** Opens the PlayFab REST API documentation for mapping Xbox Live
+**What it does:** Opens the PlayFab REST API documentation for mapping XBOX Live
 IDs to PlayFab IDs.
 
-**When to use it:** Use it when reconciling Xbox identities with PlayFab player
+**When to use it:** Use it when reconciling XBOX identities with PlayFab player
 records or debugging cross-service account linking.
 
 **Required prerequisites:** Network access. Calling the documented API requires
-PlayFab credentials and the appropriate Xbox Live identity data.
+PlayFab credentials and the appropriate XBOX Live identity data.
 
 **Expected output / side effects:** The browser opens a Microsoft Learn API
 reference. No local files change.
@@ -246,16 +246,16 @@ reference. No local files change.
 **Deeper docs:** See [PlayFab title prerequisites](../playfab/prerequisites.md)
 and the PlayFab user-session docs in [PlayFab Plugin](../playfab/plugin.md).
 
-### PlayFab + GDK Quickstart
+### PlayFab + Microsoft GDK Quickstart
 
-**What it does:** Opens the PlayFab SDK for GDK quickstart in the system
+**What it does:** Opens the PlayFab SDK for Microsoft GDK quickstart in the system
 browser.
 
-**When to use it:** Use it when you need Microsoft's native PlayFab + GDK
+**When to use it:** Use it when you need Microsoft's native PlayFab + Microsoft GDK
 integration context while comparing this repository's Godot addon layer to the
 underlying platform SDK guidance.
 
-**Required prerequisites:** Network access. Running native GDK SDK samples also
+**Required prerequisites:** Network access. Running native Microsoft GDK SDK samples also
 requires the Microsoft GDK and a PlayFab title.
 
 **Expected output / side effects:** The browser opens Microsoft Learn. No local

--- a/docs/packaging/plugin.md
+++ b/docs/packaging/plugin.md
@@ -1,4 +1,4 @@
-# Godot GDK Packaging — User Reference
+# Godot Microsoft GDK Packaging — User Reference
 
 `addons\godot_gdk_packaging\` exposes Microsoft GDK PC packaging from
 Godot — Microsoft Game Config, makepkg (genmap / pack / validate), wdapp
@@ -8,7 +8,7 @@ runner you can drive from scripts and CI, with a top-level editor `GDK` menu
 for Game Config, sandbox/package management, and documentation shortcuts.
 
 This page is the headless-surface reference. For editor UI coverage, see
-[Godot GDK Packaging — Editor `GDK` Menu](editor-menu.md).
+[Godot Microsoft GDK Packaging — Editor `GDK` Menu](editor-menu.md).
 
 ## Invocation
 
@@ -88,9 +88,9 @@ on every verb: `--help` (`-h`), `--no-json`, `--config <path>`,
 
 The `export` verb uses Godot's Windows Desktop exporter, so install the Godot
 4.6.1 export templates under `%APPDATA%\Godot\export_templates\` first.
-MSIXVC and loose-registration flows also need the public GDK toolchain on
+MSIXVC and loose-registration flows also need the public Microsoft GDK toolchain on
 `PATH` (`makepkg.exe`, `wdapp.exe`, `XblPCSandbox.exe`), or `GDK_BIN` pointing
-at the GDK `bin\` directory.
+at the Microsoft GDK `bin\` directory.
 
 | Verb               | Required flags                 | Optional flags                                                                 | Description                                                       |
 |--------------------|--------------------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------|
@@ -237,10 +237,10 @@ example `..\..\outside.png`) are refused with an error before staging begins.
 | Variable                          | Purpose                                                                       |
 |-----------------------------------|-------------------------------------------------------------------------------|
 | `GODOT_CONSOLE` / `GODOT_BIN` / `GODOT` | Shell-forwarder Godot discovery (see Invocation).                       |
-| `GDK_BIN`                         | Override the GDK install bin directory (otherwise `C:\Program Files (x86)\Microsoft GDK\bin`). |
-| `GameDKCoreLatest`                | Standard GDK install marker; used to detect the GDK version when present.     |
+| `GDK_BIN`                         | Override the Microsoft GDK install bin directory (otherwise `C:\Program Files (x86)\Microsoft GDK\bin`). |
+| `GameDKCoreLatest`                | Standard Microsoft GDK install marker; used to detect the Microsoft GDK version when present.     |
 
-## GDK tool discovery
+## Microsoft GDK tool discovery
 
 `gdk_toolchain.gd` checks `GDK_BIN` first and falls back to
 `C:\Program Files (x86)\Microsoft GDK\bin`. The toolchain is considered
@@ -293,7 +293,7 @@ addons\godot_gdk_packaging\gdkpkg.cmd terminate --package-name MyPublisher.MyGam
 
   Set one of `GODOT_CONSOLE`, `GODOT_BIN`, or `GODOT`, or pass `--godot <path>`.
 - **`EXIT_CONFIG: wdapp.exe not found`.** Set `GDK_BIN` to point at your
-  GDK install's `bin\` directory, or install the GDK to the default
+  Microsoft GDK install's `bin\` directory, or install the Microsoft GDK to the default
   location.
 - **`terminate` falls back to `wdapp` failure instead of `taskkill`.** The
   fallback only targets the exact executable named by `MicrosoftGame.config`
@@ -306,14 +306,14 @@ addons\godot_gdk_packaging\gdkpkg.cmd terminate --package-name MyPublisher.MyGam
   host project hasn't been imported yet. Run `godot --headless --import`
   once against that host. Form A (`-s ...`) still works without prior import,
   but it does not perform the import or register the class for later form-B use.
-- **GDK runtime warnings on every invocation** (e.g. silent sign-in
+- **Microsoft GDK runtime warnings on every invocation** (e.g. silent sign-in
   cancellation). Those come from the host project's autoloaded
   `GDKBootstrap`. They are unrelated to the packaging verb result and
   can be ignored when inspecting `PACKAGING_RESULT_JSON:`.
 
 ## See also
 
-- [Godot GDK Packaging — Editor `GDK` Menu](editor-menu.md) — what each
+- [Godot Microsoft GDK Packaging — Editor `GDK` Menu](editor-menu.md) — what each
   editor menu item does and what prerequisites it needs.
 - `.github\instructions\godot-gdk-packaging.instructions.md` — repo-wide
   rules for contributors editing the addon.

--- a/docs/platform/xbox-sandbox-and-test-accounts.md
+++ b/docs/platform/xbox-sandbox-and-test-accounts.md
@@ -1,7 +1,7 @@
-# Xbox sandbox and test-account setup
+# XBOX sandbox and test-account setup
 
 This guide is the canonical, addon-agnostic walk-through for getting a PC
-into the right state to test Xbox Live services from any Godot project
+into the right state to test XBOX Live services from any Godot project
 that uses `godot_gdk` (your own project or, once PR 3 of the
 tutorial-driven sample revamp lands, `sample/tutorial_app/`).
 
@@ -10,11 +10,11 @@ see [`gdk/sample-setup.md`](../gdk/sample-setup.md). This document
 covers what your **PC** and **test account** need on top of that.
 
 > **No Partner Center title yet?** Start with the
-> [ID@Xbox program](https://www.xbox.com/en-us/developers/id), register
+> [ID@XBOX program](https://www.xbox.com/en-us/developers/id), register
 > your title in the
 > [Partner Center dashboard](https://partner.microsoft.com/dashboard),
 > and follow
-> [Microsoft GDK — Configuring Xbox services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
+> [Microsoft GDK — Configuring XBOX services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
 > and
 > [Microsoft GDK — Setting up sandboxes](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/sandboxes/live-setup-sandbox)
 > for the Microsoft-side walkthrough. The IDs they produce are what
@@ -27,13 +27,13 @@ covers what your **PC** and **test account** need on top of that.
 | Requirement | How to check |
 |---|---|
 | Microsoft GDK installed | `Get-ChildItem "C:\Program Files (x86)\Microsoft GDK\bin\XblPCSandbox.exe"` returns a path |
-| Xbox app installed | `Get-AppxPackage Microsoft.GamingApp` returns a package |
+| XBOX app installed | `Get-AppxPackage Microsoft.GamingApp` returns a package |
 | Windows Developer Mode enabled | `wdapp list` runs without printing `Developer mode is not enabled.` (see [Enabling Windows Developer Mode](#enabling-windows-developer-mode)) |
 | Godot Windows export templates installed | Godot editor → **Project → Manage Export Templates… → Download and Install** finds a 4.x build matching your editor (one-time setup; required for the loose-layout workflow) |
-| Partner Center title (with at least one published Service Configuration) | You can read the SCID + Sandbox ID off Partner Center → Xbox Live → Xbox Live Setup |
-| At least one **Xbox test account** provisioned in your sandbox | Partner Center → Account Settings → Xbox Live → Test Accounts |
+| Partner Center title (with at least one published Service Configuration) | You can read the SCID + Sandbox ID off Partner Center → XBOX Live → XBOX Live Setup |
+| At least one **XBOX test account** provisioned in your sandbox | Partner Center → Account Settings → XBOX Live → Test Accounts |
 
-> Xbox Live calls fail (HRESULT `0x80070490` and friends) if any one of
+> XBOX Live calls fail (HRESULT `0x80070490` and friends) if any one of
 > these is missing. The samples log that warning at boot but stay playable
 > in offline mode — useful for local UI work, but cloud features won't fire.
 
@@ -42,7 +42,7 @@ covers what your **PC** and **test account** need on top of that.
 ## 1. Set your PC sandbox
 
 Your PC has to be in the same sandbox as the test account you plan to sign
-into. The sandbox ID comes straight from Partner Center → Xbox Live → Xbox
+into. The sandbox ID comes straight from Partner Center → XBOX Live → XBOX
 Live Setup (e.g. `XDKS.1` or `MYTEAM.0`). For the Microsoft-side reference
 on the sandbox model see
 [Microsoft GDK — Setting up sandboxes](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/sandboxes/live-setup-sandbox);
@@ -61,13 +61,13 @@ The sandbox switch is per-PC and persists across reboots. You only need to
 re-run it when you move between titles or testing environments.
 
 > **Returning to retail.** Use `RETAIL` as the sandbox ID to put the
-> machine back into the public Xbox Live environment.
+> machine back into the public XBOX Live environment.
 
 ---
 
 ## 2. Sign in a test account
 
-Xbox Live differentiates "real" Microsoft Accounts (MSAs) from **test
+XBOX Live differentiates "real" Microsoft Accounts (MSAs) from **test
 accounts** that exist only inside Partner Center. The samples expect a test
 account because:
 
@@ -77,18 +77,18 @@ account because:
 
 There are two ways to sign in:
 
-### Option A — via the Xbox app (recommended for interactive testing)
+### Option A — via the XBOX app (recommended for interactive testing)
 
 1. Make sure the PC is in the right sandbox (step 1 above).
-2. Open the **Xbox app** (`Microsoft.GamingApp`).
+2. Open the **XBOX app** (`Microsoft.GamingApp`).
 3. Sign out of any signed-in account.
 4. Sign back in with the **test account email + password** from
-   Partner Center → Account Settings → Xbox Live → Test Accounts.
-5. The Xbox app should now show the test account's gamertag.
+   Partner Center → Account Settings → XBOX Live → Test Accounts.
+5. The XBOX app should now show the test account's gamertag.
 
-When you launch a Godot for XBOX on PC sample after that, the bootstrap autoload calls
+When you launch a Godot XBOX sample after that, the bootstrap autoload calls
 `GDK.users.add_default_user_async()` (silent sign-in). If that succeeds the
-title screen HUD shows **GDK READY · SIGNED IN** with the test account's
+title screen HUD shows **Microsoft GDK READY · SIGNED IN** with the test account's
 gamertag and avatar. **If silent sign-in fails** — common when running
 unpackaged from the editor or right after a sandbox switch — the bootstrap
 automatically falls back to `GDK.users.add_user_with_ui_async()`, which
@@ -114,8 +114,8 @@ This is the same flow `tools\reset_player_data.ps1` uses internally.
 Three quick checks confirm the PC is wired up:
 
 1. **Sandbox** — `XblPCSandbox.exe` (no args) prints the sandbox ID.
-2. **Account** — Xbox app shows the test account's gamertag.
-3. **In your title** — launch any GDK-using Godot project (your own,
+2. **Account** — XBOX app shows the test account's gamertag.
+3. **In your title** — launch any Microsoft GDK-using Godot project (your own,
    or one of the tutorial samples once PR 3 lands) and check the
    title-screen HUD:
 
@@ -123,12 +123,12 @@ Three quick checks confirm the PC is wired up:
    |---|---|
    | `GDK OFFLINE` (red ring) | Extension didn't load, or `is_initialized()` returned false. Almost always a missing Title ID / SCID in `sample_config.cfg`. |
    | `GDK INIT…` (yellow ring) | Extension loaded but the runtime didn't reach the `initialized` signal yet. Should resolve in <1 s. Stuck here = check the `[GDK]` warnings in stdout. |
-   | `GDK READY · SIGNED OUT` | Runtime up, but `add_default_user_async` couldn't bind a user. **The most common cause is running the title from the Godot editor (F5).** PC GDK requires the running process to be a registered package or loose layout; an unpackaged `godot.exe` has no Title ID context, so Xbox services silently degrade. See [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. |
+   | `GDK READY · SIGNED OUT` | Runtime up, but `add_default_user_async` couldn't bind a user. **The most common cause is running the title from the Godot editor (F5).** PC Microsoft GDK requires the running process to be a registered package or loose layout; an unpackaged `godot.exe` has no Title ID context, so XBOX services silently degrade. See [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. |
    | `GDK READY · SIGNED IN` + gamertag + avatar | Everything is wired up correctly. |
 
 If the HUD says `SIGNED OUT`, the **first** thing to check is whether you
 launched via the editor's play button. F5 from the editor cannot bind a
-signed-in Xbox user — that's a hard PC GDK constraint, not a sample bug.
+signed-in XBOX user — that's a hard PC Microsoft GDK constraint, not a sample bug.
 Use [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout)
 instead. After that, work through the
 [Troubleshooting](#troubleshooting) checklist below if it's still wrong.
@@ -137,11 +137,11 @@ instead. After that, work through the
 
 ## Run the title as a registered loose layout
 
-PC GDK requires the running process to live inside a **registered package
+PC Microsoft GDK requires the running process to live inside a **registered package
 or loose-layout build** before it can bind a signed-in user. Launching a
 sample with the Godot editor's play button (F5) runs `godot.exe`
-unpackaged, so `XGameGetXboxTitleId` returns failure inside the GDK
-extension and Xbox services silently degrade — the runtime still emits
+unpackaged, so `XGameGetXboxTitleId` returns failure inside the Microsoft GDK
+extension and XBOX services silently degrade — the runtime still emits
 its `initialized` signal (so the HUD reads `GDK READY`) but no user can
 ever bind (`SIGNED OUT`).
 
@@ -209,9 +209,9 @@ scratch), use the bundled helper:
 This signs in via `XblDevAccount.exe`, then calls `XblPlayerDataReset.exe`
 to wipe data for a given XUID + sandbox + SCID. You'll be prompted for:
 
-- **SCID** — Partner Center → Xbox Live → Xbox Live Setup
+- **SCID** — Partner Center → XBOX Live → XBOX Live Setup
 - **Sandbox ID** — same one you set in step 1
-- **XUID** — the test account's Xbox User ID
+- **XUID** — the test account's XBOX User ID
 
 > **Resets only work on test accounts in a development sandbox.** Retail
 > accounts are immutable. Restart the game after a reset for the new state
@@ -223,13 +223,13 @@ to wipe data for a given XUID + sandbox + SCID. You'll be prompted for:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `[GDK] Xbox title ID is unavailable; Xbox services were not initialized.` (`0x80070490`) | `sample_config.cfg` is empty / missing Title ID / SCID. | Run `tools\setup_sample.ps1` or use the **GDK Setup** editor panel ([`gdk/sample-setup.md`](../gdk/sample-setup.md)). |
-| HUD shows `GDK READY · SIGNED OUT` even though the Xbox app is signed in to the test account | The title is running unpackaged (e.g. via Godot editor F5). PC GDK rejects sign-in attempts when `XGameGetXboxTitleId` can't bind to a registered package; the runtime layer still initializes ("READY") but Xbox services internally degrade. The Xbox app's own broker tokens are unrelated — they only apply to the Xbox app process. | Register a loose layout via `addons\godot_gdk_packaging\gdkpkg.cmd register_loose` and launch through `wdapp` — see [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. The bootstrap also falls back to the system identity picker if silent sign-in fails inside a registered title; use that to switch accounts mid-session. |
-| HUD shows `GDK READY · SIGNED OUT` from a *registered* loose layout, and the system identity picker never appears | Windows Developer Mode is disabled. PC GDK tooling (including `wdapp` and the user broker hooks) refuses to operate, and the bootstrap's UI fallback fires but the system swallows the picker. The classic symptom is `wdapp list` printing `Developer mode is not enabled. To use this tool, please enable developer mode in the Windows Settings app.` | Turn on Developer Mode (Settings → For Developers → **Developer Mode**), or run the equivalent registry edit from an elevated PowerShell — see [Enabling Windows Developer Mode](#enabling-windows-developer-mode) below. Then re-register and relaunch the sample. |
-| `XblPCSandbox.exe` returns `Error: Gaming Services must be updated. Update from https://aka.ms/gamingservices.` even though the Store shows Gaming Services as **Installed** | `XblPCSandbox.exe` is paired one-to-one with the `Microsoft.GamingServices` build that shipped in the same GDK edition (e.g. GDK 260400 ships `XblPCSandbox 1.0.2603.20002` + `GamingServices 35.112.20003.0`). The Microsoft Store ships a different consumer build (e.g. `35.112.23002.0`) that omits the developer/sandbox surface, so the GDK tool refuses to talk to it regardless of how new the Store version is. The bundled `InstallGamingServicesBundle.ps1` script is broken — it ships with literal `%GAMING_SERVICES_VERSION%` placeholders and bails out before doing anything useful. | Replace the consumer package with the GDK-shipped bundle directly. Open an **elevated** PowerShell and run the snippet under [Replacing Gaming Services with the GDK-shipped build](#replacing-gaming-services-with-the-gdk-shipped-build) below. After the script finishes, `XblPCSandbox.exe` will work and you can switch sandboxes normally. |
+| `[GDK] Xbox title ID is unavailable; Xbox services were not initialized.` (`0x80070490`) | `sample_config.cfg` is empty / missing Title ID / SCID. | Run `tools\setup_sample.ps1` or use the **Microsoft GDK Setup** editor panel ([`gdk/sample-setup.md`](../gdk/sample-setup.md)). |
+| HUD shows `GDK READY · SIGNED OUT` even though the XBOX app is signed in to the test account | The title is running unpackaged (e.g. via Godot editor F5). PC Microsoft GDK rejects sign-in attempts when `XGameGetXboxTitleId` can't bind to a registered package; the runtime layer still initializes ("READY") but XBOX services internally degrade. The XBOX app's own broker tokens are unrelated — they only apply to the XBOX app process. | Register a loose layout via `addons\godot_gdk_packaging\gdkpkg.cmd register_loose` and launch through `wdapp` — see [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. The bootstrap also falls back to the system identity picker if silent sign-in fails inside a registered title; use that to switch accounts mid-session. |
+| HUD shows `GDK READY · SIGNED OUT` from a *registered* loose layout, and the system identity picker never appears | Windows Developer Mode is disabled. PC Microsoft GDK tooling (including `wdapp` and the user broker hooks) refuses to operate, and the bootstrap's UI fallback fires but the system swallows the picker. The classic symptom is `wdapp list` printing `Developer mode is not enabled. To use this tool, please enable developer mode in the Windows Settings app.` | Turn on Developer Mode (Settings → For Developers → **Developer Mode**), or run the equivalent registry edit from an elevated PowerShell — see [Enabling Windows Developer Mode](#enabling-windows-developer-mode) below. Then re-register and relaunch the sample. |
+| `XblPCSandbox.exe` returns `Error: Gaming Services must be updated. Update from https://aka.ms/gamingservices.` even though the Store shows Gaming Services as **Installed** | `XblPCSandbox.exe` is paired one-to-one with the `Microsoft.GamingServices` build that shipped in the same Microsoft GDK edition (e.g. Microsoft GDK 260400 ships `XblPCSandbox 1.0.2603.20002` + `GamingServices 35.112.20003.0`). The Microsoft Store ships a different consumer build (e.g. `35.112.23002.0`) that omits the developer/sandbox surface, so the Microsoft GDK tool refuses to talk to it regardless of how new the Store version is. The bundled `InstallGamingServicesBundle.ps1` script is broken — it ships with literal `%GAMING_SERVICES_VERSION%` placeholders and bails out before doing anything useful. | Replace the consumer package with the Microsoft GDK-shipped bundle directly. Open an **elevated** PowerShell and run the snippet under [Replacing Gaming Services with the Microsoft GDK-shipped build](#replacing-gaming-services-with-the-microsoft-gdk-shipped-build) below. After the script finishes, `XblPCSandbox.exe` will work and you can switch sandboxes normally. |
 | `XblPCSandbox.exe : Access is denied.` | PowerShell is not elevated. | Re-launch PowerShell as Administrator before running `XblPCSandbox.exe`. |
 | Sandbox flips back to `RETAIL` after reboot | Newer Windows builds need an explicit re-set after major OS updates. | Re-run step 1. |
-| Test account does not appear in Partner Center | Sandbox membership wasn't granted. | In Partner Center → Account Settings → Xbox Live → Test Accounts → click the account → **Sandbox membership** → add the sandbox you're using. |
+| Test account does not appear in Partner Center | Sandbox membership wasn't granted. | In Partner Center → Account Settings → XBOX Live → Test Accounts → click the account → **Sandbox membership** → add the sandbox you're using. |
 | `XblDevAccount.exe signin` fails with `0x87DD0006` | Test account password reset on Partner Center but local cache is stale. | `XblDevAccount.exe signout`, then sign back in. |
 | Multiplayer activity warning at boot (`0x80070032`) | `MultiplayerActivity` requires a properly registered MSA App ID + protocol activation. | Safe to ignore for non-multiplayer samples. For real multiplayer testing, follow `gdk/sample-setup.md`. |
 
@@ -237,7 +237,7 @@ to wipe data for a given XUID + sandbox + SCID. You'll be prompted for:
 
 ## Enabling Windows Developer Mode
 
-PC GDK tooling refuses to operate when Windows Developer Mode is disabled.
+PC Microsoft GDK tooling refuses to operate when Windows Developer Mode is disabled.
 The most visible symptom is `wdapp list` printing:
 
 ```
@@ -268,13 +268,13 @@ the first time silent sign-in fails.
 
 ---
 
-## Replacing Gaming Services with the GDK-shipped build
+## Replacing Gaming Services with the Microsoft GDK-shipped build
 
 If `XblPCSandbox.exe` reports `Error: Gaming Services must be updated.` (see
 the troubleshooting table for why this happens even when the Store shows the
 package as installed), the Store-distributed `Microsoft.GamingServices`
 package needs to be replaced with the build that shipped in your installed
-GDK edition.
+Microsoft GDK edition.
 
 > **Heads-up.** The `InstallGamingServicesBundle.ps1` script in
 > `...\windows\redist\` is shipped broken (literal `%GAMING_SERVICES_VERSION%`
@@ -308,8 +308,8 @@ Get-AppxPackage Microsoft.GamingServices | Select-Object Name, Version
 & 'C:\Program Files (x86)\Microsoft GDK\bin\XblPCSandbox.exe'
 ```
 
-The `Get-AppxPackage` line should now print the GDK-paired version (e.g.
-`35.112.20003.0` for GDK 260400) instead of the consumer build, and
+The `Get-AppxPackage` line should now print the Microsoft GDK-paired version (e.g.
+`35.112.20003.0` for Microsoft GDK 260400) instead of the consumer build, and
 `XblPCSandbox.exe` should print `Current Sandbox: RETAIL` instead of the
 "Gaming Services must be updated" error. You can then switch sandboxes:
 
@@ -320,7 +320,7 @@ The `Get-AppxPackage` line should now print the GDK-paired version (e.g.
 > **Store auto-update.** The Microsoft Store may eventually re-push the
 > newer consumer build of `Microsoft.GamingServices`, which would put you
 > back in the broken state. If that happens, just re-run the snippet above.
-> A future GDK edition is expected to ship a matching newer build.
+> A future Microsoft GDK edition is expected to ship a matching newer build.
 
 ---
 
@@ -330,5 +330,5 @@ The `Get-AppxPackage` line should now print the GDK-paired version (e.g.
   Partner Center configuration (Title ID, SCID, MSA App ID, etc.).
 - [`gdk/async-system.md`](../gdk/async-system.md) — how the
   bootstrap silent sign-in op completes.
-- [`gdk/api-reference.md`](../gdk/api-reference.md) — full GDK
+- [`gdk/api-reference.md`](../gdk/api-reference.md) — full Microsoft GDK
   surface (`GDKUsers`, `GDKUser`, `get_gamer_picture_async`, …).

--- a/docs/platform/xbox-sandbox-and-test-accounts.md
+++ b/docs/platform/xbox-sandbox-and-test-accounts.md
@@ -123,12 +123,12 @@ Three quick checks confirm the PC is wired up:
    |---|---|
    | `GDK OFFLINE` (red ring) | Extension didn't load, or `is_initialized()` returned false. Almost always a missing Title ID / SCID in `sample_config.cfg`. |
    | `GDK INIT…` (yellow ring) | Extension loaded but the runtime didn't reach the `initialized` signal yet. Should resolve in <1 s. Stuck here = check the `[GDK]` warnings in stdout. |
-   | `GDK READY · SIGNED OUT` | Runtime up, but `add_default_user_async` couldn't bind a user. **The most common cause is running the title from the Godot editor (F5).** PC Microsoft GDK requires the running process to be a registered package or loose layout; an unpackaged `godot.exe` has no Title ID context, so XBOX services silently degrade. See [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. |
+   | `GDK READY · SIGNED OUT` | Runtime up, but `add_default_user_async` couldn't bind a user. **The most common cause is running the title from the Godot editor (F5).** Microsoft GDK requires the running process to be a registered package or loose layout; an unpackaged `godot.exe` has no Title ID context, so XBOX services silently degrade. See [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. |
    | `GDK READY · SIGNED IN` + gamertag + avatar | Everything is wired up correctly. |
 
 If the HUD says `SIGNED OUT`, the **first** thing to check is whether you
 launched via the editor's play button. F5 from the editor cannot bind a
-signed-in XBOX user — that's a hard PC Microsoft GDK constraint, not a sample bug.
+signed-in XBOX user — that's a hard Microsoft GDK constraint, not a sample bug.
 Use [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout)
 instead. After that, work through the
 [Troubleshooting](#troubleshooting) checklist below if it's still wrong.
@@ -137,7 +137,7 @@ instead. After that, work through the
 
 ## Run the title as a registered loose layout
 
-PC Microsoft GDK requires the running process to live inside a **registered package
+Microsoft GDK requires the running process to live inside a **registered package
 or loose-layout build** before it can bind a signed-in user. Launching a
 sample with the Godot editor's play button (F5) runs `godot.exe`
 unpackaged, so `XGameGetXboxTitleId` returns failure inside the Microsoft GDK
@@ -224,8 +224,8 @@ to wipe data for a given XUID + sandbox + SCID. You'll be prompted for:
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `[GDK] Xbox title ID is unavailable; Xbox services were not initialized.` (`0x80070490`) | `sample_config.cfg` is empty / missing Title ID / SCID. | Run `tools\setup_sample.ps1` or use the **Microsoft GDK Setup** editor panel ([`gdk/sample-setup.md`](../gdk/sample-setup.md)). |
-| HUD shows `GDK READY · SIGNED OUT` even though the XBOX app is signed in to the test account | The title is running unpackaged (e.g. via Godot editor F5). PC Microsoft GDK rejects sign-in attempts when `XGameGetXboxTitleId` can't bind to a registered package; the runtime layer still initializes ("READY") but XBOX services internally degrade. The XBOX app's own broker tokens are unrelated — they only apply to the XBOX app process. | Register a loose layout via `addons\godot_gdk_packaging\gdkpkg.cmd register_loose` and launch through `wdapp` — see [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. The bootstrap also falls back to the system identity picker if silent sign-in fails inside a registered title; use that to switch accounts mid-session. |
-| HUD shows `GDK READY · SIGNED OUT` from a *registered* loose layout, and the system identity picker never appears | Windows Developer Mode is disabled. PC Microsoft GDK tooling (including `wdapp` and the user broker hooks) refuses to operate, and the bootstrap's UI fallback fires but the system swallows the picker. The classic symptom is `wdapp list` printing `Developer mode is not enabled. To use this tool, please enable developer mode in the Windows Settings app.` | Turn on Developer Mode (Settings → For Developers → **Developer Mode**), or run the equivalent registry edit from an elevated PowerShell — see [Enabling Windows Developer Mode](#enabling-windows-developer-mode) below. Then re-register and relaunch the sample. |
+| HUD shows `GDK READY · SIGNED OUT` even though the XBOX app is signed in to the test account | The title is running unpackaged (e.g. via Godot editor F5). Microsoft GDK rejects sign-in attempts when `XGameGetXboxTitleId` can't bind to a registered package; the runtime layer still initializes ("READY") but XBOX services internally degrade. The XBOX app's own broker tokens are unrelated — they only apply to the XBOX app process. | Register a loose layout via `addons\godot_gdk_packaging\gdkpkg.cmd register_loose` and launch through `wdapp` — see [Run the title as a registered loose layout](#run-the-title-as-a-registered-loose-layout) below. The bootstrap also falls back to the system identity picker if silent sign-in fails inside a registered title; use that to switch accounts mid-session. |
+| HUD shows `GDK READY · SIGNED OUT` from a *registered* loose layout, and the system identity picker never appears | Windows Developer Mode is disabled. Microsoft GDK tooling (including `wdapp` and the user broker hooks) refuses to operate, and the bootstrap's UI fallback fires but the system swallows the picker. The classic symptom is `wdapp list` printing `Developer mode is not enabled. To use this tool, please enable developer mode in the Windows Settings app.` | Turn on Developer Mode (Settings → For Developers → **Developer Mode**), or run the equivalent registry edit from an elevated PowerShell — see [Enabling Windows Developer Mode](#enabling-windows-developer-mode) below. Then re-register and relaunch the sample. |
 | `XblPCSandbox.exe` returns `Error: Gaming Services must be updated. Update from https://aka.ms/gamingservices.` even though the Store shows Gaming Services as **Installed** | `XblPCSandbox.exe` is paired one-to-one with the `Microsoft.GamingServices` build that shipped in the same Microsoft GDK edition (e.g. Microsoft GDK 260400 ships `XblPCSandbox 1.0.2603.20002` + `GamingServices 35.112.20003.0`). The Microsoft Store ships a different consumer build (e.g. `35.112.23002.0`) that omits the developer/sandbox surface, so the Microsoft GDK tool refuses to talk to it regardless of how new the Store version is. The bundled `InstallGamingServicesBundle.ps1` script is broken — it ships with literal `%GAMING_SERVICES_VERSION%` placeholders and bails out before doing anything useful. | Replace the consumer package with the Microsoft GDK-shipped bundle directly. Open an **elevated** PowerShell and run the snippet under [Replacing Gaming Services with the Microsoft GDK-shipped build](#replacing-gaming-services-with-the-microsoft-gdk-shipped-build) below. After the script finishes, `XblPCSandbox.exe` will work and you can switch sandboxes normally. |
 | `XblPCSandbox.exe : Access is denied.` | PowerShell is not elevated. | Re-launch PowerShell as Administrator before running `XblPCSandbox.exe`. |
 | Sandbox flips back to `RETAIL` after reboot | Newer Windows builds need an explicit re-set after major OS updates. | Re-run step 1. |
@@ -237,7 +237,7 @@ to wipe data for a given XUID + sandbox + SCID. You'll be prompted for:
 
 ## Enabling Windows Developer Mode
 
-PC Microsoft GDK tooling refuses to operate when Windows Developer Mode is disabled.
+Microsoft GDK tooling refuses to operate when Windows Developer Mode is disabled.
 The most visible symptom is `wdapp list` printing:
 
 ```

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -13,13 +13,13 @@ This is the landing page for the `godot_playfab` docs set.
 - shared Game Saves runtime lifecycle through `PFGameSaveFilesInitialize` and `PFGameSaveFilesUninitializeAsync`
 - default auto-dispatch through `playfab/runtime/embed_dispatch`
 - project-settings-backed PlayFab config through `playfab/runtime/title_id` and `playfab/runtime/endpoint`
-- manual Xbox-backed PlayFab sign-in through `PlayFab.users.sign_in_with_xuser_async(...)`
+- manual XBOX-backed PlayFab sign-in through `PlayFab.users.sign_in_with_xuser_async(...)`
 - custom-ID PlayFab sign-in through `PlayFab.users.sign_in_with_custom_id_async(...)`
-- cached `PlayFabUser` wrappers keyed by local Xbox user id or custom id
+- cached `PlayFabUser` wrappers keyed by local XBOX user id or custom id
 - Game Saves add/sync, upload, folder/quota queries, cloud connectivity queries, save description updates, and cloud reset through `PlayFab.game_saves`
 - leaderboard submit, global query, around-user query, and friends/social leaderboard query
 - client-safe PlayFab service wrappers under `PlayFab.accounts`, `PlayFab.catalog`, `PlayFab.cloud_script`, `PlayFab.entity_data`, `PlayFab.experimentation`, `PlayFab.friends`, `PlayFab.groups`, `PlayFab.inventory`, `PlayFab.localization`, `PlayFab.player_data`, `PlayFab.statistics`, and `PlayFab.title_data`
-- `PlayFab.events` as a reserved service namespace; the current GDK PlayFab headers do not expose an active client event/telemetry operation in the client wrapper scope
+- `PlayFab.events` as a reserved service namespace; the current Microsoft GDK PlayFab headers do not expose an active client event/telemetry operation in the client wrapper scope
 - PlayFab Multiplayer initialization, lobby create/join/search, lobby-owned leave and property updates, match-ticket-owned cancel/status refresh, and explicit arranged-lobby joins
 - PlayFab Party network host (`create_and_join_network_async`) and join (`join_network_async`) flows over the PartyManager runtime, with peer-id handshake, descriptor publishing, chat controls (voice/text/transcription), mute, and permission management; the per-network peer object is a Godot `MultiplayerPeerExtension`
 - GUT coverage under `tests\godot\playfab\tests\`
@@ -59,7 +59,7 @@ The addon registers these Project Settings. Only the first two are read by `Play
 
 The `GodotPlayFab` editor plugin installs the `PlayFabBootstrap` autoload at `res://addons/godot_playfab/runtime/playfab_bootstrap.gd` when enabled, mirroring the `GDKBootstrap` pattern. Disabling the plugin removes the autoload again.
 
-`PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled when returning to a title screen or changing test fixtures: shutdown tears down PlayFab Core, Services, Game Save Files, the shared task queue, and cached users, then a later initialize recreates them. The underlying GDK `XGameRuntimeInitialize` reference is process-lifetime state, so the first successful runtime initialization acquires it and extension teardown releases it once. This mirrors `godot_gdk` and lets both addons coexist safely; each addon owns exactly one matching GDK runtime reference.
+`PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled when returning to a title screen or changing test fixtures: shutdown tears down PlayFab Core, Services, Game Save Files, the shared task queue, and cached users, then a later initialize recreates them. The underlying Microsoft GDK `XGameRuntimeInitialize` reference is process-lifetime state, so the first successful runtime initialization acquires it and extension teardown releases it once. This mirrors `godot_gdk` and lets both addons coexist safely; each addon owns exactly one matching Microsoft GDK runtime reference.
 
 ## Public GDScript surface
 
@@ -139,7 +139,7 @@ if not stats_result.ok:
     push_warning(stats_result.message)
 ```
 
-Game Saves still requires an Xbox-backed PlayFab session because the PlayFab Game Saves C API needs a local user handle. Acquire a real `GDKUser` object and pass it to `PlayFab.users.sign_in_with_xuser_async(...)`; custom-ID users return `xbox_user_required` from Game Saves methods.
+Game Saves still requires an XBOX-backed PlayFab session because the PlayFab Game Saves C API needs a local user handle. Acquire a real `GDKUser` object and pass it to `PlayFab.users.sign_in_with_xuser_async(...)`; custom-ID users return `xbox_user_required` from Game Saves methods.
 
 ## Leaderboard write path
 
@@ -190,7 +190,7 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\tools\run_all_tests.ps1 
 
 The runner forwards those values only to child processes as `PLAYFAB_TITLE_ID`, `PLAYFAB_CUSTOM_ID`, and `PLAYFAB_MULTIPLAYER_MATCH_QUEUE`; the PlayFab test base applies the title id to `playfab/runtime/title_id` and uses the custom id for `create_account=false` sign-in. The Multiplayer runner derives worker accounts from `PLAYFAB_CUSTOM_ID` as `<custom-id>-multiplayer-host/client/observer` unless `PLAYFAB_MULTIPLAYER_CUSTOM_ID_PREFIX` overrides the prefix. The developer secret key is only consumed by `tools\configure_playfab_test_title.ps1`, not by Godot test processes. Project settings (`playfab/runtime/title_id`, `playfab/tests/custom_id`) and the `PLAYFAB_CUSTOM_ID` environment variable remain supported for manual runs. Some `-Live` tests write online state, such as leaderboard submissions and the PlayFab Multiplayer multi-client lobby smoke, so run live PlayFab coverage only against a personal sandbox title. Leaderboard read-after-write checks poll up to `playfab/tests/leaderboard_settle_msec` and mark pending, not failed, when the service is eventually consistent beyond that budget. The live Multiplayer orchestration uses three worker processes and covers lobby creation, search isolation, private lobby discovery behavior, invalid joins, three-member snapshots, member/lobby property propagation, leave/rejoin behavior, owner migration, and cleanup; when `-PlayFabMatchmakingQueue` or `PLAYFAB_MULTIPLAYER_MATCH_QUEUE` is set it also covers match ticket create/cancel, two-player match completion, explicit arranged-lobby joins, and arranged-lobby cleanup.
 
-The PlayFab host uses custom-ID sign-in for default coverage. By default, CMake also mirrors `godot_gdk` into `tests\godot\playfab` so optional Xbox-backed compatibility tests can call `ensure_gdk_primary_user_for_playfab()`. Configure with `-DGODOT_PLAYFAB_TEST_HOST_WITH_GDK=OFF` to omit that mirror; GDK-backed helpers skip cleanly when the addon is not present.
+The PlayFab host uses custom-ID sign-in for default coverage. By default, CMake also mirrors `godot_gdk` into `tests\godot\playfab` so optional XBOX-backed compatibility tests can call `ensure_gdk_primary_user_for_playfab()`. Configure with `-DGODOT_PLAYFAB_TEST_HOST_WITH_GDK=OFF` to omit that mirror; Microsoft GDK-backed helpers skip cleanly when the addon is not present.
 
 Run the standard pipeline from the repository root:
 

--- a/docs/playfab/prerequisites.md
+++ b/docs/playfab/prerequisites.md
@@ -5,7 +5,7 @@ configuration required before any PlayFab tutorial or sample in this
 repository runs.
 
 It complements
-[Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md),
+[XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md),
 which covers the PC- and test-account-side configuration.
 
 Each PlayFab tutorial under [`docs/tutorials/`](../tutorials/README.md)
@@ -53,17 +53,17 @@ derives `https://<titleid>.playfabapi.com` from the Title ID.
 
 `PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled in tools and
 runtime flows. The PlayFab Core/Services/Game Save state and task queue are
-recreated on each initialize, while the GDK `XGameRuntimeInitialize` reference
+recreated on each initialize, while the Microsoft GDK `XGameRuntimeInitialize` reference
 is held for the process lifetime and released once when the extension unloads.
 
 > **`PlayFab.initialize()` failing with `title_id_required`** indicates
 > the setting is empty at runtime. See
 > [Troubleshooting → `PlayFab.initialize()` fails with `title_id_required`](../troubleshooting.md#playfabinitialize-fails-with-title_id_required).
 
-### Xbox-backed sign-in prerequisites
+### XBOX-backed sign-in prerequisites
 
 `PlayFab.users.sign_in_with_xuser_async(...)` accepts a signed-in `GDKUser`
-object, not a raw local Xbox user id. Reuse `GDK.users.get_primary_user()`
+object, not a raw local XBOX user id. Reuse `GDK.users.get_primary_user()`
 when a primary user is already present, or prompt for one with
 `await GDK.users.add_user_with_ui_async()`, then pass that returned object to
 `PlayFab.users.sign_in_with_xuser_async(...)`.
@@ -84,7 +84,7 @@ var sign_in_result = await PlayFab.users.sign_in_with_xuser_async(gdk_user)
 ## 2. Per-tutorial title-side fixtures
 
 Each section below lists the Game Manager configuration (or, where
-the resource is Xbox-side, the `MicrosoftGame.config` configuration)
+the resource is XBOX-side, the `MicrosoftGame.config` configuration)
 required by the matching tutorial. Sections that do not apply may be
 skipped.
 
@@ -190,14 +190,14 @@ is trusted to compute.
 requires:
 
 - **`CloudSaves` block in `MicrosoftGame.config`.** The
-  **GDK → Create MicrosoftGame.config** menu (provided by the
+  **Microsoft GDK → Create MicrosoftGame.config** menu (provided by the
   `godot_gdk_packaging` addon) writes a template that includes the
   CloudSaves block. Configurations created before the template was
   added must be updated in `GameConfigEditor.exe` to include a
   `<CloudSaves>` section.
-- **Xbox-backed PlayFab session.** Every `PlayFab.game_saves` call
+- **XBOX-backed PlayFab session.** Every `PlayFab.game_saves` call
   rejects a custom-ID session with `xbox_user_required`. Game Saves
-  is the Xbox-attached blob store and has no PlayFab-only path.
+  is the XBOX-attached blob store and has no PlayFab-only path.
   Enablement is controlled entirely by `MicrosoftGame.config`; no
   PlayFab Game Manager setting is involved.
 - **Network connectivity** for cloud sync round-trips. Game Saves
@@ -205,11 +205,11 @@ requires:
   exposes a `cloud connected` indicator.
 
 > **Game Saves vs. PlayFab title data / entity data.** Game Saves is
-> the Xbox-attached blob store that follows the Xbox account across
+> the XBOX-attached blob store that follows the XBOX account across
 > devices and is surfaced in the system Cloud Saves UI. Use it for
 > player-progress blobs. Use `PlayFab.entity_data` or
 > `PlayFab.player_data` for structured per-player JSON that does not
-> require Xbox-backed sync semantics.
+> require XBOX-backed sync semantics.
 
 ### Lobby (T5, T6, T7, T8)
 
@@ -221,21 +221,21 @@ requires:
   "Lobby enabled." Recently created titles enable this by default;
   older titles require the feature to be enabled manually.
 - **Two Godot processes** (host and client) signed into different
-  Xbox test accounts in the same sandbox. A typical setup runs the
+  XBOX test accounts in the same sandbox. A typical setup runs the
   host scene in the editor and the client as an exported build. Two
   editors with separate PlayFab sessions are also supported.
-- **Xbox-backed PlayFab session on both sides** when Xbox-shell
+- **XBOX-backed PlayFab session on both sides** when XBOX-shell
   invites (Game Bar, friends list) are required. Custom-ID lobbies
   are restricted to joining by connection string.
 
 ### Multiplayer Activity (T6, T8)
 
 [Tutorial 6 — Advertise your lobby with MPA](../tutorials/06-multiplayer-activity.md)
-is the Xbox-side advertisement layer that sits on top of a PlayFab
+is the XBOX-side advertisement layer that sits on top of a PlayFab
 lobby. There is no PlayFab Game Manager fixture for MPA; the
-prerequisites are the Xbox-side SCID, an Xbox-backed PlayFab session,
+prerequisites are the XBOX-side SCID, an XBOX-backed PlayFab session,
 and the in-sandbox test accounts documented in
-[Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md).
+[XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md).
 The only PlayFab-side prerequisite is that the T5 Lobby fixture is in
 place.
 
@@ -251,7 +251,7 @@ requires:
 - **A functional microphone on both sides** for voice-path testing.
   Text and RPC traffic do not require a microphone.
 - **The two-process / two-test-account setup described in §2 Lobby.**
-  Party's Xbox-shell invites require Xbox-backed sessions on both
+  Party's XBOX-shell invites require XBOX-backed sessions on both
   sides.
 
 #### Same-host Party UDP port override
@@ -359,9 +359,9 @@ must be treated as production credentials.
 |---|---|
 | Title ID set in Project Settings | `Get-Content .\project.godot \| Select-String "title_id"` reports the Title ID under `[playfab]` |
 | `PlayFab.initialize()` succeeds | Bootstrap log line `[PlayFab] Bootstrap: PlayFab.initialize() succeeded.` is emitted at editor or runtime startup |
-| Xbox-backed sign-in succeeds (T1) | T1 log line `[PlayFab] signed in: title_player_account:<entity-id>` is emitted |
+| XBOX-backed sign-in succeeds (T1) | T1 log line `[PlayFab] signed in: title_player_account:<entity-id>` is emitted |
 | Leaderboard accepts client writes (T3) | T3 statistic write emits `[Lead] Recorded score …`. HRESULT `0x89235472` on `submit_score_async` indicates the code is calling the direct leaderboard write path, which should be handled by a trusted backend with a developer secret key for non-statistic-backed leaderboards. Use `update_statistics_async` for client-safe statistic-backed leaderboards. The same `0x89235472` on `update_statistics_async` indicates the title's **Allow client to post player stats** setting is disabled (see §2 step 3) |
-| Game Saves accepts the local user (T4) | T4 add-user emits `[Save] User context registered`. `xbox_user_required` indicates a custom-ID rather than Xbox-backed session |
+| Game Saves accepts the local user (T4) | T4 add-user emits `[Save] User context registered`. `xbox_user_required` indicates a custom-ID rather than XBOX-backed session |
 | Lobby create succeeds (T5) | T5 host emits `[Lobby] hosting <lobbyId>` |
 | Party create succeeds (T7) | T7 host emits `[Party] network <id> hosted with descriptor <…>` |
 
@@ -376,8 +376,8 @@ the diagnostic next steps.
 - [Addons getting started](../addon-getting-started.md) — the
   addon-zip quickstart, including the `playfab/runtime/title_id`
   setting step that this page elaborates on.
-- [Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
-  — the Xbox-side companion to this page. PlayFab tutorials assume
+- [XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
+  — the XBOX-side companion to this page. PlayFab tutorials assume
   both pages are satisfied.
 - [PlayFab plugin overview](plugin.md) — `godot_playfab` runtime
   configuration, public surface, and architecture notes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ unresolvable during CMake configure.
 **Cause:** vcpkg manifest mode could not resolve the `ms-gdk[playfab]` or
 `gameinput` ports defined in the repo's `vcpkg.json`. (The `installed-gdk`
 preset does not require vcpkg at all — see
-[Source for the GDK dependency](getting-started.md#source-for-the-gdk-dependency).)
+[Source for the Microsoft GDK dependency](getting-started.md#source-for-the-microsoft-gdk-dependency).)
 
 **Fixes:**
 
@@ -324,7 +324,7 @@ for you when you flip `playfab/runtime/initialize_on_startup` to
 `GDKUser` object and reads its `local_id` to find the matching
 `XUserHandle`. Two failure paths show up most often:
 
-- `invalid_xuser` — the GDK user you passed in is `null`, has not
+- `invalid_xuser` — the Microsoft GDK user you passed in is `null`, has not
   finished sign-in (`signed_in == false`), or does not expose a
   non-zero `local_id`. Most common cause: handing `PlayFab` a stale
   `Auth.xbox_user` from before sign-in completed.

--- a/docs/tutorials/01-sign-in-user.md
+++ b/docs/tutorials/01-sign-in-user.md
@@ -2,9 +2,9 @@
 
 ## What you'll build
 
-A single autoload that brings up Xbox Live first, then PlayFab on top
+A single autoload that brings up XBOX Live first, then PlayFab on top
 of it, and exposes both sessions to the rest of your game. The flow
-is the **check → silent → UI** fallback for Xbox, followed by
+is the **check → silent → UI** fallback for XBOX, followed by
 `sign_in_with_xuser_async` for PlayFab. When it works, your Output
 panel ends with something like:
 
@@ -23,16 +23,16 @@ Everything in tutorials 2–5 assumes you can reach this state.
   `godot_gameinput`, plus `godot_gdk_packaging`) are enabled in
   **Project Settings → Plugins**, and `MicrosoftGame.config` has
   real Title ID and SCID values (not the template defaults). See
-  [Configuring Xbox services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
+  [Configuring XBOX services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
   for where these values live in
   [Partner Center](https://partner.microsoft.com/dashboard).
 - Your **PlayFab title** is provisioned and `playfab/runtime/title_id`
   is set. The walkthrough — creating the title and configuring the
   Title ID in Project Settings — is documented in
   [PlayFab title prerequisites — §1 Create the title](../playfab/prerequisites.md#1-create-the-title-and-capture-the-title-id).
-- Your **PC is in the right Xbox sandbox** and at least one Xbox
-  **test account** is signed into the Xbox app for the silent path.
-  See [Xbox sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md).
+- Your **PC is in the right XBOX sandbox** and at least one XBOX
+  **test account** is signed into the XBOX app for the silent path.
+  See [XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md).
 - `gdk/runtime/initialize_on_startup` and
   `playfab/runtime/initialize_on_startup` are both `true` (the
   quickstart sets these explicitly — they ship `false` out of the
@@ -116,7 +116,7 @@ they need to gate work on a completed session.
 
 ## Step 2 — Reach a `GDKUser` (check → silent → UI)
 
-Add the Xbox sign-in routine to `auth.gd`:
+Add the XBOX sign-in routine to `auth.gd`:
 
 ```gdscript
 func _ensure_xbox_user() -> GDKUser:
@@ -158,7 +158,7 @@ A few things worth calling out:
   `.ok`) all matter. `add_default_user_async` resolves to a result
   that is "ok" with `data == null` in a handful of edge cases (for
   example a stale handle); the explicit chain rejects those.
-- This is the **only** Xbox sign-in entry point your game should
+- This is the **only** XBOX sign-in entry point your game should
   call. Do **not** drive sign-in from `GDK.users.user_changed` —
   that signal fires for every user lifecycle event (adds, removes,
   gamertag changes, picture changes, privilege changes) and is not
@@ -168,7 +168,7 @@ A few things worth calling out:
   allows UI presentation. Running it from `_ready` is fine; running
   it during shutdown or from a worker thread is not.
 
-## Step 3 — Hand the Xbox user to PlayFab
+## Step 3 — Hand the XBOX user to PlayFab
 
 PlayFab does not have its own silent/UI distinction — once you have a
 signed-in `GDKUser`, `sign_in_with_xuser_async` does the rest:
@@ -202,7 +202,7 @@ func _ensure_playfab_user(xbox: GDKUser) -> PlayFabUser:
 
 The two failure codes worth recognizing here are:
 
-- `invalid_xuser` — the GDK user passed in was null or signed out
+- `invalid_xuser` — the Microsoft GDK user passed in was null or signed out
   between the check above and the call. The chain in step 2 makes
   this unlikely, but a user who signs out between frames will
   surface it.
@@ -322,7 +322,7 @@ func _on_state_changed(_state: Auth.State) -> void:
 ```
 
 A `gdk.add_user_with_ui` failure is the one the user can recover
-from by signing into the Xbox app and tapping a retry button that
+from by signing into the XBOX app and tapping a retry button that
 calls `await Auth.sign_in()` again — `sign_in()` resets stale
 state on each fresh attempt so it's safe to retry.
 
@@ -347,10 +347,10 @@ The most common failure paths and how to read them:
 
 | Output | Diagnosis | Fix |
 |---|---|---|
-| `[Auth] Silent sign-in failed (no_default_user) — falling back to UI.` | No Xbox-app account on the PC. The fallback handles it. | Pick a test account in the picker, or sign one into the Xbox app first. |
-| `[Auth] sign-in failed at gdk.initialize: ...` | GDK runtime did not initialize. | Confirm the GDK is installed (`winget install Microsoft.Gaming.GDK`) and the addon `bin/` folder shipped into the project. |
+| `[Auth] Silent sign-in failed (no_default_user) — falling back to UI.` | No XBOX-app account on the PC. The fallback handles it. | Pick a test account in the picker, or sign one into the XBOX app first. |
+| `[Auth] sign-in failed at gdk.initialize: ...` | Microsoft GDK runtime did not initialize. | Confirm the Microsoft GDK is installed (`winget install Microsoft.Gaming.GDK`) and the addon `bin/` folder shipped into the project. |
 | `[Auth] sign-in failed at playfab.initialize: ...` | PlayFab runtime did not initialize. Usually `title_id_required`. | Set `playfab/runtime/title_id` in Project Settings. |
-| `[Auth] sign-in failed at playfab.sign_in: invalid_xuser` | The Xbox user signed out between sign-in stages. | Retry. If it persists, check the sandbox setting and the test account state. |
+| `[Auth] sign-in failed at playfab.sign_in: invalid_xuser` | The XBOX user signed out between sign-in stages. | Retry. If it persists, check the sandbox setting and the test account state. |
 | `[Auth] sign-in failed at gdk.add_user_with_ui: ...` | The picker was dismissed or the account flow was canceled. | Run again — `add_user_with_ui_async` is idempotent, and `Auth.sign_in()` resets failure state on each retry. |
 
 ## Reference implementation

--- a/docs/tutorials/02-unlock-achievement.md
+++ b/docs/tutorials/02-unlock-achievement.md
@@ -2,7 +2,7 @@
 
 ## What you'll build
 
-A scene that watches the player rack up score, then unlocks an Xbox
+A scene that watches the player rack up score, then unlocks an XBOX
 achievement when they cross a threshold. By the end you will:
 
 - Have one achievement declared in Partner Center for your title.
@@ -10,7 +10,7 @@ achievement when they cross a threshold. By the end you will:
   GDScript using `GDK.achievements.update_achievement_async`.
 - React to the unlock by listening to the `achievement_unlocked`
   signal so your HUD / toast popup fires at the right moment.
-- Verify the unlock both in the Output panel and on the Xbox
+- Verify the unlock both in the Output panel and on the XBOX
   achievement viewer for the signed-in test account.
 
 When it works, the editor Output ends with:
@@ -36,7 +36,7 @@ When it works, the editor Output ends with:
     The snippets below use `FIRST_SCORE_ID = "1"`.
   - **Title ID** + **SCID** wired into `MicrosoftGame.config`
     (handled in the quickstart).
-- The PC is in the same Xbox sandbox the achievement was
+- The PC is in the same XBOX sandbox the achievement was
   declared in. New achievement metadata only propagates to the
   sandbox you authored it in until you promote it to retail.
 
@@ -99,7 +99,7 @@ achievement declared for the title, including `FIRST_SCORE_ID`. If
 the list is empty you are either in the wrong sandbox, the
 declaration has not propagated yet, or the test account does not have
 access to the title — fix that before moving on. The PlayFab-side
-sign-in is incidental to this query; only `GDK.users` and the Xbox
+sign-in is incidental to this query; only `GDK.users` and the XBOX
 sandbox matter here.
 
 ## Step 2 — Stage incremental progress
@@ -143,7 +143,7 @@ A couple of notes:
 - Achievement progress is **monotonic** on the service side. Pushing
   `50` after `100` is silently treated as `100`, so guarding for
   re-progress is not required.
-- The `achievement_unlocked` signal is driven by the Xbox
+- The `achievement_unlocked` signal is driven by the XBOX
   Achievements Manager, which dispatches once `GDK.dispatch()` pumps
   it. On Godot 4.5+, the addon does this every process frame by
   default (via `gdk/runtime/embed_dispatch`), so connecting the
@@ -154,7 +154,7 @@ A couple of notes:
 ## Step 3 — Hook unlocks into your real game
 
 In a real game the score update lives at the gameplay layer, not in
-a demo `_ready`. The bridge from "gameplay progress" to "Xbox
+a demo `_ready`. The bridge from "gameplay progress" to "XBOX
 progress" is small enough that it usually fits in one helper on
 your `Auth` autoload or a peer achievements singleton:
 
@@ -228,7 +228,7 @@ A successful run prints, in order:
 [Ach] Unlocked: First Score
 ```
 
-On the Xbox app for the signed-in test account, opening the title's
+On the XBOX app for the signed-in test account, opening the title's
 achievements view should show **First Score** with the unlock
 timestamp.
 
@@ -236,7 +236,7 @@ Common failures:
 
 | Output | Diagnosis | Fix |
 |---|---|---|
-| Achievement count is `0` | Wrong sandbox or the achievement has not propagated to your sandbox yet. | Use **GDK → Change Sandbox…** to switch to the sandbox you authored in. |
+| Achievement count is `0` | Wrong sandbox or the achievement has not propagated to your sandbox yet. | Use **Microsoft GDK → Change Sandbox…** to switch to the sandbox you authored in. |
 | `Update to 50% failed: invalid_argument (...)` | The `achievement_id` does not exist in this title's declared list. | Check the id in Partner Center — it is a small integer like `"1"`, not a slug. |
 | `Update to 50% failed: unauthorized (...)` | The signed-in user has no rights to the title (no test-account assignment). | Add the test account to the title's sandbox in Partner Center. |
 | `[Ach] Updated to 100% — result ok` but no `Unlocked` signal | A second copy of the unlock listener already consumed it, or the achievement was previously unlocked for this account. | Check `progress_percent` and `unlocked` on the cached entry; once unlocked the signal stays silent on repeat 100% pushes. |

--- a/docs/tutorials/03-playfab-leaderboard.md
+++ b/docs/tutorials/03-playfab-leaderboard.md
@@ -13,7 +13,7 @@ the page first. By the end you will:
 - Page through the result with `start_position` + `page_size` and
   read the same leaderboard "around the player" with
   `get_leaderboard_around_user_async`.
-- Pull an **Xbox-friend leaderboard** with
+- Pull an **XBOX-friend leaderboard** with
   `get_friend_leaderboard_async(..., include_xbox_friends=true)`.
 
 Sample output:
@@ -54,9 +54,9 @@ Sample output:
 - For the friend leaderboard step: `Auth.playfab_user` was obtained
   via `PlayFab.users.sign_in_with_xuser_async(Auth.xbox_user)`, not
   `sign_in_with_custom_id_async`. The friend-leaderboard call needs
-  the local Xbox token, which is only available when the PlayFab
-  session is backed by an Xbox user. The signed-in test account must
-  also have at least one Xbox friend who has submitted a score.
+  the local XBOX token, which is only available when the PlayFab
+  session is backed by an XBOX user. The signed-in test account must
+  also have at least one XBOX friend who has submitted a score.
 
 > **Why statistic-backed instead of direct writes?** PlayFab's
 > `LeaderboardsV2/UpdateLeaderboardEntries` is, by default,
@@ -68,14 +68,14 @@ Sample output:
 > [Troubleshooting → PlayFab leaderboard submit returns 0x89235472](../troubleshooting.md#playfab-leaderboard-submit-fails-with-e_pf_api_not_enabled_for_game_client_access-0x89235472)
 > for the diagnostic context.
 
-> **PlayFab leaderboards vs. GDK leaderboards.** PlayFab leaderboards
+> **PlayFab leaderboards vs. Microsoft GDK leaderboards.** PlayFab leaderboards
 > are an explicitly **versioned** resource: a leaderboard is created
 > in Game Manager with a reset cadence (or a manual reset endpoint),
 > and every reset increments `version`. Statistics carry their own
-> version that the leaderboard tracks. The GDK leaderboard surface
-> (`GDK.leaderboards` + `GDK.stats`) is a separate Xbox Live service
+> version that the leaderboard tracks. The Microsoft GDK leaderboard surface
+> (`GDK.leaderboards` + `GDK.stats`) is a separate XBOX Live service
 > with a different reset model; the two are not interchangeable.
-> This tutorial uses PlayFab; the GDK surface remains available in
+> This tutorial uses PlayFab; the Microsoft GDK surface remains available in
 > the addon for titles that prefer it.
 
 ## Relevant addon surfaces
@@ -290,7 +290,7 @@ below** the player, so the page size you see is roughly `2N + 1`
 when there are enough rows on either side. Pass `3` for a 7-row
 ribbon, `10` for a 21-row panel, etc.
 
-## Step 5 — Pull the Xbox-friend leaderboard
+## Step 5 — Pull the XBOX-friend leaderboard
 
 For social cards and "challenge a friend" UI, switch to
 `get_friend_leaderboard_async` with `include_xbox_friends=true`:
@@ -313,15 +313,15 @@ func _print_xbox_friend_leaderboard() -> void:
         print("[Lead]   #%d  %s — %d" % [row.get("rank", 0), _display_name(row), _primary_score(row)])
 ```
 
-`include_xbox_friends=true` is what makes this an *Xbox-friend*
+`include_xbox_friends=true` is what makes this an *XBOX-friend*
 leaderboard rather than a PlayFab-friend leaderboard. The addon
-acquires an Xbox token for the local PlayFab API call, which only
+acquires an XBOX token for the local PlayFab API call, which only
 works when the `PlayFabUser` was created with
 `sign_in_with_xuser_async`. A custom-ID PlayFab session is allowed
-to call this method but the **Xbox-friend half** of the query
+to call this method but the **XBOX-friend half** of the query
 returns an empty list — only mutual PlayFab friends appear.
 
-For PlayFab-only friend graphs pass `false` and skip the Xbox
+For PlayFab-only friend graphs pass `false` and skip the XBOX
 prereq; mutual PlayFab friends still appear either way.
 
 ## Verify
@@ -352,8 +352,8 @@ Common failures:
 | `get_leaderboard failed: not_found` | The leaderboard name does not match a leaderboard configured in Game Manager, or no entity has a statistic value yet. | Confirm the leaderboard exists and is sourced from the statistic. Then record at least one score (your own counts). |
 | Leaderboard renders `(no entries)` even after a successful record | The leaderboard is sourced from a different statistic than the one being written, or the rankings have not refreshed yet. | Confirm the Game Manager leaderboard's source statistic matches `STATISTIC_NAME`. Statistic-to-leaderboard propagation is typically a few seconds; wait and re-query. |
 | Around-user returns only one row | You are the only entity with a value in this statistic version. | Record values from a second test account, or use the global query for the demo. |
-| `friend leaderboard failed: missing_xbox_token` | `Auth.playfab_user` was created with `sign_in_with_custom_id_async`, so no Xbox token is available. | Switch the session to `PlayFab.users.sign_in_with_xuser_async(Auth.xbox_user)`. |
-| Xbox-friend page is empty for a friended account | The friend has never recorded the statistic, or you and the friend are in different PlayFab titles in the same Xbox sandbox. | Have the friend record a score; confirm the same PlayFab title id on both accounts. |
+| `friend leaderboard failed: missing_xbox_token` | `Auth.playfab_user` was created with `sign_in_with_custom_id_async`, so no XBOX token is available. | Switch the session to `PlayFab.users.sign_in_with_xuser_async(Auth.xbox_user)`. |
+| XBOX-friend page is empty for a friended account | The friend has never recorded the statistic, or you and the friend are in different PlayFab titles in the same XBOX sandbox. | Have the friend record a score; confirm the same PlayFab title id on both accounts. |
 
 ## Reference implementation
 

--- a/docs/tutorials/04-game-saves.md
+++ b/docs/tutorials/04-game-saves.md
@@ -3,7 +3,7 @@
 ## What you'll build
 
 A persistent save flow on top of PlayFab Game Saves, backed by the
-Xbox-signed-in PlayFab session you reached in tutorial 1. By the end
+XBOX-signed-in PlayFab session you reached in tutorial 1. By the end
 you will:
 
 - Add the signed-in PlayFab user to Game Saves with
@@ -32,11 +32,11 @@ Sample output:
   `has_local_user_handle == true`. PlayFab sessions that were created
   with `sign_in_with_custom_id_async` are rejected by every Game
   Saves call with the `xbox_user_required` code — Game Saves is
-  Xbox-backed only.
+  XBOX-backed only.
 - The title-side Game Saves configuration is in place: a `CloudSaves`
   block is present in `MicrosoftGame.config`, and the signed-in
-  PlayFab session is Xbox-backed. The walkthrough — including the
-  template written by **GDK → Create MicrosoftGame.config** and the
+  PlayFab session is XBOX-backed. The walkthrough — including the
+  template written by **Microsoft GDK → Create MicrosoftGame.config** and the
   procedure for updating older configurations — is documented in
   [PlayFab title prerequisites — §2 Game Saves](../playfab/prerequisites.md#game-saves-t4-t8).
 - Network connectivity for the cloud sync round-trips. Game Saves
@@ -44,11 +44,11 @@ Sample output:
   result has an explicit "cloud connected" bit you can check.
 
 > **Game Saves vs. PlayFab title data / entity data.** Game Saves is
-> the Xbox-attached blob store that follows the Xbox account across
+> the XBOX-attached blob store that follows the XBOX account across
 > devices and surfaces in the system Cloud Saves UI. Use it for
 > player-progress blobs. Use `PlayFab.entity_data` or
 > `PlayFab.player_data` for structured per-player JSON that does not
-> need the Xbox-backed sync semantics.
+> need the XBOX-backed sync semantics.
 
 ## Relevant addon surfaces
 
@@ -58,7 +58,7 @@ Sample output:
   `is_connected_to_cloud`, `set_save_description_async`,
   `reset_cloud_async`.
 - [`PlayFabUser`](../../addons/godot_playfab/doc_classes/PlayFabUser.xml) — read
-  `has_local_user_handle` to confirm an Xbox-backed session.
+  `has_local_user_handle` to confirm an XBOX-backed session.
 - One-page primer on the addons' async model:
   [Async patterns](../async-patterns.md).
 
@@ -278,7 +278,7 @@ func _on_resolve_action(action: StringName) -> void:
 A few discipline points worth pinning down before you ship this:
 
 - **Pre-flight before showing the dialog.** Game Saves only
-  supports Xbox-backed sessions, so check
+  supports XBOX-backed sessions, so check
   `Auth.playfab_user.has_local_user_handle` first and refuse to
   open the dialog (rather than letting `add_user_with_ui_async`
   fail under the player's nose).
@@ -317,7 +317,7 @@ Common failures:
 
 | Output | Diagnosis | Fix |
 |---|---|---|
-| `Add user failed: xbox_user_required` | The PlayFab session is custom-id, not Xbox-backed. | Sign in through `sign_in_with_xuser_async` (tutorial 1), not `sign_in_with_custom_id_async`. |
+| `Add user failed: xbox_user_required` | The PlayFab session is custom-id, not XBOX-backed. | Sign in through `sign_in_with_xuser_async` (tutorial 1), not `sign_in_with_custom_id_async`. |
 | `Add user failed: not_initialized` | PlayFab runtime did not initialize. | Set `playfab/runtime/title_id` and re-run sign-in. |
 | `Upload failed: out_of_quota` | The save folder is over the per-user quota. | Trim files in `_save_folder` before retrying; `get_remaining_quota` reports the budget. |
 | `Upload failed: not_connected` | The PC has no internet, or PlayFab Game Saves connectivity dropped. | Cache the local write and retry the upload when connectivity returns. `is_connected_to_cloud(user)` is your check. |

--- a/docs/tutorials/05-multiplayer-lobby.md
+++ b/docs/tutorials/05-multiplayer-lobby.md
@@ -37,12 +37,12 @@ Sample output (host side):
 - Two Godot processes (one host, one client). The simplest way to
   test on one PC is to run the host scene in the editor and a
   separate exported build for the client, each signed into a
-  different Xbox test account. Two editors with two different
+  different XBOX test account. Two editors with two different
   PlayFab sessions also works as long as both PCs are in the same
   sandbox.
-- `Auth.playfab_user` resolves to an Xbox-backed PlayFab session
+- `Auth.playfab_user` resolves to an XBOX-backed PlayFab session
   for the snippets below. Custom-ID sessions also work for lobby
-  but invites from the Xbox shell will not.
+  but invites from the XBOX shell will not.
 
 > **Lobby vs. Matchmaking.** Lobbies are persistent rooms identified
 > by a lobby id and a connection string. Matchmaking
@@ -73,7 +73,7 @@ Sample output (host side):
 - [`GDK.presence`](../../addons/godot_gdk/doc_classes/GDKPresence.xml)
   — `set_presence_async`, `clear_presence_async`, signal
   `local_presence_set`. Used in Step 8 to advertise the local
-  user's lobby state to Xbox friends. The `state` parameter is a
+  user's lobby state to XBOX friends. The `state` parameter is a
   **rich-presence ID** registered on the title in Partner Center,
   not a freeform string; if your title has no presence IDs
   configured, skip Step 8 — the rest of the lobby flow still works.
@@ -259,7 +259,7 @@ is two layers:
    controls, restricted accounts, missing subscription. Result
    data carries `has_privilege: bool` and a `deny_reason: String`.
 2. When `has_privilege` comes back `false` and the runtime allows
-   the user to fix it (sign in to Xbox Live, accept the
+   the user to fix it (sign in to XBOX Live, accept the
    subscription prompt, ask a parent), `resolve_privilege_with_ui_async`
    pops the system UI to walk the user through it. The same
    signal returns the post-resolution `has_privilege`.
@@ -505,7 +505,7 @@ either:
 - A `find_lobbies_async` call against the `search_properties` you
   set on the host. PlayFab filter syntax uses the reserved search
   keys, for example `string_key1 eq 'casual'`.
-- An Xbox-shell invite — the host invites a friend, the client side
+- An XBOX-shell invite — the host invites a friend, the client side
   receives `PlayFab.multiplayer.invite_received` with a
   `PlayFabLobbyInvite.connection_string`, and the client calls
   `join_lobby_async` with that string.
@@ -632,11 +632,11 @@ This step requires one piece of **Partner Center title config** —
 a rich-presence ID registered against your title's SCID. If your
 title has none configured yet, skip the step; the rest of the
 chain still works. Configuring a presence ID is a one-time per-
-title step in Partner Center → Xbox Live → Rich Presence.
+title step in Partner Center → XBOX Live → Rich Presence.
 
 Assuming you registered a presence ID called `in_lobby`, extend
 your `Lobby` autoload so successful host / join sets the local
-user's Xbox presence, and `leave` clears it:
+user's XBOX presence, and `leave` clears it:
 
 ```gdscript
 const PRESENCE_IN_LOBBY := "in_lobby"
@@ -685,7 +685,7 @@ func leave_lobby() -> bool:
 Notes:
 
 - `set_presence_async`'s `state` argument is the **presence ID
-  string** from Partner Center, not a UI-display string. Xbox
+  string** from Partner Center, not a UI-display string. XBOX
   resolves it on the friend's shell to whatever localized text
   you authored against that ID.
 - The optional `rich_presence` Dictionary lets you pass

--- a/docs/tutorials/06-multiplayer-activity.md
+++ b/docs/tutorials/06-multiplayer-activity.md
@@ -3,7 +3,7 @@
 ## What you'll build
 
 Hook your [Tutorial 5 lobby](05-multiplayer-lobby.md) into the
-Xbox shell's **Multiplayer Activity** (MPA) surface so the user's
+XBOX shell's **Multiplayer Activity** (MPA) surface so the user's
 friends can see "Playing with you" cards, accept invites from the
 Game Bar, and rejoin your session through the system UI. By the
 end you will:
@@ -52,19 +52,19 @@ Game Bar):
   resolves to the per-sandbox MPSD ("Multiplayer Session
   Directory"), and a wrong-sandbox PC silently writes activities
   into a graveyard SCID nobody can see.
-- For end-to-end testing of invites: two Xbox **test accounts**
+- For end-to-end testing of invites: two XBOX **test accounts**
   that follow each other in the same sandbox, signed into two
-  separate machines (or two Xbox app sessions on the same PC).
+  separate machines (or two XBOX app sessions on the same PC).
   Friends-of-friends invites also work but are flakier in
   pre-release sandboxes.
 - One-page primer on the addons' async model: [Async patterns](../async-patterns.md).
 
 > **MPA vs. the lobby.** A `PlayFabLobby` is the actual session
 > roster — connection string, member list, properties, ownership.
-> The **multiplayer activity** is an Xbox shell concept layered on
+> The **multiplayer activity** is an XBOX shell concept layered on
 > top: a per-user advertisement that says "this XUID is in a
 > session with this connection string, here's how to join". MPA
-> does not move bytes. It exists so the Xbox / Game Bar / Game DVR
+> does not move bytes. It exists so the XBOX / Game Bar / Game DVR
 > / "Currently playing" surfaces know that a user is joinable and
 > what string to pass back into your title when a friend taps
 > **Join**.
@@ -118,7 +118,7 @@ Game Bar):
 
 Add the three signal connections to the `Lobby` autoload's
 `_ready` (alongside the existing `Auth.sign_in()` await). The goal
-is to install handlers **before** the GDK runtime can fire a
+is to install handlers **before** the Microsoft GDK runtime can fire a
 deferred `invite_accepted` from a launch-with-invite activation —
 that activation can race `_ready` if the title is launched cold
 straight from a friend's invite.
@@ -127,8 +127,8 @@ The PlayFab Multiplayer side stays inside the
 `_ensure_initialized()` helper you added in
 [T5 Step 1](05-multiplayer-lobby.md#step-1--bring-up-the-lobby-autoload)
 so the SDK only spins up when the user actually hosts / joins. The
-GDK side wires up unconditionally in `_ready` — `GDK.multiplayer_activity`
-is part of the core GDK runtime that's already initialized by the
+Microsoft GDK side wires up unconditionally in `_ready` — `GDK.multiplayer_activity`
+is part of the core Microsoft GDK runtime that's already initialized by the
 bootstrap.
 
 ```gdscript
@@ -143,7 +143,7 @@ func _ready() -> void:
     print("[Lobby] autoload ready (Lobby + MPA wired; PlayFab Multiplayer init is lazy)")
 ```
 
-The three GDK signals are stateless — connecting after a missed
+The three Microsoft GDK signals are stateless — connecting after a missed
 `invite_accepted` simply means you miss that one. The launch-with-
 invite path is handled by the activation service queueing the
 event until the first signal listener attaches, so connecting in
@@ -214,7 +214,7 @@ A few notes:
 - `group_id` is for grouping friends who are about to play
   together (e.g. a pre-game party). Most titles pass `""`.
 - `allow_cross_platform_join` controls whether the activity is
-  visible to non-Xbox platforms (PlayFab Multiplayer's
+  visible to non-XBOX platforms (PlayFab Multiplayer's
   cross-platform discovery). Defaults to `false` because most
   titles want explicit opt-in.
 
@@ -288,7 +288,7 @@ seconds while the leave round-trips.
 
 ## Step 4 — Accept an invite that arrives mid-game
 
-When a friend taps **Join** on your activity, the Xbox shell
+When a friend taps **Join** on your activity, the XBOX shell
 queues an activation event. The addon parses the activation URI
 into a `Dictionary` and fires `invite_accepted`. The handler
 should pull the `connectionstring` out of that dict and decide
@@ -333,7 +333,7 @@ func _on_invite_accepted(invite: Dictionary) -> void:
 A few notes:
 
 - The dictionary keys are **lowercased** (the addon normalizes them
-  for stable indexing across activations). The Xbox URI uses
+  for stable indexing across activations). The XBOX URI uses
   `connectionString` (camel case); the parsed dict exposes it as
   `"connectionstring"`. Use `invite.get("raw_uri", "")` for the
   full URI when you need to log unparsed cases.
@@ -469,7 +469,7 @@ Two flavors:
 - **Targeted invite** — you know the friend's XUID and want to
   push the invite without surfacing UI. Use
   `Lobby.get_friends_async()` (Step 5a) to pull a real friends
-  list from the Xbox Social Manager instead of asking the player
+  list from the XBOX Social Manager instead of asking the player
   to paste a XUID by hand.
 - **Picker invite** — surface the system **People Picker** so the
   user chooses who to invite.
@@ -509,7 +509,7 @@ Two flavors:
 
 ### Step 5a — Pull a real friends list from Social Manager
 
-The friends list lives in the **Xbox Social Manager**, which
+The friends list lives in the **XBOX Social Manager**, which
 tracks the local user's social graph in the background and exposes
 it as a snapshot of `GDKSocialUser` records (XUID + gamertag +
 presence). Bring it up lazily on first call, then reuse the cached
@@ -593,7 +593,7 @@ Notes:
 - Always destroy the group in `_exit_tree`. Leaving it alive after
   the autoload is gone keeps the Social Manager doing background
   work for nothing.
-- For testing the targeted invite path without two real Xbox
+- For testing the targeted invite path without two real XBOX
   accounts, fall back to the system picker
   (`show_invite_ui_async`) which uses the shell's own friends
   view and works against test sandbox accounts immediately.
@@ -639,7 +639,7 @@ Notes:
   flows where the inviter is advertising a different "lobby" than
   the one they want the invitee to join (rare; mostly relevant for
   staged invite flows where the inviter has not joined yet).
-- `show_invite_ui_async` is a thin wrapper over the system Xbox
+- `show_invite_ui_async` is a thin wrapper over the system XBOX
   People Picker. The UI surfaces the user's friends list with
   multi-select; the actual invites go out automatically once the
   user confirms. The awaited result fires when the picker closes,
@@ -831,7 +831,7 @@ republished activity:
 | `set_activity failed: invalid_connection_string` | `_lobby.connection_string` was empty when `_publish_activity` was called. | Make sure you call `_publish_activity` **after** `create_lobby_async` / `join_lobby_async` resolves — the connection string is populated as part of that completion. |
 | `set_activity failed: auth_invalid_scid` | The PC's sandbox SCID does not match Partner Center. | See [Troubleshooting → SCID mismatch](../troubleshooting.md). |
 | `invite_accepted` never fires when a friend taps Join | The PC and the friend are in different sandboxes, or the friend's title's SCID does not match yours. | Both sides must be in the same sandbox, with the same SCID published. |
-| `invite_accepted` fires with `invite.get("connectionstring", "") == ""` | The invite was issued against a non-PlayFab activity (e.g. a stale Xbox-only MPSD session from an earlier build), or you passed an empty `connection_string` to `send_invites_async`. | Always advertise a real lobby connection string in `set_activity_async`, and let `send_invites_async` default to it. |
+| `invite_accepted` fires with `invite.get("connectionstring", "") == ""` | The invite was issued against a non-PlayFab activity (e.g. a stale XBOX-only MPSD session from an earlier build), or you passed an empty `connection_string` to `send_invites_async`. | Always advertise a real lobby connection string in `set_activity_async`, and let `send_invites_async` default to it. |
 | `send_invites failed: invalid_xuids` | One or more entries in the `xuids` PackedStringArray was not a valid base-10 XUID. | XUIDs are decimal strings (e.g. `"2814635463725476"`) — not gamertags. Pull them from `Lobby.get_friends_async()` (Step 5a) — each `GDKSocialUser.xuid` is in the correct format. |
 | `delete_activity failed: not_found` | No activity was ever set, or the runtime restarted between set and delete. | Safe to ignore — the user is already not advertising. |
 

--- a/docs/tutorials/07-playfab-party.md
+++ b/docs/tutorials/07-playfab-party.md
@@ -38,8 +38,8 @@ Sample output (host side):
 ## Prerequisites
 
 - [Tutorial 1 — Sign in a user](01-sign-in-user.md) is complete and
-  `Auth.playfab_user` resolves to an Xbox-backed PlayFab session on
-  both sides. Custom-ID sessions also work for Party but Xbox-shell
+  `Auth.playfab_user` resolves to an XBOX-backed PlayFab session on
+  both sides. Custom-ID sessions also work for Party but XBOX-shell
   invites will not.
 - [Tutorial 5 — Create and join a lobby](05-multiplayer-lobby.md) is
   complete. This tutorial assumes the host has already called
@@ -59,7 +59,7 @@ Sample output (host side):
   be enabled manually. See
   [PlayFab title prerequisites — §2 Party](../playfab/prerequisites.md#party-t7-t8).
 - Two Godot processes (host + client), each signed into a different
-  Xbox test account in the same sandbox. As with the lobby tutorial,
+  XBOX test account in the same sandbox. As with the lobby tutorial,
   the easiest setup is one editor scene as host and an exported
   build as client; two editors with different PlayFab sessions also
   work.
@@ -697,7 +697,7 @@ Notes:
   (covered in Step 7); checking permissions at network-create
   time would be too early — the peer isn't there yet.
 - For chat permission **changes mid-session** (the local user
-  blocks a remote peer through the Xbox shell), the addon fires
+  blocks a remote peer through the XBOX shell), the addon fires
   `chat_permissions_changed(peer_id, permissions)`. Re-run the
   same `check_permission_async` flow against the affected peer
   in response and call `set_peer_chat_permissions_async` again.
@@ -913,7 +913,7 @@ Common failures:
 | Output | Diagnosis | Fix |
 |---|---|---|
 | `init failed: party_not_initialized` | `PartyManager` startup failed. | Check that the title has **Multiplayer → Party** enabled in PlayFab Game Manager and that `PlayFab.initialize()` resolved cleanly. |
-| `create_and_join failed: party_invalid_user` | The signed-in `PlayFabUser` doesn't have an entity token, or the title id doesn't match. | Run Tutorial 1's sign-in to completion; `PlayFab.users.sign_in_*` must resolve to an Xbox-backed or Custom-ID `PlayFabUser` first. |
+| `create_and_join failed: party_invalid_user` | The signed-in `PlayFabUser` doesn't have an entity token, or the title id doesn't match. | Run Tutorial 1's sign-in to completion; `PlayFab.users.sign_in_*` must resolve to an XBOX-backed or Custom-ID `PlayFabUser` first. |
 | `create_and_join failed: party_network_create_failed` or `party_network_connect_failed` | The Party service rejected the create or the local user failed to authenticate into the new network. | Re-check the title's Party configuration; verify the network and the local user are not already part of another network (`party_network_already_active`). |
 | `join_network failed: party_descriptor_invalid` | The descriptor string was empty or malformed when the client called `join_network_async`. | Confirm the host's descriptor arrived through `change.lobby.properties` and is non-empty before joining. |
 | Host prints `Network created` but never `Descriptor ready` | The descriptor finalization didn't reach `NETWORK_CHANGE_DESCRIPTOR_UPDATED` and was not populated synchronously after the await either. | Confirm `_network.state_changed` is connected in `host_party()` before yielding control; do not reassign `_network` between the await and the signal. |
@@ -957,7 +957,7 @@ From here you might also want to:
 - **Cross-platform voice.** Set
   `direct_peer_connectivity = DIRECT_PEER_CONNECTIVITY_ANY`
   on `PlayFabPartyConfig` (as in the snippets above) when you
-  expect PC ↔ Xbox sessions. `DIRECT_PEER_CONNECTIVITY_ANY` is
+  expect PC ↔ XBOX sessions. `DIRECT_PEER_CONNECTIVITY_ANY` is
   shorthand for "any platform type + any login provider", which is
   the SDK's required pairing. Same-platform-only is a small latency
   win when you ship single-platform builds — e.g.

--- a/docs/tutorials/08-integration-tech-demo.md
+++ b/docs/tutorials/08-integration-tech-demo.md
@@ -69,7 +69,7 @@ out side by side.
 - `playfab/runtime/initialize_on_startup` and
   `gdk/runtime/initialize_on_startup` are both `true` so the two
   runtimes are up by the time the dashboard's panels query them.
-- A signed-in Xbox test account with at least one **declared
+- A signed-in XBOX test account with at least one **declared
   achievement** in Partner Center (any progress-style achievement
   works) and a **PlayFab statistic + a leaderboard that sources the
   statistic** configured in Game Manager (the snippets below use
@@ -774,7 +774,7 @@ once, and every panel that depends on them benefits:
   `batch_check_permission_async("play_multiplayer", xuids)`
   filter through the same `Lobby.invite_friend` autoload helper.
   The picker invite path (`show_invite_ui_async`) does its own
-  permission filtering inside the Xbox shell.
+  permission filtering inside the XBOX shell.
 - The **Party** autoload (T7 Step 6) decides whether to enable
   voice / text on the `PlayFabPartyConfig` based on the local
   user's `Communications` + `CommunicationVoiceIngame`
@@ -832,7 +832,7 @@ error fires.
 | HUD says "Signing in…" forever | `Auth` is stuck in `SIGNING_IN_*`. | Check the Output panel for a `[Auth] sign-in failed at <stage>: <message>` line and run the matching T1 fix. The HUD retry button re-runs `Auth.sign_in()` without restarting the scene; `sign_in()` resets stale failure state on each retry. |
 | Achievements panel `Status` is "Achievement 1 not yet in cache" indefinitely | The achievement id passed in `ACHIEVEMENT_ID` does not match a declared achievement in Partner Center. | Update `ACHIEVEMENT_ID` to one of your declared ids (a numeric string like `"2"`, not a slug). |
 | Leaderboard panel renders `(no entries)` even after a successful record | Statistic-to-leaderboard propagation is eventually consistent, or the leaderboard's source statistic does not match `STATISTIC_NAME`. | Wait 1–10 seconds and click **Refresh**. If still empty, confirm in Game Manager that `LEADERBOARD_NAME` matches a leaderboard sourced from the statistic named `STATISTIC_NAME`, and that the entity type seeded by your sign-in (`title_player_account`) matches the statistic's expected entity. See T3's common-failures table for the same diagnoses. |
-| Game Saves panel `_save_folder` stays empty | `add_user_with_ui_async` failed. | Most common cause: the PlayFab session is custom-id rather than Xbox-backed. See T4's common failures table. |
+| Game Saves panel `_save_folder` stays empty | `add_user_with_ui_async` failed. | Most common cause: the PlayFab session is custom-id rather than XBOX-backed. See T4's common failures table. |
 | MPA panel shows "Advertising …" but the second client never sees a join card | Sandbox mismatch between PC and friend's PC. | See [Troubleshooting → Sandbox mismatch](../troubleshooting.md). |
 | Party panel chat send returns ok but no remote ever receives it | The remote peer's chat control had not been mapped at send time (zero broadcast targets). | Wait for `PlayFabPartyPeer.chat_control_added(peer_id, control)` for at least one remote peer before exposing the chat send UI — same diagnosis as T7. |
 | `_on_runtime_error` fires every frame for the same service | Stale connection that the addon keeps retrying. | Restart the runtime: `PlayFab.shutdown()` then `PlayFab.initialize()` from the HUD's retry button, or recreate the Party network from the Party panel. |

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,6 +1,6 @@
 # Tutorials
 
-Task-oriented walkthroughs for the Godot for XBOX on PC addons. The tutorial
+Task-oriented walkthroughs for the Godot XBOX addons. The tutorial
 chain takes you from a fresh project to a single integrated tech
 demo — sign-in, achievements, leaderboards, game saves, lobby,
 multiplayer activity, Party chat — with each step landing one
@@ -9,16 +9,16 @@ addon surface. A separate standalone track covers GameInput.
 If you have not enabled the addons yet, start with
 [Addons getting started](../addon-getting-started.md). It covers
 copying the addons into a project, setting the PlayFab title id,
-creating the `MicrosoftGame.config`, switching the Xbox sandbox, and
-signing a user into both Xbox Live and PlayFab. Every tutorial below
+creating the `MicrosoftGame.config`, switching the XBOX sandbox, and
+signing a user into both XBOX Live and PlayFab. Every tutorial below
 assumes you have completed that quickstart.
 
-> **You also need a Partner Center title with Xbox Live configured.**
+> **You also need a Partner Center title with XBOX Live configured.**
 > The quickstart links above assume you already have one. If you don't,
-> start at the [ID@Xbox program](https://www.xbox.com/en-us/developers/id),
+> start at the [ID@XBOX program](https://www.xbox.com/en-us/developers/id),
 > register your title in the
 > [Partner Center dashboard](https://partner.microsoft.com/dashboard),
-> and follow [Microsoft GDK — Configuring Xbox services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
+> and follow [Microsoft GDK — Configuring XBOX services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
 > to surface the Title ID and SCID values the addon quickstart asks for.
 
 > **And a PlayFab title.** Every tutorial below talks to PlayFab. The
@@ -119,7 +119,7 @@ open either project in Godot.
   and is reused in the capstone. Drop the standalone GameInput
   tutorial wherever it fits your input-handling story.
 - **Sign-in + identity only**: T1. Stop after T1 if all you need
-  is "let the user sign into Xbox Live and PlayFab from my game".
+  is "let the user sign into XBOX Live and PlayFab from my game".
 - **Single-player progression**: T1 → T2 → T3 → T4. Stop after T4 if
   you do not need any multiplayer surface.
 - **Multiplayer without voice**: T1 → T5 → T6. Stop after T6 if you

--- a/docs/tutorials/gameinput-action-bridge.md
+++ b/docs/tutorials/gameinput-action-bridge.md
@@ -4,7 +4,7 @@
 > cumulative chain (Sign-in → Achievements → Leaderboards → Game
 > Saves → Lobby → MPA → Party → Capstone). You can read it before,
 > after, or in parallel with that chain — it does not depend on
-> a signed-in Xbox user or any PlayFab state.
+> a signed-in XBOX user or any PlayFab state.
 
 ## What you'll build
 
@@ -22,9 +22,9 @@ gamepad into Godot's standard `InputMap`. By the end:
   `GameInput.device_connected` / `device_disconnected` signals.
 
 When it works, a Sprite that uses `move_left` / `move_right` /
-`jump` reacts to gamepad input even when the player's Xbox
+`jump` reacts to gamepad input even when the player's XBOX
 controller would otherwise be routed through GameInput-only paths
-(some Windows builds, all GDK title-process builds).
+(some Windows builds, all Microsoft GDK title-process builds).
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ controller would otherwise be routed through GameInput-only paths
 - A scratch Godot project with a single scene to attach the
   mapper to. You do **not** need to have followed any tutorial
   in the main cumulative chain — GameInput is entirely
-  independent of Xbox / PlayFab sign-in.
+  independent of XBOX / PlayFab sign-in.
 - `game_input/runtime/initialize_on_startup` is set to `true`.
   This defaults to `false`, so flip it explicitly in
   **Project Settings → Game Input → Runtime** (or call
@@ -45,7 +45,7 @@ controller would otherwise be routed through GameInput-only paths
   auto-poll, `GameInputMapper` calls poll defensively per frame
   anyway — auto-poll is mostly a perf optimization when multiple
   consumers share state.
-- A wired or wireless Xbox controller (or other GameInput-compatible
+- A wired or wireless XBOX controller (or other GameInput-compatible
   gamepad) plugged into the dev PC. The action bridge is
   GDScript-only on top of `GameInput` — it works on any
   GameInput-supported device kind.
@@ -72,9 +72,9 @@ controller would otherwise be routed through GameInput-only paths
 
 > **GameInput vs. Godot's built-in joypad backend.** Godot has its
 > own joypad backend that delivers `InputEventJoypadButton` and
-> `InputEventJoypadMotion`. GameInput is the GDK runtime that
-> exposes the same hardware through the Xbox-supported input stack.
-> Use this tutorial when your project ships to GDK targets (so the
+> `InputEventJoypadMotion`. GameInput is the Microsoft GDK runtime that
+> exposes the same hardware through the XBOX-supported input stack.
+> Use this tutorial when your project ships to Microsoft GDK targets (so the
 > built-in backend may not see the controller) or when you want
 > richer feedback like impulse triggers and per-motor rumble.
 
@@ -266,7 +266,7 @@ process lifetime.
 ## Step 6 — (Optional) Sanity-check the runtime
 
 When a build runs without a GameInput-capable host (for example a
-non-GDK Windows build that did not satisfy
+non-Microsoft GDK Windows build that did not satisfy
 `GameInputCreate()`), every GameInput call soft-fails into a safe
 default and `GameInput.is_initialized()` returns `false`. Your
 gameplay code keeps working off keyboard input; the mapper just
@@ -302,7 +302,7 @@ Common failures:
 | Single `push_warning` per missing action like `[GameInputMapper] Action not found in InputMap: 'jump'` | The action name on a `GameInputBinding` does not exist in **Project Settings → Input Map**. | Add the action, or fix the typo on the binding. |
 | Action fires twice (e.g., your jump triggers a double-jump) | A native joypad event for the same button is bound in the Input Map AND the mapper is also firing. | Either remove the native joypad event for that action, or accept the mapper's automatic skip (it should detect this case — if it doesn't, file a bug). |
 | Analog stick "snaps" to full strength at a small tilt | `deadzone` on the axis binding is too low. | Raise `deadzone` to `0.2` or higher (the default). |
-| `[Pad] GameInput runtime not available` on a GDK build | `GameInputCreate()` failed at runtime. | Check that the GDK is installed on the target machine and the addon `bin/` ships with the build. |
+| `[Pad] GameInput runtime not available` on a Microsoft GDK build | `GameInputCreate()` failed at runtime. | Check that the Microsoft GDK is installed on the target machine and the addon `bin/` ships with the build. |
 
 ## Reference implementation
 
@@ -331,7 +331,7 @@ The end-state lives in the standalone GameInput sample at
 - **Per-player binding for split-screen.** The hot-plug handler in
   Step 5 is the starting point — extend it to pin specific device
   ids to per-player `GameInputMapper` nodes.
-- **Wire GameInput into a signed-in Xbox session.** If you also
+- **Wire GameInput into a signed-in XBOX session.** If you also
   built through the main cumulative chain (signs in, lobbies,
   Party, MPA), the [capstone integration tech demo](08-integration-tech-demo.md)
   is the natural place to drop the gamepad autoload alongside the


### PR DESCRIPTION
## Summary

This PR applies consistent brand-name spellings across the `docs/` tree:

- **`GDK` → `Microsoft GDK`** — in prose only. Skipped when already prefixed with `Microsoft` (e.g. `Microsoft GDK`, `Microsoft public GDK`, `Microsoft.Gaming.GDK`), and when inside inline code, code blocks, URLs, or compound identifiers like `GDKResult` and `GDK.users`.
- **`Xbox` / `xbox` → `XBOX`** — case-sensitive in prose only; existing `XBOX` is left alone, and anything inside backticks, fenced code blocks, or URLs is preserved verbatim.
- **`Godot for Xbox on PC` (and variants) → `Godot XBOX`** — normalizes the product name to the canonical short form already used in headings such as `# Godot XBOX Documentation`.

## What is protected (unchanged)

- Fenced code blocks (```` ``` ```` … ```` ``` ````)
- Inline code spans (`` ` `` … `` ` ``)
- Markdown link and image URL targets (the `(url)` portion of `[text](url)`)
- Bare HTTP(S) URLs
- HTML comments

## Anchor links updated

Two anchors needed to be updated because the heading text they reference changed in a way that affects the GitHub-generated anchor:

| Old anchor | New anchor |
|---|---|
| `#source-for-the-gdk-dependency` | `#source-for-the-microsoft-gdk-dependency` |
| `#replacing-gaming-services-with-the-gdk-shipped-build` | `#replacing-gaming-services-with-the-microsoft-gdk-shipped-build` |

Other renamed headings (`Xbox` → `XBOX`, etc.) keep the same lowercased anchor and required no link fixes.

## Notes for reviewers

- The literal editor export-platform label **`Xbox GDK (PC)`** is a UI string that ships in the editor. Where it appeared as bolded prose in `docs/gdk/sample-setup.md`, I wrapped it in backticks so the verbatim label is preserved (it was already backticked in every other occurrence).
- A few UI labels still get rewritten by the rules (e.g. the top-level **GDK** editor menu becomes **Microsoft GDK** in the docs). If you want UI labels to match the in-product strings exactly, the follow-up is to wrap each label occurrence in backticks; happy to do that pass if you prefer.
- 30 of 31 `.md` files under `docs/` changed. `docs/playfab/async-system.md` had no relevant references and was untouched.

## How this was generated

A small Python script walks every `.md` file under `docs/`, protects code/URL/HTML regions with placeholders, applies the three substitutions, and then restores the protected regions verbatim. The script is not committed; if you want it kept under `tools/` for future re-runs let me know and I will add it in a follow-up.