### PR TITLE
Fix typo in sandbox command in setup_sample.ps1 next-steps output

### DIFF
--- a/tools/setup_sample.ps1
+++ b/tools/setup_sample.ps1
@@ -161,7 +161,7 @@ Write-Host ""
 Write-Host "Setup complete!" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Yellow
-Write-Host "  1. Set your PC sandbox:  XblPCSandbox.exe set $SandboxId"
+Write-Host "  1. Set your PC sandbox:  XblPCSandbox.exe $SandboxId"
 Write-Host "  2. Build the addon:      cmake --build build --preset debug"
 $LaunchScript = Join-Path $SampleDir "launch_editor.bat"
 Write-Host "  3. Launch the editor:    $LaunchScript"


### PR DESCRIPTION
Fixes #99

The "Next steps" output in `tools/setup_sample.ps1` instructed users to run:

```
XblPCSandbox.exe set <SandboxId>
```

but the correct invocation is just:

```
XblPCSandbox.exe <SandboxId>
```

Removing the stray `set` keyword from the printed instruction so the copy-pasteable command actually works.