### PR TITLE
docs: remove release-zip references and update repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the **first step** in our Godot for XBOX on PC integration journey. We p
 
 ## Addons
 
-The addons are designed to be dropped into any Godot 4.5+ project — most developers will consume them as a prebuilt addon zip. This repository is where the addons are authored, built, tested, and demonstrated through the tutorial sample projects under `sample/tutorial_app/` and `sample/tutorial_gameinput/`.
+The addons are designed to be dropped into any Godot 4.5+ project. This repository is where the addons are authored, built, tested, and demonstrated through the tutorial sample projects under `sample/tutorial_app/` and `sample/tutorial_gameinput/`. Build the addons from source per [Getting started](docs/getting-started.md), then drop the addon folders into your project.
 
 | Addon | Description |
 |-------|-------------|
@@ -40,7 +40,7 @@ Start here:
 
 - [**Documentation index**](docs/README.md) — full doc tree
 - [**Getting started**](docs/getting-started.md) — clone, build, install the addons in your own Godot project, and sign in
-- [**Addons quickstart**](docs/addon-getting-started.md) — drop-in addon zip in an existing project
+- [**Addons quickstart**](docs/addon-getting-started.md) — drop the addons into an existing Godot project
 - [**Tutorials**](docs/tutorials/README.md) — task-oriented walkthroughs (sign-in, achievements, leaderboards, Game Saves, lobbies, Multiplayer Activity, PlayFab Party, integration tech demo) plus a standalone GameInput track
 - [**Troubleshooting**](docs/troubleshooting.md) — common build, runtime, and test issues
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Microsoft public GDK.
 docs/
 ├── README.md                                — this index
 ├── getting-started.md                       — onboarding (repo build + first sign-in)
-├── addon-getting-started.md                 — addon-zip quickstart
+├── addon-getting-started.md                 — drop-in addons quickstart
 ├── async-patterns.md                        — one-page async-system primer
 ├── troubleshooting.md                       — common build, runtime, and test issues
 ├── tutorials/                               — task-oriented walkthroughs
@@ -28,8 +28,9 @@ docs/
   project, configuring project settings, getting to user sign-in (XBOX
   + PlayFab), and building from source
 - [**Addons getting started**](addon-getting-started.md) — short
-  quickstart shipped inside the addon zip (enable, set PlayFab title
-  id, create game config, switch sandbox, sign in)
+  quickstart for dropping the addons into an existing Godot project
+  (enable, set PlayFab title id, create game config, switch sandbox,
+  sign in)
 - [**Tutorials**](tutorials/README.md) — task-oriented walkthroughs
   for sign-in, achievements, leaderboards, Game Saves, lobbies,
   Multiplayer Activity, PlayFab Party, the integration tech demo

--- a/docs/addon-getting-started.md
+++ b/docs/addon-getting-started.md
@@ -1,14 +1,17 @@
 # Godot XBOX addons — getting started
 
-A quickstart for the addon zip. This walks through enabling the addons,
-setting the PlayFab title id, creating the MicrosoftGame.config, switching
-the XBOX sandbox, and signing a user in — first into XBOX Live, then
-into PlayFab.
+A quickstart for dropping the addons into your Godot project. This
+walks through enabling the addons, setting the PlayFab title id,
+creating the MicrosoftGame.config, switching the XBOX sandbox, and
+signing a user in — first into XBOX Live, then into PlayFab.
 
-For the full repo guide (building from source, samples, deeper API
-notes), see `docs/getting-started.md` in the source repo.
+For the full repo guide (building the addons from source, samples,
+deeper API notes), see [`docs/getting-started.md`](getting-started.md).
 
