### PR TITLE
 docs: Fix link case sensitivity for xbox-sandbox-and-test-accounts.md in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -415,7 +415,7 @@ For the full method/signal table see
 > Real XBOX Live sign-in needs Partner Center configuration, the right
 > sandbox set on the PC, and a test account signed into the XBOX app —
 > see [Sample project setup](gdk/sample-setup.md) and
-> [XBOX sandbox and test-account setup](platform/XBOX-sandbox-and-test-accounts.md).
+> [XBOX sandbox and test-account setup](platform/xbox-sandbox-and-test-accounts.md).
 > Without those, sign-in will report a clear error and the rest of the
 > game keeps running fine.
 
@@ -513,7 +513,7 @@ test-account guide.
 |---------|--------------|-----|
 | `GDExtension dynamic library not found` | The `bin/` folder didn't make it into the project copy | Copy `addons/<addon>/` recursively, including `bin/` |
 | `[GDK] Bootstrap: 'GDK' singleton not registered` | Extension failed to load (wrong Windows arch, missing Microsoft GDK install, missing `libHttpClient.dll`) | Check that the addon copy preserved `bin/` and that the Microsoft GDK is installed on the machine that runs the game |
-| Silent sign-in returns `no_default_user` | No test account signed in to the XBOX app on the PC, or the PC sandbox doesn't match Partner Center | Set the sandbox with `XblPCSandbox.exe` and sign a test account into the XBOX app — see [XBOX sandbox and test-account setup](platform/XBOX-sandbox-and-test-accounts.md) |
+| Silent sign-in returns `no_default_user` | No test account signed in to the XBOX app on the PC, or the PC sandbox doesn't match Partner Center | Set the sandbox with `XblPCSandbox.exe` and sign a test account into the XBOX app — see [XBOX sandbox and test-account setup](platform/xbox-sandbox-and-test-accounts.md) |
 | `PlayFab.initialize()` fails immediately | `playfab/runtime/title_id` is empty | Set `playfab/runtime/title_id` in Project Settings (or `project.godot` `[playfab] runtime/title_id="..."`) |
 | `sign_in_with_xuser_async` returns `invalid_xuser` | Passing a null / signed-out Microsoft GDK user | Verify `xbox_user != null and xbox_user.signed_in` before calling |
 | `PlayFab.game_saves` returns `xbox_user_required` | The PlayFab session was created with a custom id | Use `sign_in_with_xuser_async` for any flow that touches Game Saves |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ errors in `MicrosoftGame.config`, etc.).
 > this guide refers to.
 
 See [Sample project setup](gdk/sample-setup.md) and
-[XBOX sandbox and test-account setup](platform/XBOX-sandbox-and-test-accounts.md)
+[XBOX sandbox and test-account setup](platform/xbox-sandbox-and-test-accounts.md)
 for the canonical addon-side walk-through.
 
 ### To make PlayFab sign-in work


### PR DESCRIPTION
<!--
This template is auto-applied by GitHub when a PR is opened. Fill it in honestly
— the agent workflow expects each section to be present and substantive. If a
section truly does not apply, write "Not applicable: <reason>" rather than
deleting it.
-->

## Summary

Partly addressed by https://github.com/microsoft/XBOX-Godot-Sample/pull/91 but not fully fixed.

Fixes issue introduced by https://github.com/microsoft/XBOX-Godot-Sample/pull/88 where links leading to `xbox-sandbox-and-test-accounts.md` were broken due to GitHub using case sensitive file system.

<!-- 1–3 lines. Name the branch and the user-visible change. -->

## Public API changes

None.

## Spec / docs / samples updated

<!-- Tick the boxes that apply to the touched surfaces. -->

- [ ] `spec\gdext-<feature>.md` updated (Plan / Progress sections if multi-session work)
- [ ] `docs\godot-<addon>-*.md` updated
- [ ] `addons\<addon>\doc_classes\*.xml` updated for any public API change
- [ ] Sample content (`sample\<host>\`) updated when public addon behaviour changed
- [ ] Path-scoped instruction file (`.github\instructions\<addon>.instructions.md`) updated if conventions changed
- [x] Not applicable — no public addon behaviour changed

## Test coverage delta

<!--
State how the test pipeline moved. Use the per-tier counts from the orchestrator
summary (`build\test-results\run-summary.md`).
-->

- Contract (offline) tests added/removed: None
- Live-read tests added/removed: None
- Live-write tests added/removed: None
- Live title id used (if any): None

## Validation run

Not applicable: change in documentation only

## Migration notes

<!--
Only if this PR breaks the public surface or changes a Project Setting key.
Otherwise write "None".
-->

None.
