### PR TITLE
Ensure correct CMake Version and add automatic VCPKG Finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.29)
+if(POLICY CMP0162)
+   cmake_policy(SET CMP0162 NEW)
+endif()
+
 project(godot_public_gdk_ext LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,6 +1,6 @@
 {
     "version": 6,
-    "cmakeMinimumRequired": { "major": 3, "minor": 25, "patch": 0 },
+    "cmakeMinimumRequired": { "major": 3, "minor": 29, "patch": 0 },
     "configurePresets": [
         {
             "name": "_base",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,7 @@ for the canonical addon-side walk-through.
   don't need a separate Microsoft GDK install just to compile the addons.
   Set the `VCPKG_ROOT` environment variable to your vcpkg clone (the
   CMake preset reads it via `$env{VCPKG_ROOT}`). You can also use the VCPKG 
-  componenet if it is installed with Visual Studio. The script `package_addons.ps1` 
+  component if it is installed with Visual Studio. The script `package_addons.ps1` 
   will detect it and use it as `VCPKG_ROOT` automatically.
 
 > **Note:** The vcpkg manifest only provides the **build-time headers and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,13 +129,15 @@ for the canonical addon-side walk-through.
 ### To build the addons from source
 
 - Visual Studio 2022+ with the **C++ Desktop** workload
-- CMake 3.25+ (required by the `CMakePresets.json` schema version)
+- CMake 3.29+ (required by the `CMakePresets.json` schema version)
 - [vcpkg](https://github.com/microsoft/vcpkg) in manifest mode. The build
   reads `vcpkg.json` + `vcpkg-configuration.json` at the repo root and
   resolves the `ms-gdk[playfab]` and `gameinput` ports for you, so you
   don't need a separate Microsoft GDK install just to compile the addons.
   Set the `VCPKG_ROOT` environment variable to your vcpkg clone (the
-  CMake preset reads it via `$env{VCPKG_ROOT}`).
+  CMake preset reads it via `$env{VCPKG_ROOT}`). You can also use the VCPKG 
+  componenet if it is installed with Visual Studio. The script `package_addons.ps1` 
+  will detect it and use it as `VCPKG_ROOT` automatically.
 
 > **Note:** The vcpkg manifest only provides the **build-time headers and
 > import libs** for Microsoft GDK + GameInput. You still need a full Microsoft GDK

--- a/tools/package_addons.ps1
+++ b/tools/package_addons.ps1
@@ -271,6 +271,37 @@ function Copy-PackagingAddon {
     }
 }
 
+function FindVisualStudio {
+    if (-not [string]::IsNullOrEmpty($env:VCPKG_ROOT)) {
+        Write-Host "  VCPKG_ROOT=$env:VCPKG_ROOT"
+        return
+    }
+
+    $vsEditions = @('2022', '2026') | ForEach-Object { $year = $_; @('Community', 'Enterprise', 'Professional') | ForEach-Object { "$year\$_" } }
+
+    foreach ($drive in @('C:', 'D:')) {
+        $vsBase = "$drive\Program Files\Microsoft Visual Studio"
+        if (-not (Test-Path -LiteralPath $vsBase -PathType Container)) {
+            continue
+        }
+        foreach ($edition in $vsEditions) {
+            $vcpkgCandidate = Join-Path $vsBase "$edition\VC\vcpkg"
+            if (Test-Path -LiteralPath $vcpkgCandidate -PathType Container) {
+                $env:VCPKG_ROOT = $vcpkgCandidate
+                Write-Host "  VCPKG_ROOT=$env:VCPKG_ROOT"
+                return
+            } else {
+                throw "Could not find VCPKG file in Visual Studio"
+            }
+        }
+    }
+    throw "Could not find Visual Studio install. If it is in a custom directory ensure VCPKG is installed and you set VCPKG_ROOT = \VS_Location\VC\vcpkg "
+}
+
+
+
+FindVisualStudio
+
 $outputFullPath = Resolve-OutputPath -Path $OutputPath
 $stageFullPath = [System.IO.Path]::GetFullPath($script:StageDir)
 $stagePrefix = $stageFullPath.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar

--- a/tools/package_addons.ps1
+++ b/tools/package_addons.ps1
@@ -290,8 +290,6 @@ function FindVCPKG_ROOT {
                 $env:VCPKG_ROOT = $vcpkgCandidate
                 Write-Host "  VCPKG_ROOT=$env:VCPKG_ROOT"
                 return
-            } else {
-                throw "Could not find VCPKG file in Visual Studio"
             }
         }
     }

--- a/tools/package_addons.ps1
+++ b/tools/package_addons.ps1
@@ -295,7 +295,7 @@ function FindVCPKG_ROOT {
             }
         }
     }
-    throw "Could not find Visual Studio install. If it is in a custom directory ensure VCPKG is installed and you set VCPKG_ROOT = \VS_Location\VC\vcpkg "
+    throw "Could not auto-detect VCPKG_ROOT from a default Visual Studio install. Ensure the Visual Studio vcpkg component is installed, or set VCPKG_ROOT to a vcpkg checkout (e.g. C:\\vcpkg) or to <VS>\\VC\\vcpkg."
 }
 
 

--- a/tools/package_addons.ps1
+++ b/tools/package_addons.ps1
@@ -271,7 +271,7 @@ function Copy-PackagingAddon {
     }
 }
 
-function FindVisualStudio {
+function FindVCPKG_ROOT {
     if (-not [string]::IsNullOrEmpty($env:VCPKG_ROOT)) {
         Write-Host "  VCPKG_ROOT=$env:VCPKG_ROOT"
         return
@@ -300,7 +300,7 @@ function FindVisualStudio {
 
 
 
-FindVisualStudio
+FindVCPKG_ROOT
 
 $outputFullPath = Resolve-OutputPath -Path $OutputPath
 $stageFullPath = [System.IO.Path]::GetFullPath($script:StageDir)


### PR DESCRIPTION
Based on issue raised here: https://github.com/microsoft/Godot-XBOX/issues/72

This update sets CMake 3.29, a version of CMake that ships with Visual Studio 2022, as the minimum required version.
Add function FindVCPKG_ROOT to grab VCPKG from VS if it is already installed.