### PR TITLE
Fix sandbox/package dialogs expanding vertically on first open (#61)

### DIFF
--- a/addons/godot_gdk_packaging/editor/gdk_package_manager_dialog.gd
+++ b/addons/godot_gdk_packaging/editor/gdk_package_manager_dialog.gd
@@ -20,6 +20,10 @@ const WdappManagerScript = preload("res://addons/godot_gdk_packaging/core/wdapp_
 
 const COL_PFN := 0
 const COL_AUMID := 1
+# Wrap width for the autowrap labels. Kept below min_size.x (820) so it never
+# forces the window wider, but pins a width so autowrap heights are computed
+# correctly on first open instead of inflating the window vertically.
+const _CONTENT_WIDTH: int = 780
 
 var _toolchain: RefCounted
 var _wdapp_manager: RefCounted
@@ -89,13 +93,21 @@ func _notification(what: int) -> void:
 
 func show_centered_clamped() -> void:
 	_apply_screen_size_cap()
-	# Snap to the layout's calculated minimum so the window opens only as
-	# tall as the current package count + chrome needs. Without this the
-	# Window's prior size (or its size_flags / max_size interaction with
-	# the SIZE_EXPAND_FILL root) makes it open near full-screen height.
-	reset_size()
+	# First-open fix (issue #61). The window's height is derived from its
+	# content's combined minimum size, but an AUTOWRAP Label (the machine-wide
+	# description) only knows its real wrapped height once it has been laid out
+	# against a constrained width. Before the first popup no layout pass has
+	# run, so a pre-show reset_size() overshoots and the window opens near
+	# full-screen height. Show first (which runs a layout pass at the real
+	# min_size width), then snap to the now-correct content size on the next
+	# frame. The screen cap keeps the transient frame on-screen.
 	popup_centered()
 	refresh()
+	await get_tree().process_frame
+	if not is_inside_tree() or not visible:
+		return
+	reset_size()
+	move_to_center()
 
 
 # Caps max_size to fit the current monitor (with a small chrome / taskbar
@@ -142,6 +154,10 @@ func _build_ui() -> void:
 	var desc: Label = Label.new()
 	desc.text = "This list reflects every package currently installed on this machine — not just the current Godot project."
 	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	# Pin a wrap width so the autowrap height is computed against a known width
+	# even before the first layout pass; otherwise the label reports an
+	# inflated height on first open and the window opens near full-screen tall.
+	desc.custom_minimum_size.x = _CONTENT_WIDTH
 	desc.add_theme_font_size_override("font_size", 11)
 	desc.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
 	root.add_child(desc)
@@ -201,6 +217,7 @@ func _build_ui() -> void:
 	_status_label = Label.new()
 	_status_label.text = ""
 	_status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_status_label.custom_minimum_size.x = _CONTENT_WIDTH
 	root.add_child(_status_label)
 
 	_install_file_dialog = FileDialog.new()

--- a/addons/godot_gdk_packaging/editor/gdk_sandbox_dialog.gd
+++ b/addons/godot_gdk_packaging/editor/gdk_sandbox_dialog.gd
@@ -12,6 +12,10 @@ extends AcceptDialog
 ## the dialog still opens but disables the action buttons and explains why.
 
 const _RETAIL_LABEL: String = "RETAIL"
+# Wrap width for the autowrap labels. Kept below min_size.x (540) so it never
+# forces the window wider, but pins a width so autowrap heights are computed
+# correctly on first open instead of inflating the window vertically.
+const _CONTENT_WIDTH: int = 500
 const _MACHINE_WIDE_WARNING: String = (
 	"⚠  Sandbox switching is machine-wide. It affects every signed-in user, "
 	+ "every Xbox tool, and every Xbox-aware app running on this PC — not "
@@ -44,13 +48,51 @@ func setup(toolchain: RefCounted) -> void:
 
 
 func show_centered_clamped() -> void:
-	# Snap to the layout's calculated minimum so the window opens only as
-	# tall as the warning + rows + buttons need. Without this the dialog
-	# opens at its stale prior size (or stretches to the editor window
-	# height on first open).
-	reset_size()
+	# First-open fix (issue #61). The dialog's height is derived from its
+	# content's combined minimum size, but an AUTOWRAP Label only knows its
+	# real (wrapped) height once it has been laid out against a constrained
+	# width. Before the first popup no layout pass has run, so a pre-show
+	# reset_size() overshoots and the window opens taller than the screen.
+	# Cap to the current screen so the transient frame can never go
+	# off-screen, show (which runs a layout pass at the real min_size width),
+	# then snap to the now-correct content size on the next frame.
+	_apply_screen_size_cap()
 	popup_centered()
 	refresh_status()
+	await get_tree().process_frame
+	if not is_inside_tree() or not visible:
+		return
+	reset_size()
+	move_to_center()
+
+
+# Caps max_size to fit the current monitor (with a small chrome / taskbar
+# margin) so the dialog never opens taller than the user's screen. Re-evaluated
+# per popup because the editor may move between monitors of different sizes.
+func _apply_screen_size_cap() -> void:
+	var screen_idx: int = _current_screen_index()
+	var usable: Rect2i = DisplayServer.screen_get_usable_rect(screen_idx)
+	if usable.size.x <= 0 or usable.size.y <= 0:
+		return  # DisplayServer didn't report a usable rect; keep defaults
+	var capped_w: int = max(min_size.x, usable.size.x - 80)
+	var capped_h: int = max(min_size.y, usable.size.y - 120)
+	max_size = Vector2i(capped_w, capped_h)
+	# Actively shrink the current size if a previous open left it larger than
+	# what fits the current screen (e.g. user moved monitors between opens).
+	if size.x > capped_w or size.y > capped_h:
+		size = Vector2i(mini(size.x, capped_w), mini(size.y, capped_h))
+
+
+# Returns the screen index the editor's main window is currently on, so the
+# cap matches the monitor the dialog will actually open on. Falls back to the
+# primary screen if no editor window is available.
+func _current_screen_index() -> int:
+	var base: Control = EditorInterface.get_base_control()
+	if base != null:
+		var w: Window = base.get_window()
+		if w != null:
+			return w.current_screen
+	return DisplayServer.get_primary_screen()
 
 
 func _build_ui() -> void:
@@ -61,6 +103,10 @@ func _build_ui() -> void:
 	var warn := Label.new()
 	warn.text = _MACHINE_WIDE_WARNING
 	warn.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	# Pin a wrap width so the autowrap height is computed against a known
+	# width even before the first layout pass. Without this the label reports
+	# an inflated height on first open and the window opens screen-tall.
+	warn.custom_minimum_size.x = _CONTENT_WIDTH
 	warn.add_theme_color_override("font_color", Color(0.83, 0.51, 0.04))
 	root.add_child(warn)
 
@@ -113,6 +159,7 @@ func _build_ui() -> void:
 	_status_label = Label.new()
 	_status_label.text = ""
 	_status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_status_label.custom_minimum_size.x = _CONTENT_WIDTH
 	_status_label.visible = false
 	root.add_child(_status_label)
 


### PR DESCRIPTION
Fixes #61.

## Problem
The GDK Sandbox Switcher (`GDK > Change Sandbox…`) and the GDK Package Manager (`GDK > Package Manager…`) opened **taller than the screen the first time** they were shown in a Godot editor session. ALT+TAB / closing once "primed" them, and every subsequent open in that session was sized correctly.

## Root cause
Both dialogs are `AcceptDialog` subclasses that size their window from the content's combined minimum size. They contain `Label`s with `autowrap_mode = AUTOWRAP_WORD_SMART` (the machine-wide warning / description / status labels). An autowrap label only knows its real wrapped height **after** it has been laid out against a constrained width. On first open no layout pass has run yet, so the pre-show `reset_size()` read an inflated label height and the window opened screen-tall. Once the layout settled, later opens were correct — hence "first open only".

## Fix
- Pin a wrap width on every autowrap label via `custom_minimum_size.x` (kept below each dialog's `min_size.x` so it never forces the window wider). This makes the wrapped height correct even before the first layout pass.
- Defer the final `reset_size()` + re-center to the frame after `popup_centered()` so the window snaps to the correct content size, with a post-await `is_inside_tree()/visible` guard.
- Add the screen-size cap (`max_size` clamped to the usable monitor rect) to the sandbox dialog — the package manager already had it — so the transient first frame can never go off-screen.

## Validation
- `tools\check_gd_scripts_headless.ps1` passes.
- `cmake --build build --preset debug` succeeds and syncs the addon mirrors into `sample\tutorial_app` and the test hosts.
- Manually verified in the tutorial app editor: both dialogs now open at the correct size on first open and on subsequent opens.