-## What's in the zip
+## Addon layout
+
+After you've built the addons (see [Getting started](getting-started.md)),
+the staged drop-in layout is:
 
 ```
 addons/
@@ -79,8 +82,8 @@ your Godot project's `addons/` directory.
 
 ## 1. Enable the addons
 
-1. Drop the `addons/` directory from this zip into your Godot project
-   root (so you end up with `your_project/addons/godot_gdk/...`).
+1. Drop the addon folders into your Godot project's `addons/`
+   directory (so you end up with `your_project/addons/godot_gdk/...`).
 2. Open the project in Godot once so it discovers the new
    `plugin.cfg` files.
 3. Go to **Project — Project Settings — Plugins** and tick the box for
@@ -332,5 +335,5 @@ snippets above tells you which step failed.
   Manager…** (list / install / uninstall registered packages) and
   **Project — Export…** integration for building MSIXVC or loose
   packages.
-- For the full source-level guide, see the repo at
-  <https://github.com/gaming-microsoft/godot-public-gdk-ext>.
+- For the full source-level guide, see
+  [`docs/getting-started.md`](getting-started.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,8 +43,8 @@ account.
   64-bit)
 - [Microsoft GDK](https://github.com/microsoft/GDK/releases) installed
   (`winget install Microsoft.Gaming.GDK`)
-- A built copy of each addon you want to use — either a release zip,
-  or built from source per **Step 1** below
+- A built copy of each addon you want to use — built from source per
+  **Step 1** below
 - For XBOX-services tutorials (T1+): a Partner Center title + SCID +
   sandbox test account
 - For PlayFab tutorials (T1+): a PlayFab title id
@@ -53,8 +53,8 @@ account.
   Godot project)
 
 > **TL;DR**
-> 1. Get the addon binaries (download a release zip, or build one from source).
-> 2. Extract or copy `addons/<addon>/` into your project, including the `bin/` folder.
+> 1. Build the addon binaries from source (Step 1 below).
+> 2. Copy `addons/<addon>/` into your project, including the `bin/` folder.
 > 3. Enable the editor plugin in **Project Settings → Plugins**.
 > 4. Set the `gdk/runtime/*` and `playfab/*` project settings.
 > 5. Subscribe to `GDK.users.user_changed` (XBOX) and call
@@ -150,25 +150,15 @@ for the canonical addon-side walk-through.
 
 ---
 
-## 1. Get the addon binaries
+## 1. Build the addon binaries
 
-You need a built copy of each addon you want to use. Use a tagged release zip
-when one is available, or generate the same drop-in layout from source.
-
-### Option A — Download a release (when available)
-
-If a release zip has been published at
-<https://github.com/gaming-microsoft/godot-public-gdk-ext/releases>, unzip
-the `addons/<addon>/` directory of each addon you want into your project's
-`addons/` folder. Skip ahead to **Step 2 — Copy the addons**.
-
-### Option B — Build a drop-in zip from source
-
-Clone with submodules and run the package helper:
+You need a built copy of each addon you want to use. Build the
+drop-in layout from source: clone with submodules and run the package
+helper.
 
 ```powershell
-git clone --recurse-submodules https://github.com/gaming-microsoft/godot-public-gdk-ext.git
-cd godot-public-gdk-ext
+git clone --recurse-submodules https://github.com/microsoft/Godot-XBOX.git
+cd Godot-XBOX
 
 .\tools\package_addons.ps1
 ```
@@ -176,8 +166,9 @@ cd godot-public-gdk-ext
 The helper configures the `addon-package` CMake preset, builds Debug and
 Release native addon DLLs by default, stages the drop-in addon files under
 `build\dist\godot-gdk-addons\addons\`, and writes
-`build\dist\godot-gdk-addons-debug-release.zip`. Extract that zip into your
-Godot project root, or copy only the addon folders you need.
+`build\dist\godot-gdk-addons-debug-release.zip`. Copy the addon folders
+you need from `build\dist\godot-gdk-addons\addons\` into your Godot
+project's `addons/` folder (or extract the zip there).
 
 The package build:
 
@@ -508,8 +499,8 @@ themselves.
 ### Clone with submodules
 
 ```powershell
-git clone --recurse-submodules https://github.com/gaming-microsoft/godot-public-gdk-ext.git
-cd godot-public-gdk-ext
+git clone --recurse-submodules https://github.com/microsoft/Godot-XBOX.git
+cd Godot-XBOX
 ```
 
 If you've already cloned without submodules:
@@ -520,7 +511,8 @@ git submodule update --init --recursive
 
 ### Build
 
-For a consumer-ready zip:
+For a packaged drop-in build (stages addons under `build\dist\` and
+produces an addons zip):
 
 ```powershell
 .\tools\package_addons.ps1

--- a/docs/playfab/prerequisites.md
+++ b/docs/playfab/prerequisites.md
@@ -374,7 +374,7 @@ the diagnostic next steps.
 ## Related docs
 
 - [Addons getting started](../addon-getting-started.md) — the
-  addon-zip quickstart, including the `playfab/runtime/title_id`
+  drop-in addons quickstart, including the `playfab/runtime/title_id`
   setting step that this page elaborates on.
 - [XBOX sandbox and test accounts](../platform/xbox-sandbox-and-test-accounts.md)
   — the XBOX-side companion to this page. PlayFab tutorials assume


### PR DESCRIPTION
## Summary

Branch `docs/cleanup-release-zip-refs`. Removes references to a release zip that does not exist (the repo has no published releases) and updates outdated internal-mirror repo URLs to the public `microsoft/Godot-XBOX` repo.

## Public API changes

None — documentation-only change.

```gdscript
# No API surface touched.
```

## Spec / docs / samples updated

- [ ] `spec\gdext-<feature>.md` updated (Plan / Progress sections if multi-session work)
- [x] `docs\godot-<addon>-*.md` updated — root `README.md`, `docs/README.md`, `docs/getting-started.md`, `docs/addon-getting-started.md`, `docs/playfab/prerequisites.md`
- [ ] `addons\<addon>\doc_classes\*.xml` updated for any public API change
- [ ] Sample content (`sample\<host>\`) updated when public addon behaviour changed
- [ ] Path-scoped instruction file (`.github\instructions\<addon>.instructions.md`) updated if conventions changed
- [x] Not applicable — no public addon behaviour changed

## Test coverage delta

- Contract (offline) tests added/removed: none
- Live-read tests added/removed: none
- Live-write tests added/removed: none
- Live title id used (if any): none

## Validation run

No `.gd` files were touched, so the parse gate was not required, and `tools\run_all_tests.ps1` was not run. This is a documentation-only change per `code_change_instructions` (`Documentation changes do not need to be linted, built or tested unless there are specific tests for documentation`).

```text
# parse gate          -> not applicable (no .gd files touched)
# run_all_tests.ps1   -> not applicable (no runtime / .gd / native code touched)
```

What changed (per file):

- `README.md` — drop `prebuilt addon zip` framing in the Addons paragraph and rephrase the `Addons quickstart` bullet.
- `docs/README.md` — rename `addon-zip quickstart` to `drop-in addons quickstart` in the folder-structure block and the Addons-getting-started bullet.
- `docs/getting-started.md`:
  - Drop the dead `Option A — Download a release` section pointing to `https://github.com/gaming-microsoft/godot-public-gdk-ext/releases`.
  - Inline the build-from-source helper as the only path to obtain the addon binaries; rename Section 1 to `Build the addon binaries`.
  - Replace `github.com/gaming-microsoft/godot-public-gdk-ext` clone URLs (internal dev mirror) with `github.com/microsoft/Godot-XBOX` (the public repo) in both the quickstart and `Building from source` clone blocks.
  - Update `TL;DR` and prerequisites bullet to drop the `release zip` wording.
- `docs/addon-getting-started.md` — reframe intro and `What's in the zip` section as `Addon layout`; fix `Drop the addons/ directory from this zip` instruction; replace the trailing `see the repo at gaming-microsoft/...` pointer with an in-repo link to `getting-started.md`.
- `docs/playfab/prerequisites.md` — rename the cross-reference label from `addon-zip quickstart` to `drop-in addons quickstart`.

`tools\package_addons.ps1` is kept as a documented build path because it still produces a real staged addons drop under `build\dist\`; it is just no longer described as the `consumer-ready zip` workflow.

## Migration notes

None.
