### PR TITLE
Fix #73: untrack Party network on LeaveNetworkCompleted so rejoin can fully reconnect

### DIFF
--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -2570,6 +2570,39 @@ void PlayFabParty::_process_leave_network_completed(const Party::PartyStateChang
     if (network.is_valid()) {
         network->set_state_value(NETWORK_STATE_DISCONNECTED);
         _emit_network_state(network, NETWORK_CHANGE_STATE, 0, result, "disconnected");
+
+        // Issue #73 — after a title-initiated LeaveNetwork completes, detach
+        // and untrack the wrapper here instead of waiting for the
+        // PartyNetworkDestroyed event (which arrives some Party DoWork cycles
+        // later). If the title immediately rejoins the same network, holding
+        // the dying wrapper in m_networks lets stale local_peer entity-key
+        // records steal PartyChatControlCreated events from the new network
+        // (the iteration in _process_chat_control_created / _attach_orphan_chat_controls
+        // is order-sensitive and the older wrapper wins). The GDScript autoload
+        // disconnects its handlers via _detach_network, so chat_control_added
+        // emitted on the stale peer is silently dropped — voice and text never
+        // re-arm on the rejoined network. Only do this on a successful leave;
+        // if the leave failed the wrapper may still own live native resources
+        // and we must keep tracking it until PartyNetworkDestroyed lands.
+        if (result.is_valid() && result->is_ok()) {
+            Ref<PlayFabPartyPeer> peer = network->get_local_peer();
+            if (peer.is_valid()) {
+                peer->set_connection_status(MultiplayerPeer::CONNECTION_DISCONNECTED);
+                peer->set_unique_id(0);
+            }
+            // PENDING_JOIN_HANDSHAKE has no Party-side completion event of its
+            // own — it waits for a HANDSHAKE_REPLY packet. After we detach
+            // the wrapper, the message-received path can no longer route the
+            // reply, so drain any such op here (mirrors _process_network_destroyed).
+            // Other join-chain pending kinds will gracefully bail through
+            // _abort_join_op_if_network_dead once they observe the detached
+            // native handle on their *Completed event.
+            while (PendingOperation *handshake_op = _find_pending(PENDING_JOIN_HANDSHAKE, change->network)) {
+                _complete_pending(handshake_op, PlayFabResult::error_result(E_ABORT, PARTY_RESOURCE_NOT_READY, "Network left during handshake."));
+            }
+            network->detach_native();
+            _untrack_network(network);
+        }
     }
     if (operation != nullptr) {
         _complete_pending(operation, result);

--- a/tests/godot/mp_orchestrator/scenarios/_base/party_flows.gd
+++ b/tests/godot/mp_orchestrator/scenarios/_base/party_flows.gd
@@ -220,6 +220,107 @@ func run_party_state_host_leaves_network_destroyed_on_guest(orch) -> Dictionary:
 	return await run_party_lifecycle_host_create_join_destroy(orch)
 
 
+# Regression cover for issue #73. A guest that voluntarily leaves a Party
+# network and immediately rejoins it must still be able to send AND receive
+# text chat with the host. Pre-fix, PlayFabParty::_process_leave_network_completed
+# kept the dying wrapper in m_networks until the later PartyNetworkDestroyed
+# landed, which let the rejoin's PartyChatControlCreated for the host bind
+# to the stale wrapper's peer record instead of the new one. With the chat
+# control mapping wrong, the new local_peer's m_peer_records[host_id]
+# .chat_control is null, so send_text_async finds zero targets and
+# ChatTextReceived routes incoming text to the detached wrapper — both
+# directions silently fail. This scenario drives the exact leave -> immediate
+# rejoin sequence the tutorial T7 panel reported, then asserts text moves
+# both ways. It is deliberately ordered so the rejoin happens before the
+# host has had a chance to observe peer_disconnected, mirroring the original
+# race so the test still catches a regression of the underlying root cause.
+func run_party_leave_rejoin_chat_round_trip(orch) -> Dictionary:
+	var gate: Variant = requires_live_write(orch)
+	if gate != null: return gate
+	var pair: Variant = await _party_pair(orch, true)
+	if _is_failure(pair): return pair
+	var descriptor: String = String(pair.get("descriptor", ""))
+	var invitation_id: String = String(pair.get("invitation_id", ""))
+
+	# Arm the host's peer_disconnected waiter BEFORE issuing leave so the
+	# event can't be missed even if the host processes it before we get
+	# back here. Then issue leave + rejoin back-to-back to reproduce the
+	# exact race that triggered #73 (waiting for the host-side disconnect
+	# first would give Party extra DoWork cycles and could let the unfixed
+	# bug self-heal via the later PartyNetworkDestroyed cleanup).
+	var wait_host_disconnect = _client(orch, "host").expect_event("party.peer_disconnected", {})
+	var left: Variant = await _command_ok(orch, "guest", "party_leave_network", { "handle": "party" }, COMMAND_TIMEOUT_MS)
+	if _is_failure(left): return left
+	var rejoined: Variant = await _party_join_network(orch, "guest", "party", descriptor, invitation_id, true)
+	if _is_failure(rejoined): return rejoined
+
+	# Let the host observe the leave + reconvergence (order between
+	# disconnect and the new endpoint isn't guaranteed across processes).
+	if not bool((await wait_host_disconnect.wait(PARTY_WAIT_MS)).get("ok", false)):
+		return fail("host did not observe peer_disconnected after guest leave/rejoin race")
+	var host_converged: Variant = await _wait_party_peer_count(orch, "host", "party", 1)
+	if _is_failure(host_converged): return host_converged
+	var guest_converged: Variant = await _wait_party_peer_count(orch, "guest", "party", 1)
+	if _is_failure(guest_converged): return guest_converged
+
+	# Chat-readiness probe on the guest side (the side affected by #73).
+	# set_peer_chat_permissions_async returns party_peer_not_connected
+	# while the local_peer.m_peer_records[peer_id].chat_control is still
+	# null/stale — which is the exact failure surface the bug produced on
+	# the rejoining client — so we retry briefly until it succeeds. The
+	# probe doubles as a deterministic "chat plumbing is ready" gate
+	# before we exercise send/receive, and mirrors what the tutorial
+	# autoload does in response to chat_control_added. The orchestrator
+	# process does not load the PlayFab GDExtension so we hardcode the
+	# CHAT_PERMISSION_RECEIVE_TEXT enum value (matches
+	# PlayFabParty::CHAT_PERMISSION_RECEIVE_TEXT in playfab_party.h)
+	# instead of going through ClassDB.
+	const PARTY_CHAT_PERMISSION_RECEIVE_TEXT: int = 4
+	var ready: Variant = await _retry_party_set_peer_chat_permissions(orch, "guest", "party", 1, PARTY_CHAT_PERMISSION_RECEIVE_TEXT, PARTY_WAIT_MS)
+	if _is_failure(ready): return ready
+
+	# Bidirectional chat round trip. Pre-fix, guest.send_text_async()
+	# enumerates m_peer_records and finds zero targets with a valid
+	# chat_control (so the host never sees the text) AND host->guest
+	# text routes to the detached wrapper (so the guest never sees it).
+	# Both directions must succeed post-fix.
+	var text_g_to_h: String = _unique_token(orch, "rejoin-g2h")
+	var wait_host_chat = _client(orch, "host").expect_event("party.chat.text_received", { "text": text_g_to_h })
+	var sent_g: Variant = await _party_send_chat(orch, "guest", text_g_to_h)
+	if _is_failure(sent_g): return sent_g
+	if not bool((await wait_host_chat.wait(PARTY_WAIT_MS)).get("ok", false)):
+		return fail("host did not receive guest chat text after rejoin (issue #73 regression)", { "text": text_g_to_h })
+
+	var text_h_to_g: String = _unique_token(orch, "rejoin-h2g")
+	var wait_guest_chat = _client(orch, "guest").expect_event("party.chat.text_received", { "text": text_h_to_g })
+	var sent_h: Variant = await _party_send_chat(orch, "host", text_h_to_g)
+	if _is_failure(sent_h): return sent_h
+	if not bool((await wait_guest_chat.wait(PARTY_WAIT_MS)).get("ok", false)):
+		return fail("guest did not receive host chat text after rejoin (issue #73 regression)", { "text": text_h_to_g })
+
+	return ok({ "guest_to_host": text_g_to_h, "host_to_guest": text_h_to_g })
+
+
+# Retry party_set_peer_chat_permissions until the target peer's chat
+# control is attached to the local peer record (or the deadline expires).
+# Used as a "chat ready" gate after a rejoin: the only retryable error
+# is party_peer_not_connected — every other failure mode is fatal and
+# returned immediately rather than burning the deadline.
+func _retry_party_set_peer_chat_permissions(orch, role: String, handle: String, peer_id: int, permissions: int, timeout_ms: int) -> Variant:
+	var deadline: int = Time.get_ticks_msec() + timeout_ms
+	var last: Dictionary = {}
+	while Time.get_ticks_msec() < deadline:
+		var resp: Dictionary = await _command(orch, role, "party_set_peer_chat_permissions", { "handle": handle, "peer_id": peer_id, "permissions": permissions }, COMMAND_TIMEOUT_MS)
+		if bool(resp.get("ok", false)):
+			return ok({ "handle": handle, "peer_id": peer_id, "permissions": permissions })
+		last = resp
+		var code: String = String(resp.get("error", {}).get("code", ""))
+		if code != "party_peer_not_connected":
+			return fail("party_set_peer_chat_permissions failed: %s" % code, { "response": resp })
+		await _sleep_ms(orch, 100)
+	return fail("party_set_peer_chat_permissions readiness probe timed out (%d ms)" % timeout_ms, { "role": role, "peer_id": peer_id, "last_response": last })
+
+
 func run_party_chaos_host_kill_network_destroyed(orch) -> Dictionary:
 	var gate: Variant = requires_live_write(orch)
 	if gate != null: return gate

--- a/tests/godot/mp_orchestrator/scenarios/party/c5_party_leave_rejoin_chat_round_trip.gd
+++ b/tests/godot/mp_orchestrator/scenarios/party/c5_party_leave_rejoin_chat_round_trip.gd
@@ -1,0 +1,14 @@
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const Flow := preload("res://scenarios/_base/party_flows.gd")
+
+const SCENARIO_ID: String = "party.network.leave.rejoin_chat_round_trip"
+const SCENARIO_NAME: String = "Guest rejoins Party network and chat round-trips both ways (issue #73 regression)"
+const PRIORITY: String = "P0"
+const CATEGORY: String = "party"
+const REQUIRED_ROLES: Array[String] = ["host", "guest"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_party_available", "live_write_allowed", "multi_host_processes"]
+const TIMEOUT_SEC: int = 360
+
+func run(orch) -> Dictionary:
+	return await Flow.new().run_party_leave_rejoin_chat_round_trip(orch)


### PR DESCRIPTION
Fixes #73.

## Symptom

In the tutorial app's T7 Party panel:

1. Client 2 joins the host's PlayFab Party network — works.
2. Client 2 hits **Leave** — appears to leave cleanly.
3. Client 2 hits **Join** again — connects to the network, but voice/text chat with the host never re-arms. Restarting the app is the only known workaround.

## Root cause

`PlayFabParty::_process_leave_network_completed` only updated the wrapper's state and emitted `NETWORK_CHANGE_STATE/disconnected`. The wrapper was kept in `m_networks` until the later `PartyNetworkDestroyed` event, which can land several Party DoWork cycles after the title's `leave_async()` coroutine resolves.

In the meantime, the GDScript `Party` autoload is free to call `join_party_network()`. When the **new** network's `PartyChatControlCreated` for the host arrives, the iteration in `_process_chat_control_created` / `_attach_orphan_chat_controls` walks `m_networks` in order and binds the new chat control to the **first** wrapper whose `local_peer->find_peer_by_entity_key(...)` matches — which is the stale **OLD** wrapper, because the host's entity key is the same on both networks. The autoload had already disconnected its handlers from the OLD peer via `_detach_network`, so `chat_control_added` was silently dropped on the new network. Without that signal `set_peer_chat_permissions_async` was never called and permissions stayed `PARTY_CHAT_NONE` — voice and text never re-armed.

## Fix

On a **successful** `PartyLeaveNetworkCompleted` (only on success — a failed leave still gets cleaned up by the subsequent `NetworkDestroyed`):

- Reset the local peer's `connection_status` / `unique_id` (mirror of `_process_network_destroyed`), so retained refs to the old peer no longer report stale `CONNECTED` state.
- Drain any in-flight `PENDING_JOIN_HANDSHAKE` for this native network. That kind has no Party-side `*Completed` event of its own, so without an explicit drain a `join_network_async()` that lost its race with the leave would await forever once the wrapper is detached.
- Call `network->detach_native()` and `_untrack_network(network)` so the new rejoin sees an empty `m_networks` and binds chat-control events to the correct (new) wrapper.

The later `PartyNetworkDestroyed` event becomes a graceful no-op because `_process_network_destroyed` already early-returns when `_find_network_by_native` returns null. Other in-flight join-chain ops (`CONNECT_NETWORK`, `AUTHENTICATE`, `CREATE_CHAT_CONTROL`, `CONNECT_CHAT_CONTROL`, `CREATE_ENDPOINT`) bail safely through `_abort_join_op_if_network_dead` once they observe the wrapper's null native handle on their own `*Completed` events.

## Sample usage (no public API change — leave/rejoin "just works")

```gdscript
# in sample/tutorial_app/autoload/party.gd, called by T7 panel
func _rejoin_after_leave() -> void:
    var leave_result := await leave_party()
    assert(leave_result.is_ok())
    # Before this fix the next join would connect but stay silent
    # (chat permissions never set). Now voice and text re-arm normally.
    var join_result := await _join_party_network(_last_network_descriptor)
    assert(join_result.is_ok())
```

## Validation

- `tools\check_gd_scripts_headless.ps1` — **n/a** (C++-only change; covered by the orchestrator's parse-gate stage).
- `cmake --build build --preset debug` — **PASS**.
- `tools\run_all_tests.ps1` — **PASS** (all 7 stages green):
  - Parse gate ✅
  - CMake build (debug) ✅
  - C++ doctest (gdk_unit_tests.exe) ✅
  - GUT hosts ✅ — gdk 245 tests / 2144 asserts, **playfab 70 tests / 1693 asserts**, gameinput 53 tests / 46256 asserts, 0 failures
  - PlayFab Multiplayer orchestrator — **SKIPPED** (no `-Live`)
  - Bootstrap mini-runners ✅
- Live tier: **not run** (no `-Live`, no `-AllowLiveWrites`). The end-to-end T7 fix can only be confirmed with two real clients; the existing PlayFab GUT host still passes, so the classification and lifecycle invariants the suite already covers are preserved.