### PR TITLE
fix(gdk,playfab): pass MicrosoftGame.config to XGameRuntimeInitializeWithOptions

### DIFF
--- a/addons/godot_gdk/src/gdk_runtime.cpp
+++ b/addons/godot_gdk/src/gdk_runtime.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include <godot_cpp/classes/project_settings.hpp>
+
 #include "gdk_pending_signal.h"
 #include "gdk_result.h"
 
@@ -14,6 +16,71 @@ constexpr bool GDK_PLATFORM_AVAILABLE = true;
 #else
 constexpr bool GDK_PLATFORM_AVAILABLE = false;
 #endif
+
+constexpr const char *GAME_CONFIG_RES_PATH = "res://MicrosoftGame.config";
+
+// Process-lifetime storage for the UTF-8 path handed to
+// XGameRuntimeInitializeWithOptions. The GDK runtime is a process-lifetime
+// resource and we initialize it at most once per process, so a single static
+// buffer is sufficient. Keeping the bytes alive here removes any reliance on
+// the XGameRuntimeInitializeWithOptions copy semantics, which the public
+// XGameRuntimeInit.h header does not document either way.
+CharString g_xgame_runtime_config_path;
+
+// Resolves res://MicrosoftGame.config to an absolute OS path, or returns an
+// empty String when the file is not present on disk. Uses GetFileAttributesExW
+// instead of Godot's FileAccess so a config that lives inside a packed .pck is
+// not mistaken for a real file (XGameRuntime cannot read from inside a .pck).
+String _resolve_game_config_path() {
+    ProjectSettings *settings = ProjectSettings::get_singleton();
+    if (settings == nullptr) {
+        return String();
+    }
+
+    String resolved = settings->globalize_path(GAME_CONFIG_RES_PATH);
+    if (resolved.is_empty() || resolved.begins_with("res://")) {
+        return String();
+    }
+
+    Char16String wide_path = resolved.utf16();
+    WIN32_FILE_ATTRIBUTE_DATA attrs = {};
+    BOOL ok = GetFileAttributesExW(
+            reinterpret_cast<LPCWSTR>(wide_path.get_data()),
+            GetFileExInfoStandard,
+            &attrs);
+    if (!ok) {
+        return String();
+    }
+    if ((attrs.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        return String();
+    }
+    return resolved;
+}
+
+// Calls XGameRuntimeInitializeWithOptions when res://MicrosoftGame.config is
+// on disk so unpackaged Godot dev runs (editor or `godot project.godot`) pick
+// up the game config explicitly and avoid the "no package identity" HRESULT
+// class that XGameGetXboxTitleId / XblInitialize otherwise surface downstream
+// as xbox_title_id_unavailable. Falls back to XGameRuntimeInitialize() for
+// packaged GDK launches, where the registered package supplies identity.
+//
+// r_config_path is set to the absolute path passed into
+// XGameRuntimeInitializeWithOptions, or to an empty String when the fall-back
+// path was taken; callers include it in their failure message.
+HRESULT _initialize_xgame_runtime(String &r_config_path) {
+    String resolved = _resolve_game_config_path();
+    if (resolved.is_empty()) {
+        r_config_path = String();
+        return XGameRuntimeInitialize();
+    }
+
+    g_xgame_runtime_config_path = resolved.utf8();
+    XGameRuntimeOptions options = {};
+    options.gameConfigSource = XGameRuntimeGameConfigSource::File;
+    options.gameConfig = g_xgame_runtime_config_path.get_data();
+    r_config_path = resolved;
+    return XGameRuntimeInitializeWithOptions(&options);
+}
 
 } // namespace
 
