### PR TITLE
Fix link case sensitivity for Xbox sandbox docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Per-addon documentation:
 
 Platform setup:
 
-- [XBOX sandbox and test accounts](docs/platform/Xbox-sandbox-and-test-accounts.md)
+- [XBOX sandbox and test accounts](docs/platform/xbox-sandbox-and-test-accounts.md)
 
 Design specs live in [`spec/`](spec/) — design intent that is not always reflective of the current implementation.
 


### PR DESCRIPTION
<!--
This template is auto-applied by GitHub when a PR is opened. Fill it in honestly
— the agent workflow expects each section to be present and substantive. If a
section truly does not apply, write "Not applicable: <reason>" rather than
deleting it.
-->

## Summary

<!-- 1–3 lines. Name the branch and the user-visible change. -->
Fixing 404 link in README - Casing change.

## Public API changes

<!--
Every renamed/added GDScript-visible class, method, property, signal, or enum
goes here, with a short GDScript usage example for each. If the PR adds no
public API, write "None".
-->

None.

## Spec / docs / samples updated

<!-- Tick the boxes that apply to the touched surfaces. -->

- [ ] `spec\gdext-<feature>.md` updated (Plan / Progress sections if multi-session work)
- [ ] `docs\godot-<addon>-*.md` updated
- [ ] `addons\<addon>\doc_classes\*.xml` updated for any public API change
- [ ] Sample content (`sample\<host>\`) updated when public addon behaviour changed
- [ ] Path-scoped instruction file (`.github\instructions\<addon>.instructions.md`) updated if conventions changed
- [x] Not applicable — no public addon behaviour changed

## Test coverage delta

None. Docs link fix. 

## Validation run

None. Docs casing only.

## Migration notes


None.
