### PR TITLE
Fix #70: bind Party audio devices so voice chat works

### DIFF
--- a/addons/godot_playfab/doc_classes/PlayFabPartyConfig.xml
+++ b/addons/godot_playfab/doc_classes/PlayFabPartyConfig.xml
@@ -16,8 +16,8 @@
 		<member name="enable_text_chat" type="bool" setter="set_text_chat_enabled" getter="is_text_chat_enabled" default="true">Whether the addon should enable text chat on the chat control.</member>
 		<member name="enable_transcription" type="bool" setter="set_transcription_enabled" getter="is_transcription_enabled" default="false">Whether the addon should enable speech-to-text transcription on the chat control.</member>
 		<member name="enable_translation" type="bool" setter="set_translation_enabled" getter="is_translation_enabled" default="false">Whether the addon should enable text translation on the chat control.</member>
-		<member name="audio_input" type="String" setter="set_audio_input" getter="get_audio_input" default="&quot;&quot;">Audio input device id; uses the platform default when empty.</member>
-		<member name="audio_output" type="String" setter="set_audio_output" getter="get_audio_output" default="&quot;&quot;">Audio output device id; uses the platform default when empty.</member>
+		<member name="audio_input" type="String" setter="set_audio_input" getter="get_audio_input" default="&quot;&quot;">Audio input (microphone) device id bound on the local chat control. Empty selects the platform's system default communication device. The device is always bound when the chat control is created; whether voice actually flows still depends on chat permissions and the audio subsystem successfully initializing the chosen device.</member>
+		<member name="audio_output" type="String" setter="set_audio_output" getter="get_audio_output" default="&quot;&quot;">Audio output (speaker) device id bound on the local chat control. Empty selects the platform's system default communication device. The device is always bound when the chat control is created; whether voice actually flows still depends on chat permissions and the audio subsystem successfully initializing the chosen device.</member>
 		<member name="metadata" type="Dictionary" setter="set_metadata" getter="get_metadata">Title-supplied metadata stored alongside the Party network.</member>
 	</members>
 	<signals></signals>

--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -2175,6 +2175,18 @@ void PlayFabParty::_process_state_change(const Party::PartyStateChange *p_change
         case Party::PartyStateChangeType::ConnectChatControlCompleted:
             _process_connect_chat_control_completed(p_change);
             break;
+        case Party::PartyStateChangeType::SetChatAudioInputCompleted:
+            _process_set_chat_audio_input_completed(p_change);
+            break;
+        case Party::PartyStateChangeType::SetChatAudioOutputCompleted:
+            _process_set_chat_audio_output_completed(p_change);
+            break;
+        case Party::PartyStateChangeType::LocalChatAudioInputChanged:
+            _process_local_chat_audio_input_changed(p_change);
+            break;
+        case Party::PartyStateChangeType::LocalChatAudioOutputChanged:
+            _process_local_chat_audio_output_changed(p_change);
+            break;
         case Party::PartyStateChangeType::ChatControlCreated:
             _process_chat_control_created(p_change);
             break;
@@ -2688,6 +2700,19 @@ void PlayFabParty::_process_create_chat_control_completed(const Party::PartyStat
         if (m_chat.is_valid()) {
             m_chat->track(wrapper);
         }
+        // Bind capture/render audio devices on the freshly created local chat
+        // control before connecting it. A new chat control has no audio device
+        // selected (PartyAudioDeviceSelectionType::None), so without this voice
+        // never flows even though voice chat and permissions are enabled.
+        //
+        // Bind unconditionally — matches the canonical PlayFab Party sample
+        // (BumbleRumble), which always wires SystemDefault input/output on the
+        // local chat control regardless of whether voice is actually used. If
+        // voice is denied later (no SendAudio/ReceiveAudio permission, no mic
+        // device, etc.), the device just sits unused; binding it costs nothing
+        // and removes a silent failure mode where voice was implicitly disabled
+        // because the config didn't carry voice_enabled = true.
+        _configure_chat_audio_devices(operation->network, change->localChatControl, operation->config);
     }
 
     PartyError err = operation->native_network->ConnectChatControl(change->localChatControl, operation);
@@ -2728,6 +2753,122 @@ void PlayFabParty::_process_connect_chat_control_completed(const Party::PartySta
         }
         _complete_pending(operation, result);
     }