@@ -43,9 +110,14 @@ Ref<GDKResult> GDKRuntime::initialize() {
     }
 
     if (!m_xgame_runtime_initialized) {
-        HRESULT hr = XGameRuntimeInitialize();
+        String attempted_config_path;
+        HRESULT hr = _initialize_xgame_runtime(attempted_config_path);
         if (FAILED(hr)) {
-            Ref<GDKResult> result = GDKResult::hresult_error(hr, "Failed to initialize GDK runtime.", "runtime_initialize_failed");
+            String message = "Failed to initialize GDK runtime.";
+            if (!attempted_config_path.is_empty()) {
+                message += " Tried game config at: " + attempted_config_path;
+            }
+            Ref<GDKResult> result = GDKResult::hresult_error(hr, message, "runtime_initialize_failed");
             return result;
         }
         m_xgame_runtime_initialized = true;

--- a/addons/godot_gdk/src/gdk_runtime.h
+++ b/addons/godot_gdk/src/gdk_runtime.h
@@ -22,15 +22,20 @@ class GDKResult;
 class GDKRuntime {
     bool m_initialized = false;
     bool m_shutting_down = false;
-    // XGameRuntimeInitialize is documented as a process-lifetime call (paired
-    // with one XGameRuntimeUninitialize before process exit). Repeatedly
-    // cycling Initialize/Uninitialize within a single process - as the test
-    // harness does across many gdk.initialize()/gdk.shutdown() rounds - leaks
-    // GDK runtime threads and triggers a SIGSEGV at process exit during DLL
-    // unload (fault module ntdll.dll). Track the global-init state separately
-    // from the per-session m_initialized flag so XGameRuntimeInitialize runs
-    // at most once per process and XGameRuntimeUninitialize runs only from
-    // ~GDKRuntime().
+    // XGameRuntimeInitialize(WithOptions) is documented as a process-lifetime
+    // call (paired with one XGameRuntimeUninitialize before process exit).
+    // Repeatedly cycling Initialize/Uninitialize within a single process - as
+    // the test harness does across many gdk.initialize()/gdk.shutdown() rounds
+    // - leaks GDK runtime threads and triggers a SIGSEGV at process exit
+    // during DLL unload (fault module ntdll.dll). Track the global-init state
+    // separately from the per-session m_initialized flag so the runtime is
+    // initialized at most once per process and XGameRuntimeUninitialize runs
+    // only from ~GDKRuntime(). The init call resolves to
+    // XGameRuntimeInitializeWithOptions(File, "<abs path>") when
+    // res://MicrosoftGame.config is on disk (so unpackaged dev runs get
+    // package identity from the project-root config), and falls back to
+    // XGameRuntimeInitialize() for packaged GDK launches that get identity
+    // from the registered package.
     bool m_xgame_runtime_initialized = false;
     XTaskQueueHandle m_task_queue = nullptr;
     std::vector<Ref<GDKPendingSignal>> m_active_pending_signals;

--- a/addons/godot_playfab/src/playfab_runtime.cpp
+++ b/addons/godot_playfab/src/playfab_runtime.cpp
@@ -31,6 +31,73 @@ void wait_for_async_completion(HRESULT p_start_hr, XAsyncBlock *p_async_block) {
 constexpr const char *PLAYFAB_TITLE_ID_SETTING = "playfab/runtime/title_id";
 constexpr const char *PLAYFAB_ENDPOINT_SETTING = "playfab/runtime/endpoint";
 
+constexpr const char *GAME_CONFIG_RES_PATH = "res://MicrosoftGame.config";
+
+// Process-lifetime storage for the UTF-8 path handed to
+// XGameRuntimeInitializeWithOptions. The Microsoft GDK runtime is a
+// process-lifetime resource and we initialize it at most once per process, so
+// a single static buffer is sufficient. Keeping the bytes alive here removes
+// any reliance on the XGameRuntimeInitializeWithOptions copy semantics, which
+// the public XGameRuntimeInit.h header does not document either way.
+CharString g_xgame_runtime_config_path;
+
+// Resolves res://MicrosoftGame.config to an absolute OS path, or returns an
+// empty String when the file is not present on disk. Uses GetFileAttributesExW
+// instead of Godot's FileAccess so a config that lives inside a packed .pck is
+// not mistaken for a real file (XGameRuntime cannot read from inside a .pck).
+String _resolve_game_config_path() {
+    ProjectSettings *settings = ProjectSettings::get_singleton();
+    if (settings == nullptr) {
+        return String();
+    }
+
+    String resolved = settings->globalize_path(GAME_CONFIG_RES_PATH);
+    if (resolved.is_empty() || resolved.begins_with("res://")) {
+        return String();
+    }
+
+    Char16String wide_path = resolved.utf16();
+    WIN32_FILE_ATTRIBUTE_DATA attrs = {};
+    BOOL ok = GetFileAttributesExW(
+            reinterpret_cast<LPCWSTR>(wide_path.get_data()),
+            GetFileExInfoStandard,
+            &attrs);
+    if (!ok) {
+        return String();
+    }
+    if ((attrs.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        return String();
+    }
+    return resolved;
+}
+
+// Calls XGameRuntimeInitializeWithOptions when res://MicrosoftGame.config is
+// on disk so unpackaged Godot dev runs (editor or `godot project.godot`) pick
+// up the game config explicitly and avoid the "no package identity" HRESULT
+// class. Falls back to XGameRuntimeInitialize() for packaged GDK launches,
+// where the registered package supplies identity. Mirrors the helper in
+// godot_gdk so both addons feed XGameRuntime the same options; XGameRuntime is
+// ref-counted, and using the same hardcoded path keeps the first caller's
+// options consistent regardless of bootstrap ordering.
+//
+// r_config_path is set to the absolute path passed into
+// XGameRuntimeInitializeWithOptions, or to an empty String when the fall-back
+// path was taken; callers include it in their failure message.
+HRESULT _initialize_xgame_runtime(String &r_config_path) {
+    String resolved = _resolve_game_config_path();
+    if (resolved.is_empty()) {
+        r_config_path = String();
+        return XGameRuntimeInitialize();
+    }
+
+    g_xgame_runtime_config_path = resolved.utf8();
+    XGameRuntimeOptions options = {};
+    options.gameConfigSource = XGameRuntimeGameConfigSource::File;
+    options.gameConfig = g_xgame_runtime_config_path.get_data();
+    r_config_path = resolved;
+    return XGameRuntimeInitializeWithOptions(&options);
+}
+
 } // namespace
 
 PlayFabRuntime::PlayFabRuntime() {
@@ -81,9 +148,14 @@ Ref<PlayFabResult> PlayFabRuntime::initialize() {
     bool game_save_files_initialized = false;
 
     if (!m_xgame_runtime_initialized) {
-        HRESULT runtime_hr = XGameRuntimeInitialize();
+        String attempted_config_path;
+        HRESULT runtime_hr = _initialize_xgame_runtime(attempted_config_path);
         if (FAILED(runtime_hr)) {
-            Ref<PlayFabResult> result = PlayFabResult::hresult_error(runtime_hr, "Failed to initialize the Gaming Runtime.", "runtime_initialize_failed");
+            String message = "Failed to initialize the Gaming Runtime.";
+            if (!attempted_config_path.is_empty()) {
+                message += " Tried game config at: " + attempted_config_path;
+            }
+            Ref<PlayFabResult> result = PlayFabResult::hresult_error(runtime_hr, message, "runtime_initialize_failed");
             return result;
         }
         m_xgame_runtime_initialized = true;

--- a/docs/gdk/async-system.md
+++ b/docs/gdk/async-system.md
@@ -294,7 +294,11 @@ Fields:
 
 `GDKRuntime::initialize()` does two things:
 
-1. calls `XGameRuntimeInitialize()`
+1. calls `XGameRuntimeInitializeWithOptions()` with `File` source pointing at
+   `<project_root>/MicrosoftGame.config` when that file is on disk (so
+   unpackaged Godot dev runs get explicit package identity); falls back to
+   `XGameRuntimeInitialize()` for packaged GDK launches that get identity from
+   the registered package
 2. creates one `XTaskQueue` with:
    - `ThreadPool` work dispatch
    - `Manual` completion dispatch

--- a/docs/gdk/native-runtime.md
+++ b/docs/gdk/native-runtime.md
@@ -72,7 +72,11 @@ Current public shape:
 
 It is responsible for:
 
-- calling `XGameRuntimeInitialize()`
+- calling `XGameRuntimeInitializeWithOptions()` with `File` source pointing at
+  `<project_root>/MicrosoftGame.config` when that file is on disk (so
+  unpackaged Godot dev runs get explicit package identity); falling back to
+  `XGameRuntimeInitialize()` for packaged GDK launches that get identity from
+  the registered package
 - creating the shared `XTaskQueue`
 - retaining in-flight completion signals
 - pumping manual completion dispatch

--- a/docs/playfab/prerequisites.md
+++ b/docs/playfab/prerequisites.md
@@ -53,8 +53,11 @@ derives `https://<titleid>.playfabapi.com` from the Title ID.
 
 `PlayFab.initialize()` / `PlayFab.shutdown()` may be cycled in tools and
 runtime flows. The PlayFab Core/Services/Game Save state and task queue are
-recreated on each initialize, while the Microsoft GDK `XGameRuntimeInitialize` reference
-is held for the process lifetime and released once when the extension unloads.
+recreated on each initialize, while the Microsoft GDK runtime reference
+(acquired through `XGameRuntimeInitializeWithOptions()` when
+`res://MicrosoftGame.config` is on disk, or `XGameRuntimeInitialize()`
+otherwise) is held for the process lifetime and released once when the
+extension unloads.
 
 > **`PlayFab.initialize()` failing with `title_id_required`** indicates
 > the setting is empty at runtime. See

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -161,16 +161,21 @@ git submodule update --init --recursive
 
 **Possible causes:**
 
-1. **Wrong sandbox** — Your PC must be in the same sandbox as your test account:
+1. **`MicrosoftGame.config` missing from project root** — Without it,
+   `XGameRuntimeInitialize()` (or the registered package) cannot provide
+   package identity, and downstream Xbox services init fails with
+   `xbox_title_id_unavailable`. See
+   [No package identity at startup](#no-package-identity-at-startup) below.
+2. **Wrong sandbox** — Your PC must be in the same sandbox as your test account:
    ```powershell
    & "C:\Program Files (x86)\Microsoft GDK\bin\XblPCSandbox.exe"
    ```
    See [Microsoft GDK — Setting up sandboxes](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/sandboxes/live-setup-sandbox)
    and
    [PC Sandbox Switcher (XblPCSandbox.exe)](https://learn.microsoft.com/en-us/gaming/gdk/docs/tools/tools-services/live-pc-sandbox-switcher).
-2. **Using personal account** — The sample requires XBOX test accounts, not
+3. **Using personal account** — The sample requires XBOX test accounts, not
    personal Microsoft accounts.
-3. **Title not configured** — Ensure your title is set up in
+4. **Title not configured** — Ensure your title is set up in
    [Partner Center](https://partner.microsoft.com/dashboard) with XBOX Live
    enabled. See
    [Microsoft GDK — Configuring XBOX services (Title ID + SCID)](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/portal-config/live-service-config-ids-mp)
@@ -178,6 +183,48 @@ git submodule update --init --recursive
 
 See [Sample Project Setup](gdk/sample-setup.md) for the full
 configuration guide.
+
+## No package identity at startup
+
+**Symptom:**
+
+```
+[GDK] initialize failed: code=runtime_initialize_failed, message=Failed to initialize GDK runtime. Tried game config at: <abs path>
+```
+
+or, in a downstream surface that depends on the game config:
+
+```
+[GDK] add_default_user_async failed: code=xbox_title_id_unavailable
+```
+
+or a system-level "no package identity" / `0x80073D54`-class error from the
+Microsoft GDK runtime itself.
+
+**Cause:** Both `godot_gdk` and `godot_playfab` look for
+`res://MicrosoftGame.config` on disk and call
+`XGameRuntimeInitializeWithOptions` with `File` source pointing at that path,
+so unpackaged Godot dev runs (editor or `godot project.godot`) get explicit
+package identity. When the file is missing, the addons fall back to plain
+`XGameRuntimeInitialize()`, which only succeeds in a packaged GDK launch where
+a registered package supplies identity.
+
+**Fix:**
+
+- For unpackaged dev runs, put `MicrosoftGame.config` at the project root next
+  to `project.godot`. The packaging tooling can create a starter file via
+  **Project → Tools → Microsoft GDK → Create MicrosoftGame.config**, or
+  through the CLI:
+  ```powershell
+  & "<godot.exe>" --headless --path . --script res://addons/godot_gdk_packaging/core/packaging_cli.gd -- config_template
+  ```
+- For packaged GDK launches, `wdapp register` the staged loose folder (or
+  install a `.msixvc`) before launching the game so the registered package
+  supplies identity.
+- If the message says `Tried game config at: <path>`, the file at `<path>`
+  was found but the runtime rejected it — open it with the GDK
+  `GameConfigEditor.exe` (or **Project → Tools → Microsoft GDK → Edit
+  MicrosoftGame.config**) and confirm the schema is valid.
 
 ## SCID does not match between `MicrosoftGame.config` and Partner Center
 

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -21,7 +21,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 
 | Domain | Status | Notes |
 | --- | --- | --- |
-| Runtime init/shutdown | Implemented | `XGameRuntimeInitialize`, queue/bootstrap |
+| Runtime init/shutdown | Implemented | `XGameRuntimeInitializeWithOptions` (`File` source) when `res://MicrosoftGame.config` is on disk, otherwise `XGameRuntimeInitialize`; queue/bootstrap |
 | User identity/sign-in | Implemented | `XUser`-backed; not an Xbox Services `xsapi-c` surface |
 | PC GDK helpers | Implemented selectively | Includes launcher, game UI, accessibility, system metadata, and error reporting; these are outside the Xbox Services coverage matrix below |
 | Package metadata and DLC content access | Implemented | `GDK.package` wraps PC-supported `XPackage` enumeration, install progress, package mounts, and resource-pack loading |
@@ -411,7 +411,7 @@ and `GDK.achievements.runtime_error`).
 
 | Public surface | Native API(s) | Notes |
 | --- | --- | --- |
-| `GDK.initialize()` | `XGameRuntimeInitialize`, `XTaskQueueCreate` | Creates the shared task queue and runtime bootstrap state used by all one-shot completion signals and service-owned callback bridges. |
+| `GDK.initialize()` | `XGameRuntimeInitializeWithOptions` (`File` source pointing at `res://MicrosoftGame.config` when that file is on disk; otherwise plain `XGameRuntimeInitialize`), `XTaskQueueCreate` | Creates the shared task queue and runtime bootstrap state used by all one-shot completion signals and service-owned callback bridges. The `WithOptions` path makes unpackaged Godot dev runs (editor or `godot project.godot`) get package identity from the project-root `MicrosoftGame.config` so downstream `XGameGetXboxTitleId` / `XblInitialize` calls do not surface `xbox_title_id_unavailable`. Packaged GDK launches get identity from the registered package and take the plain-init fall-back. |
 | `GDK.shutdown()` | `XTaskQueueTerminate`, `XTaskQueueCloseHandle` | Service and user cleanup runs first; queue teardown happens last. `XGameRuntimeUninitialize()` is intentionally reserved for extension teardown (`~GDKRuntime()`), not each shutdown cycle. |
 | `GDK.dispatch()` | `XTaskQueueDispatch`, `XblAchievementsManagerDoWork`, `XblSocialManagerDoWork`, `XErrorSetCallback` callback-drain bridge | Main-thread pump. Dispatch the completion port, translate native payloads into Godot objects, update caches, then emit signals. |
 | `GDK.launcher.launch_uri()` | `XLaunchUri` (`XLauncher.h`, `xgameruntime.lib`) | PC-supported URI launcher surface for app-to-app, Store, and Settings destinations. |

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -21,7 +21,7 @@ Lobby/matchmaking and Party design work are tracked separately in `spec\gdext-pl
 
 | Domain | Included | Notes |
 | --- | --- | --- |
-| Runtime init/shutdown | Yes | Process-lifetime `XGameRuntimeInitialize` reference, re-armable PlayFab init/shutdown, shared queue |
+| Runtime init/shutdown | Yes | Process-lifetime Microsoft GDK runtime reference (`XGameRuntimeInitializeWithOptions` with `File` source when `res://MicrosoftGame.config` is on disk, otherwise `XGameRuntimeInitialize`), re-armable PlayFab init/shutdown, shared queue |
 | Manual sign-in | Yes | `GDKUser` object and custom-ID entry points |
 | Cached user sessions | Yes | `PlayFabUser` keyed by local Xbox user id or custom id |
 | Game Saves | Yes | add/sync, upload, folder/quota/cloud-state queries |
@@ -81,7 +81,7 @@ The addon registers these Project Settings, but they are consumed by different l
 
 ## Runtime lifecycle
 
-`PlayFab.initialize()` acquires this addon's GDK `XGameRuntimeInitialize` reference the first time the runtime initializes successfully and keeps it for the process lifetime. `PlayFab.shutdown()` tears down PlayFab-owned state (`PFGameSaveFiles`, service config, `PFServices`, `PFInitialize`, pending signals, cached users, and the shared task queue) but deliberately does not call `XGameRuntimeUninitialize`; the matching GDK runtime release happens once during extension teardown. This mirrors the `godot_gdk` singleton/runtime pattern and allows titles or tests to cycle `initialize() -> shutdown() -> initialize()` without racing the process-wide Gaming Runtime, even when both addons are loaded.
+`PlayFab.initialize()` acquires this addon's Microsoft GDK runtime reference the first time the runtime initializes successfully and keeps it for the process lifetime. The runtime reference is acquired through `XGameRuntimeInitializeWithOptions` with `File` source pointing at `<project_root>/MicrosoftGame.config` when that file is on disk (so unpackaged Godot dev runs get explicit package identity), and falls back to `XGameRuntimeInitialize` for packaged GDK launches that get identity from the registered package. `PlayFab.shutdown()` tears down PlayFab-owned state (`PFGameSaveFiles`, service config, `PFServices`, `PFInitialize`, pending signals, cached users, and the shared task queue) but deliberately does not call `XGameRuntimeUninitialize`; the matching GDK runtime release happens once during extension teardown. This mirrors the `godot_gdk` singleton/runtime pattern and allows titles or tests to cycle `initialize() -> shutdown() -> initialize()` without racing the process-wide Gaming Runtime, even when both addons are loaded. Because `godot_gdk` and `godot_playfab` resolve the same hardcoded `res://MicrosoftGame.config` path, the ref-counted Microsoft GDK runtime sees consistent options regardless of which addon's bootstrap initializes first.
 
 ## Async model
 


### PR DESCRIPTION
## Summary

Both `godot_gdk` and `godot_playfab` were calling `XGameRuntimeInitialize()` with no options. On an unpackaged Godot dev run (Godot editor or `godot project.godot`) that yields **no package identity** from the Microsoft GDK runtime, and every downstream surface that depends on package/title identity falls over as a consequence:

- `XGameGetXboxTitleId` → `xbox_title_id_unavailable` (blocks `XblInitialize`, blocks sign-in)
- `XGameActivationRegisterForEvent` → HRESULT `0x80070490` (`ERROR_NOT_FOUND`)
- generally any Xbox-services call that needs SCID / title id

Both addon runtimes now resolve `res://MicrosoftGame.config`, check for it on disk with `GetFileAttributesExW` (intentionally **not** Godot `FileAccess`, so a copy embedded inside a packed `.pck` is not mistaken for a real file `XGameRuntime` can read), and call `XGameRuntimeInitializeWithOptions` with a `File` source pointing at the absolute path. When the file is missing they fall back to plain `XGameRuntimeInitialize()` so packaged GDK launches still get identity from the registered package.

Fixes #60
Fixes #66

## Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| Unpackaged dev run, `res://MicrosoftGame.config` present | `no package identity`, downstream services fail | `XGameRuntimeInitializeWithOptions(File, <abs>)`, identity available |
| Unpackaged dev run, no `MicrosoftGame.config` | `no package identity` | Same fall-back to `XGameRuntimeInitialize()` (clear error message names the path that was checked) |
| Packaged GDK launch (`wdapp register` / installed `.msixvc`) | `XGameRuntimeInitialize()` from registered package | Unchanged — still falls back to `XGameRuntimeInitialize()` because `res://MicrosoftGame.config` is not on the filesystem in the export |

## Implementation notes

- **Pointer lifetime.** `XGameRuntimeOptions::gameConfig` is a raw `const char*` and the GDK header does not document whether it is copied. The UTF-8 path bytes are stored in a process-lifetime `CharString` in each addon so the pointer stays valid regardless. This was the riskiest assumption in the change and is now removed.
- **Cross-addon coordination.** `XGameRuntime` is ref-counted across calls. Both addons resolve the *same* hardcoded path, so whichever bootstrap initializes first locks in consistent options for the other.
- **Diagnostics.** `runtime_initialize_failed` now includes the attempted config path:
  `Failed to initialize GDK runtime. Tried game config at: C:\path\to\MicrosoftGame.config`
- **Test hosts.** `tests/godot/{gdk,playfab,gameinput}` ship no `MicrosoftGame.config` and continue to take the fall-back path. Packaging tests that transiently write the file already clean up after themselves.

## Usage

There is no new public API or project setting. Drop a `MicrosoftGame.config` at your project root next to `project.godot` and the next launch picks it up automatically:

```gdscript
# Unchanged — the WithOptions plumbing is internal.
var init: GDKResult = GDK.initialize()
if not init.ok:
    push_warning("GDK.initialize failed: %s" % init.message)
    # On a misconfigured config, the message now includes the path that was tried.
```

You can create a starter `MicrosoftGame.config` from the **Project → Tools → Microsoft GDK → Create MicrosoftGame.config** menu (or via the `packaging_cli.gd` `config_template` command).

## Files changed

- `addons/godot_gdk/src/gdk_runtime.cpp`, `.h` — `_resolve_game_config_path()` + `_initialize_xgame_runtime()` helpers, threaded into `GDKRuntime::initialize()`.
- `addons/godot_playfab/src/playfab_runtime.cpp` — mirrored helpers, threaded into `PlayFabRuntime::initialize()`.
- `spec/gdext-gdk.md`, `spec/gdext-playfab.md` — scope-table rows and native-runtime mapping rows now mention `WithOptions` and the fall-back.
- `docs/gdk/native-runtime.md`, `docs/gdk/async-system.md`, `docs/playfab/prerequisites.md` — runtime-init descriptions updated.
- `docs/troubleshooting.md` — new **No package identity at startup** entry and cross-link from **XBOX sign-in fails at runtime**.

## Validation

Per repo conventions / Before Reporting Completion:

- **Parse gate:** `tools\check_gd_scripts_headless.ps1` — not strictly needed (no `.gd` files touched), but ran via the orchestrator anyway: PASS.
- **Build:** `cmake --build build --preset debug` — PASS.
- **C++ doctests:** `gdk_unit_tests.exe` — PASS.
- **GUT:** 374 tests across `tests/godot/{gdk,playfab,gameinput}` hosts — PASS (256 + 70 + 53; 50083/50083 asserts).
- **Bootstrap mini-runners:** 10 — PASS.
- **Live tests:** intentionally skipped (no `-Live`; this fix is a pure runtime-init change and does not need live-service coverage to validate). A sandboxed sign-in smoke test against a real `MicrosoftGame.config` is the natural follow-up for the next time someone runs the live tier.