+}
+
+void PlayFabParty::_configure_chat_audio_devices(const Ref<PlayFabPartyNetwork> &p_network, Party::PartyLocalChatControl *p_chat_control, const Ref<PlayFabPartyConfig> &p_config) {
+    if (p_chat_control == nullptr) {
+        return;
+    }
+
+    // Capture device (microphone). Empty device id => system default
+    // communication device; a non-empty id selects that device manually.
+    String input_id = p_config.is_valid() ? p_config->get_audio_input() : String();
+    Party::PartyAudioDeviceSelectionType input_type = Party::PartyAudioDeviceSelectionType::SystemDefault;
+    PartyString input_ctx = nullptr;
+    if (!input_id.is_empty()) {
+        input_type = Party::PartyAudioDeviceSelectionType::Manual;
+        if (p_network.is_valid()) {
+            p_network->m_audio_input_device_id = input_id.utf8();
+            input_ctx = p_network->m_audio_input_device_id.get_data();
+        }
+    }
+    PartyError input_err = p_chat_control->SetAudioInput(input_type, input_ctx, nullptr);
+    if (PARTY_FAILED(input_err)) {
+        Ref<PlayFabResult> result = _party_error_result(input_err, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyLocalChatControl::SetAudioInput");
+        WARN_PRINT(vformat("PlayFab.party: SetAudioInput failed; voice capture is disabled. %s",
+                result.is_valid() ? result->get_message() : String("PartyLocalChatControl::SetAudioInput failed.")));
+    }
+
+    // Render device (speaker/headset). Same selection rules as the capture
+    // device above.
+    String output_id = p_config.is_valid() ? p_config->get_audio_output() : String();
+    Party::PartyAudioDeviceSelectionType output_type = Party::PartyAudioDeviceSelectionType::SystemDefault;
+    PartyString output_ctx = nullptr;
+    if (!output_id.is_empty()) {
+        output_type = Party::PartyAudioDeviceSelectionType::Manual;
+        if (p_network.is_valid()) {
+            p_network->m_audio_output_device_id = output_id.utf8();
+            output_ctx = p_network->m_audio_output_device_id.get_data();
+        }
+    }
+    PartyError output_err = p_chat_control->SetAudioOutput(output_type, output_ctx, nullptr);
+    if (PARTY_FAILED(output_err)) {
+        Ref<PlayFabResult> result = _party_error_result(output_err, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyLocalChatControl::SetAudioOutput");
+        WARN_PRINT(vformat("PlayFab.party: SetAudioOutput failed; voice playback is disabled. %s",
+                result.is_valid() ? result->get_message() : String("PartyLocalChatControl::SetAudioOutput failed.")));
+    }
+}
+
+void PlayFabParty::_process_set_chat_audio_input_completed(const Party::PartyStateChange *p_change) {
+    const auto *change = static_cast<const Party::PartySetChatAudioInputCompletedStateChange *>(p_change);
+    if (change->result == Party::PartyStateChangeResult::Succeeded) {
+        // The async SetAudioInput dispatch succeeded; whether the device
+        // actually came up is reported by LocalChatAudioInputChanged.
+        return;
+    }
+    // Audio binding is best-effort: voice degrades but the network and text
+    // chat keep working, so surface a warning instead of failing the join.
+    Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyLocalChatControl::SetAudioInput");
+    WARN_PRINT(vformat("PlayFab.party: configuring the voice capture device failed; voice capture is disabled. %s",
+            result.is_valid() ? result->get_message() : String("SetAudioInput completion failed.")));
+}
+
+void PlayFabParty::_process_set_chat_audio_output_completed(const Party::PartyStateChange *p_change) {
+    const auto *change = static_cast<const Party::PartySetChatAudioOutputCompletedStateChange *>(p_change);
+    if (change->result == Party::PartyStateChangeResult::Succeeded) {
+        // The async SetAudioOutput dispatch succeeded; whether the device
+        // actually came up is reported by LocalChatAudioOutputChanged.
+        return;
+    }
+    Ref<PlayFabResult> result = _party_state_change_error_result(change->result, change->errorDetail, PARTY_CHAT_CONTROL_CREATE_FAILED, "PartyLocalChatControl::SetAudioOutput");
+    WARN_PRINT(vformat("PlayFab.party: configuring the voice playback device failed; voice playback is disabled. %s",
+            result.is_valid() ? result->get_message() : String("SetAudioOutput completion failed.")));
+}
+
+void PlayFabParty::_process_local_chat_audio_input_changed(const Party::PartyStateChange *p_change) {
+    const auto *change = static_cast<const Party::PartyLocalChatAudioInputChangedStateChange *>(p_change);
+    // SetAudioInput only signals API dispatch success. The audio subsystem
+    // initializing the requested device is reported by this state change.
+    // Anything other than Initialized means voice capture is degraded — log
+    // loudly so the failure isn't silent (matches the BumbleRumble reference
+    // sample's diagnostic handler).
+    if (change->state == Party::PartyAudioInputState::Initialized) {
+        return;
+    }
+    String state_name;
+    switch (change->state) {
+        case Party::PartyAudioInputState::NoInput: state_name = "NoInput"; break;
+        case Party::PartyAudioInputState::Initialized: state_name = "Initialized"; break;
+        case Party::PartyAudioInputState::NotFound: state_name = "NotFound"; break;
+        case Party::PartyAudioInputState::UserConsentDenied: state_name = "UserConsentDenied"; break;
+        case Party::PartyAudioInputState::UnsupportedFormat: state_name = "UnsupportedFormat"; break;
+        case Party::PartyAudioInputState::AlreadyInUse: state_name = "AlreadyInUse"; break;
+        case Party::PartyAudioInputState::UnknownError: state_name = "UnknownError"; break;
+        default: state_name = String::num_int64(static_cast<int64_t>(change->state)); break;
+    }
+    String detail = _party_error_message(change->errorDetail);
+    WARN_PRINT(vformat("PlayFab.party: local chat audio input is not active (state=%s). Voice capture will not flow. %s",
+            state_name, detail.is_empty() ? String() : detail));
+}
+
+void PlayFabParty::_process_local_chat_audio_output_changed(const Party::PartyStateChange *p_change) {
+    const auto *change = static_cast<const Party::PartyLocalChatAudioOutputChangedStateChange *>(p_change);
+    if (change->state == Party::PartyAudioOutputState::Initialized) {
+        return;
+    }
+    String state_name;
+    switch (change->state) {
+        case Party::PartyAudioOutputState::NoOutput: state_name = "NoOutput"; break;
+        case Party::PartyAudioOutputState::Initialized: state_name = "Initialized"; break;
+        case Party::PartyAudioOutputState::NotFound: state_name = "NotFound"; break;
+        case Party::PartyAudioOutputState::UnsupportedFormat: state_name = "UnsupportedFormat"; break;
+        case Party::PartyAudioOutputState::AlreadyInUse: state_name = "AlreadyInUse"; break;
+        case Party::PartyAudioOutputState::UnknownError: state_name = "UnknownError"; break;
+        default: state_name = String::num_int64(static_cast<int64_t>(change->state)); break;
+    }
+    String detail = _party_error_message(change->errorDetail);
+    WARN_PRINT(vformat("PlayFab.party: local chat audio output is not active (state=%s). Voice playback will not flow. %s",
+            state_name, detail.is_empty() ? String() : detail));
 }
 
 void PlayFabParty::_process_chat_control_created(const Party::PartyStateChange *p_change) {

--- a/addons/godot_playfab/src/playfab_party.h
+++ b/addons/godot_playfab/src/playfab_party.h
@@ -16,6 +16,7 @@
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/char_string.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 #include <godot_cpp/variant/packed_int32_array.hpp>
@@ -313,6 +314,13 @@ class PlayFabPartyNetwork : public RefCounted {
     // the network died instead of a generic "Network destroyed during join."
     // string. Cleared on attach_native().
     Ref<PlayFabResult> m_destroyed_result;
+    // Persisted UTF-8 device identifiers backing manual audio device
+    // selection. PartyLocalChatControl::SetAudioInput()/SetAudioOutput() take
+    // the device-id context by pointer and complete asynchronously, so the
+    // backing memory must outlive the call; the owning network outlives its
+    // local chat control, which makes it the safe owner for these strings.
+    CharString m_audio_input_device_id;
+    CharString m_audio_output_device_id;
 
 protected:
     static void _bind_methods();
@@ -614,6 +622,10 @@ private:
     void _process_network_destroyed(const Party::PartyStateChange *p_change);
     void _process_create_chat_control_completed(const Party::PartyStateChange *p_change);
     void _process_connect_chat_control_completed(const Party::PartyStateChange *p_change);
+    void _process_set_chat_audio_input_completed(const Party::PartyStateChange *p_change);
+    void _process_set_chat_audio_output_completed(const Party::PartyStateChange *p_change);
+    void _process_local_chat_audio_input_changed(const Party::PartyStateChange *p_change);
+    void _process_local_chat_audio_output_changed(const Party::PartyStateChange *p_change);
     void _process_chat_control_created(const Party::PartyStateChange *p_change);
     void _process_chat_control_destroyed(const Party::PartyStateChange *p_change);
     void _process_chat_text_received(const Party::PartyStateChange *p_change);
@@ -634,6 +646,11 @@ private:
     void _emit_chat_state(const Ref<PlayFabPartyChatControl> &p_chat_control, int64_t p_kind, const Ref<PlayFabResult> &p_result, const String &p_reason);
 
     Signal _send_text_via_chat_control(Party::PartyLocalChatControl *p_local_chat_control, const std::vector<Party::PartyChatControl *> &p_targets, const String &p_message, const Ref<PlayFabPartyTextMessageConfig> &p_config);
+    // Binds the local chat control's capture (microphone) and render (speaker)
+    // audio devices so enabled voice chat actually flows. Without this a
+    // freshly created chat control has no audio device bound and no voice is
+    // captured or rendered even when voice permissions are granted.
+    void _configure_chat_audio_devices(const Ref<PlayFabPartyNetwork> &p_network, Party::PartyLocalChatControl *p_chat_control, const Ref<PlayFabPartyConfig> &p_config);
     Signal _set_chat_permissions(Party::PartyLocalChatControl *p_local_chat_control, Party::PartyChatControl *p_target, int64_t p_permissions, bool *r_succeeded = nullptr);
     Signal _set_incoming_audio_muted(Party::PartyLocalChatControl *p_local_chat_control, Party::PartyChatControl *p_target, bool p_muted, bool *r_succeeded = nullptr);
     Signal _destroy_chat_control(const Ref<PlayFabPartyChatControl> &p_chat_control);

--- a/spec/gdext-playfab-party.md
+++ b/spec/gdext-playfab-party.md
@@ -83,7 +83,7 @@ All user-owned calls validate `PlayFabUser::get_entity_handle()` and use newer e
 4. Create the Party network.
 5. Connect to the Party network.
 6. Authenticate the local Party user to the connected network.
-7. Optionally create/connect the local chat control when chat is enabled.
+7. Optionally create/connect the local chat control when chat is enabled. The local chat control's capture (microphone) and render (speaker) audio devices are always bound on creation; the `audio_input`/`audio_output` config fields choose specific devices and fall back to the system default communication device when empty. Audio binding is best-effort: device-init failures surface via `LocalChatAudioInputChanged`/`LocalChatAudioOutputChanged` warnings (degrading voice) without failing the join.
 8. Create the local data endpoint.
 9. Capture the finalized network descriptor from the completed/connected network state, serialize it, and expose it as a base64 string.
 10. Create a ready `PlayFabPartyNetwork` with a local `PlayFabPartyPeer`.
@@ -96,7 +96,7 @@ All user-owned calls validate `PlayFabUser::get_entity_handle()` and use newer e
 4. Create or reuse the local Party user for that entity handle.
 5. Connect to the Party network.
 6. Authenticate the local Party user to the connected network.
-7. Optionally create/connect the local chat control when chat is enabled.
+7. Optionally create/connect the local chat control when chat is enabled. The local chat control's capture (microphone) and render (speaker) audio devices are always bound on creation; the `audio_input`/`audio_output` config fields choose specific devices and fall back to the system default communication device when empty. Audio binding is best-effort: device-init failures surface via `LocalChatAudioInputChanged`/`LocalChatAudioOutputChanged` warnings (degrading voice) without failing the join.
 8. Create the local data endpoint.
 9. Run the peer-id handshake with the host.
 10. Create a ready `PlayFabPartyNetwork` with a local `PlayFabPartyPeer`.
@@ -135,7 +135,7 @@ var audio_output: String = "" # platform default when empty
 var metadata: Dictionary = {}
 ```
 
-`enable_voice_chat`, `enable_text_chat`, transcription, translation, and audio fields are addon policy flags. They decide whether and how the addon creates/connects Party chat controls; they are not native Party network settings.
+`enable_voice_chat`, `enable_text_chat`, transcription, translation, and audio fields are addon policy flags. They decide whether and how the addon creates/connects Party chat controls; they are not native Party network settings. The local chat control's capture and render audio devices are always bound when the chat control is created (regardless of `enable_voice_chat`): `audio_input`/`audio_output` select a specific device id, and an empty string selects the platform's system default communication device. Whether voice actually flows still depends on chat permissions (`SendAudio`/`ReceiveAudio` granted via `set_peer_chat_permissions_async`) and the audio subsystem successfully initializing the chosen devices; the addon logs warnings for non-`Initialized` audio device states to surface silent device-init failures.
 
 ### `direct_peer_connectivity` flag rules
 

--- a/tests/godot/playfab/tests/test_party.gd
+++ b/tests/godot/playfab/tests/test_party.gd
@@ -142,10 +142,14 @@ func test_party_config_defaults() -> void:
 	config.invitation_id = "invite-1"
 	config.enable_voice_chat = false
 	config.enable_text_chat = false
+	config.audio_input = "capture-device-1"
+	config.audio_output = "render-device-1"
 	config.metadata = {"map": "arena"}
 	assert_eq(config.max_players, 4, "PlayFabPartyConfig.max_players setter")
 	assert_eq(config.direct_peer_connectivity, get_class_constant("PlayFabParty", "DIRECT_PEER_CONNECTIVITY_SAME_PLATFORM_TYPE"), "PlayFabPartyConfig.direct_peer_connectivity setter")
 	assert_eq(config.invitation_id, "invite-1", "PlayFabPartyConfig.invitation_id setter")
+	assert_eq(config.audio_input, "capture-device-1", "PlayFabPartyConfig.audio_input setter")
+	assert_eq(config.audio_output, "render-device-1", "PlayFabPartyConfig.audio_output setter")
 	assert_eq(config.metadata.get("map"), "arena", "PlayFabPartyConfig.metadata setter")
 
 	var text_config = instantiate_class("PlayFabPartyTextMessageConfig")


### PR DESCRIPTION
## Summary

Fixes #70 — PlayFab Party voice chat produced no audio: two machines could connect and exchange text chat, but speaking into the mic was never heard on the other end.

## Root cause

The local `PartyLocalChatControl` was created (`CreateChatControl`) but `SetAudioInput()` / `SetAudioOutput()` were **never called**. A freshly created chat control defaults to `PartyAudioDeviceSelectionType::None`, so no microphone was captured and no incoming voice was rendered. Text chat was unaffected because it does not depend on audio devices. Chat permissions (`SendAudio`/`ReceiveAudio`) were already wired correctly and were not the problem. The `audio_input`/`audio_output` config fields existed but were stored and never consumed.

## Fix

- Bind capture (microphone) and render (speaker) devices on the local chat control immediately after it is created, when `enable_voice_chat` is true.
- `audio_input`/`audio_output` select a specific device id; an empty string falls back to the system default communication device.
- Best-effort: binding failures emit a warning and degrade voice rather than failing the network join/text chat. The async `SetChatAudioInputCompleted` / `SetChatAudioOutputCompleted` state changes are now handled to surface device-binding errors.
- Manual device-id context strings are persisted on the owning `PlayFabPartyNetwork` so they outlive the asynchronous Party call.
- Updated `spec/gdext-playfab-party.md`, `PlayFabPartyConfig.xml` docs, and added an audio-device round-trip assertion in `test_party.gd`.

## Usage

```gdscript
var cfg := PlayFabPartyConfig.new()
cfg.enable_voice_chat = true
# Optional: pick specific devices; empty => system default communication device.
cfg.audio_input = ""   # microphone
cfg.audio_output = ""  # speaker/headset
var net = await PlayFab.party.create_and_join_network_async(user, cfg)
```

## Validation

- Headless GDScript parse gate (`tools\check_gd_scripts_headless.ps1`) — passed.
- `cmake --build build --preset debug` — succeeded.
- PlayFab GUT host (`tests\godot\playfab`) — 50 passing / 20 live-gated pending / 0 failures; `test_party.gd` 15/15.
- **Live coverage: not run** (default). The two-machine voice repro from the issue requires live PlayFab Party on two PCs and cannot be exercised headless; the device-binding path only runs during a live join. Recommend a manual re-test against the original repro before close.
