### PR TITLE
feat(godot_gdk): 100% GDK API reference coverage — TTS, Store/GameUI Show-UIs, Events, feature probe, Game Save, XSAPI fills, GameChat2 (#94)

### DIFF
--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(godot_gdk SHARED
     src/gdk_activation.cpp
     src/gdk_speech_synthesizer.cpp
     src/gdk_events.cpp
+    src/gdk_game_save.cpp
 )
 
 target_include_directories(godot_gdk PRIVATE

--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(godot_gdk SHARED
     src/gdk_xbox_services.cpp
     src/gdk_display.cpp
     src/gdk_activation.cpp
+    src/gdk_speech_synthesizer.cpp
 )
 
 target_include_directories(godot_gdk PRIVATE

--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(godot_gdk SHARED
     src/gdk_display.cpp
     src/gdk_activation.cpp
     src/gdk_speech_synthesizer.cpp
+    src/gdk_events.cpp
 )
 
 target_include_directories(godot_gdk PRIVATE

--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(godot_gdk SHARED
     src/gdk_speech_synthesizer.cpp
     src/gdk_events.cpp
     src/gdk_game_save.cpp
+    src/gdk_game_chat.cpp
 )
 
 target_include_directories(godot_gdk PRIVATE
@@ -48,6 +49,7 @@ target_link_libraries(godot_gdk PRIVATE
     Xbox::GameRuntime
     Xbox::XSAPI
     Xbox::HTTPClient
+    Xbox::GameChat2
 )
 
 target_compile_definitions(godot_gdk PRIVATE _GAMING_DESKTOP)
@@ -81,6 +83,7 @@ godot_addon_copy_runtime_files(
     FILES
         "$<TARGET_FILE:Xbox::HTTPClient>"
         "$<TARGET_FILE:Xbox::XCurl>"
+        "$<TARGET_FILE:Xbox::GameChat2>"
         ${XSAPI_THUNKS_DLLS}
 )
 

--- a/addons/godot_gdk/doc_classes/GDKAchievements.xml
+++ b/addons/godot_gdk/doc_classes/GDKAchievements.xml
@@ -31,6 +31,14 @@
 				Returns an [Array] of cached [GDKAchievement] objects for the specified [param user]. Call [method query_player_achievements_async] first to populate the cache.
 			</description>
 		</method>
+		<method name="get_achievements_by_state">
+			<return type="GDKResult" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="progress_state" type="String" />
+			<description>
+				Returns the cached achievements for [param user] filtered by progress state via [code]XblAchievementsManagerGetAchievementsByState[/code]. [param progress_state] is one of [code]"Achieved"[/code], [code]"NotStarted"[/code], [code]"InProgress"[/code], or [code]"Unknown"[/code] (case-insensitive). On success [member GDKResult.data] holds [code]progress_state[/code] and an [code]achievements[/code] [Array] of [GDKAchievement]. Returns [code]achievements_not_loaded[/code] if [method query_player_achievements_async] has not completed for [param user] yet.
+			</description>
+		</method>
 	</methods>
 	<members>
 	</members>

--- a/addons/godot_gdk/doc_classes/GDKEvents.xml
+++ b/addons/godot_gdk/doc_classes/GDKEvents.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDKEvents" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Title telemetry service accessed via GDK.events.
+	</brief_description>
+	<description>
+		Writes GDK-native in-game telemetry events through [code]XGameEventWrite[/code]. Events are batched and uploaded asynchronously by the runtime. The event name and the names of any [code]dimensions[/code]/[code]measurements[/code] fields must match the title's Xbox Live service configuration event manifest; events whose names do not match are silently dropped by the service. This is complementary to PlayFab analytics ([code]godot_playfab[/code]).
+	</description>
+	<tutorials></tutorials>
+	<methods>
+		<method name="write_event">
+			<return type="GDKResult" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="event_name" type="String" />
+			<param index="2" name="dimensions" type="Dictionary" default="{}" />
+			<param index="3" name="measurements" type="Dictionary" default="{}" />
+			<description>
+				Writes a telemetry event on behalf of [param user]. [param dimensions] hold fields with a finite set of values (map id, difficulty, mode, etc.); [param measurements] hold scalar numeric metrics (score, time, counters, etc.). Both are serialized to JSON internally. Returns an ok [GDKResult] whose [code]data[/code] contains [code]event_name[/code] and [code]play_session_id[/code]. When the GDK telemetry feature is unavailable in the current runtime, returns [code]events_feature_unavailable[/code] without writing.
+			</description>
+		</method>
+		<method name="set_play_session_id">
+			<return type="void" />
+			<param index="0" name="play_session_id" type="String" />
+			<description>
+				Sets the play-session ID used to group events from a single play session. Pass an empty string to generate a fresh random GUID.
+			</description>
+		</method>
+		<method name="get_play_session_id">
+			<return type="String" />
+			<description>
+				Returns the current play-session ID, generating one on first access if none was set.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="play_session_id" type="String" setter="set_play_session_id" getter="get_play_session_id">
+			A unique per-session GUID that groups the events written during a single play session. Auto-generated when the runtime initializes.
+		</member>
+	</members>
+	<signals></signals>
+	<constants></constants>
+</class>

--- a/addons/godot_gdk/doc_classes/GDKGameChat.xml
+++ b/addons/godot_gdk/doc_classes/GDKGameChat.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDKGameChat" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		GDK-native voice and text chat service accessed via GDK.game_chat.
+	</brief_description>
+	<description>
+		Wraps the Game Chat 2 ([code]GameChat2.h[/code]) [code]chat_manager[/code] singleton. Game Chat encodes its own opaque audio and text data frames and tracks per-user communication relationships, muting, and chat indicators; it does [b]not[/b] choose or build a network transport. This wrapper exposes that data-frame surface so titles can ferry frames over whatever transport they already have: outbound frames are reported through the [signal outgoing_data_frame] signal, and inbound frames are handed back via [method process_incoming_data_frame]. Inbound text and transcribed messages surface through [signal text_chat_received] and [signal transcribed_chat_received].
+		Call [method initialize] once after [code]GDK.initialize()[/code], add local and remote users, configure communication relationships, then pump the manager every frame (handled automatically by [code]GDK.dispatch()[/code]). This is the GDK-native alternative to PlayFab Party's batteries-included voice/text option ([code]godot_playfab[/code]); unlike Party, it has no built-in transport.
+		Real voice capture and rendering require multi-machine audio hardware and cannot be exercised headlessly; headless tests and the sample drive lifecycle and data-frame plumbing using single-process loopback (feeding each [signal outgoing_data_frame] straight back into [method process_incoming_data_frame]).
+	</description>
+	<tutorials></tutorials>
+	<methods>
+		<method name="initialize">
+			<return type="GDKResult" />
+			<param index="0" name="max_users" type="int" default="16" />
+			<param index="1" name="default_relationship" type="int" default="31" enum="GDKGameChat.CommunicationRelationship" />
+			<description>
+				Initializes the Game Chat 2 [code]chat_manager[/code] with room for [param max_users] combined local and remote users and the [param default_relationship] applied between new local and remote users. Requires the GDK runtime to be initialized first. Returns an ok [GDKResult], or an error with code [code]not_initialized[/code], [code]already_initialized[/code], or [code]invalid_max_users[/code].
+			</description>
+		</method>
+		<method name="is_initialized" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when [method initialize] has succeeded and [method cleanup] has not yet been called.
+			</description>
+		</method>
+		<method name="cleanup">
+			<return type="void" />
+			<description>
+				Reclaims all Game Chat resources by calling [code]chat_manager::cleanup()[/code]. Safe to call when not initialized (no-op). Invoked automatically when the GDK runtime shuts down.
+			</description>
+		</method>
+		<method name="add_local_user">
+			<return type="GDKResult" />
+			<param index="0" name="user" type="GDKUser" />
+			<description>
+				Adds a signed-in [param user] as a local chat user. On success [code]GDKResult.data.xuid[/code] holds the user's Xbox User ID. Errors with [code]not_initialized[/code], [code]invalid_user[/code], or [code]add_user_failed[/code].
+			</description>
+		</method>
+		<method name="add_remote_user">
+			<return type="GDKResult" />
+			<param index="0" name="xuid" type="String" />
+			<param index="1" name="endpoint_id" type="int" />
+			<description>
+				Adds a remote chat user identified by [param xuid] reachable on the title-assigned [param endpoint_id]. Remote users on the same device/endpoint must share an [param endpoint_id]; Game Chat uses it to address outgoing frames and to attribute incoming frames passed to [method process_incoming_data_frame]. On success [code]GDKResult.data[/code] holds [code]xuid[/code] and [code]endpoint_id[/code]. Errors with [code]not_initialized[/code], [code]invalid_xuid[/code], or [code]add_user_failed[/code].
+			</description>
+		</method>
+		<method name="remove_user">
+			<return type="GDKResult" />
+			<param index="0" name="xuid" type="String" />
+			<description>
+				Removes the local or remote chat user matching [param xuid]. Errors with [code]not_initialized[/code] or [code]user_not_found[/code].
+			</description>
+		</method>
+		<method name="set_communication_relationship">
+			<return type="GDKResult" />
+			<param index="0" name="local_xuid" type="String" />
+			<param index="1" name="target_xuid" type="String" />
+			<param index="2" name="relationship" type="int" enum="GDKGameChat.CommunicationRelationship" />
+			<description>
+				Sets the communication [param relationship] (a bitwise combination of [enum CommunicationRelationship] flags) that the local user [param local_xuid] is allowed to use toward [param target_xuid]. Errors with [code]not_initialized[/code], [code]user_not_found[/code], [code]not_local_user[/code], or [code]target_not_found[/code].
+			</description>
+		</method>
+		<method name="set_microphone_muted">
+			<return type="GDKResult" />
+			<param index="0" name="local_xuid" type="String" />
+			<param index="1" name="muted" type="bool" />
+			<description>
+				Sets whether the local user [param local_xuid]'s microphone is muted. Muting stops microphone capture but not outgoing text or synthesized speech. Errors with [code]not_initialized[/code], [code]user_not_found[/code], or [code]not_local_user[/code].
+			</description>
+		</method>
+		<method name="set_remote_user_muted">
+			<return type="GDKResult" />
+			<param index="0" name="local_xuid" type="String" />
+			<param index="1" name="target_xuid" type="String" />
+			<param index="2" name="muted" type="bool" />
+			<description>
+				Sets whether the remote user [param target_xuid] is muted for the local user [param local_xuid]. A muted remote user's audio is not rendered and the local user is excluded from that remote's text receiver list. Errors with [code]not_initialized[/code], [code]user_not_found[/code], [code]not_local_user[/code], or [code]target_not_found[/code].
+			</description>
+		</method>
+		<method name="set_audio_render_volume">
+			<return type="GDKResult" />
+			<param index="0" name="local_xuid" type="String" />
+			<param index="1" name="target_xuid" type="String" />
+			<param index="2" name="volume" type="float" />
+			<description>
+				Sets the render [param volume] (0.0 quietest to 1.0 standard; clamped) used for audio received from [param target_xuid] by the local user [param local_xuid]. Errors with [code]not_initialized[/code], [code]user_not_found[/code], [code]not_local_user[/code], or [code]target_not_found[/code].
+			</description>
+		</method>
+		<method name="send_text">
+			<return type="GDKResult" />
+			<param index="0" name="local_xuid" type="String" />
+			<param index="1" name="text" type="String" />
+			<description>
+				Sends a chat [param text] message (1 to 1023 characters) from the local user [param local_xuid] to every user configured to receive text from them. Errors with [code]not_initialized[/code], [code]invalid_text[/code], [code]user_not_found[/code], or [code]not_local_user[/code].
+			</description>
+		</method>
+		<method name="synthesize_text_to_speech">
+			<return type="GDKResult" />
+			<param index="0" name="local_xuid" type="String" />
+			<param index="1" name="text" type="String" />
+			<description>
+				Synthesizes [param text] as speech audio from the local user [param local_xuid], as if spoken into their microphone. Only takes effect when the user has text-to-speech enabled. Errors with [code]not_initialized[/code], [code]invalid_text[/code], [code]user_not_found[/code], or [code]not_local_user[/code].
+			</description>
+		</method>
+		<method name="process_incoming_data_frame">
+			<return type="GDKResult" />
+			<param index="0" name="source_endpoint_id" type="int" />
+			<param index="1" name="bytes" type="PackedByteArray" />
+			<description>
+				Hands Game Chat a data frame received from a remote endpoint. [param source_endpoint_id] must match the [code]endpoint_id[/code] a remote user was added with via [method add_remote_user], and [param bytes] is the opaque payload that arrived in an [signal outgoing_data_frame] on the sender. Errors with [code]not_initialized[/code] or [code]invalid_data[/code].
+			</description>
+		</method>
+		<method name="get_chat_users" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns an [Array] of [Dictionary] entries describing the current chat users, each with [code]xuid[/code] ([String]), [code]is_local[/code] ([bool]), and [code]chat_indicator[/code] ([int], see [enum ChatIndicator]). Returns an empty array when not initialized.
+			</description>
+		</method>
+	</methods>
+	<members>
+	</members>
+	<signals>
+		<signal name="outgoing_data_frame">
+			<param index="0" name="target_endpoint_ids" type="PackedInt64Array" />
+			<param index="1" name="bytes" type="PackedByteArray" />
+			<param index="2" name="transport_requirement" type="int" />
+			<description>
+				Emitted while pumping (during [code]GDK.dispatch()[/code]) for each Game Chat data frame the title must transmit. Deliver [param bytes] to every endpoint in [param target_endpoint_ids] over the title's own transport, then call [method process_incoming_data_frame] on each receiving instance. [param transport_requirement] is a [enum TransportRequirement] value indicating whether guaranteed or best-effort delivery is expected.
+			</description>
+		</signal>
+		<signal name="text_chat_received">
+			<param index="0" name="sender_xuid" type="String" />
+			<param index="1" name="message" type="String" />
+			<description>
+				Emitted while pumping when a text message from [param sender_xuid] is addressed to one or more local users.
+			</description>
+		</signal>
+		<signal name="transcribed_chat_received">
+			<param index="0" name="speaker_xuid" type="String" />
+			<param index="1" name="message" type="String" />
+			<description>
+				Emitted while pumping when a remote speaker [param speaker_xuid]'s voice has been transcribed for local users who requested speech-to-text.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="RELATIONSHIP_NONE" value="0" enum="CommunicationRelationship">
+			No communication is allowed between the two users.
+		</constant>
+		<constant name="RELATIONSHIP_SEND_MICROPHONE_AUDIO" value="1" enum="CommunicationRelationship">
+			The local user may send microphone audio to the target user.
+		</constant>
+		<constant name="RELATIONSHIP_SEND_TEXT_TO_SPEECH_AUDIO" value="2" enum="CommunicationRelationship">
+			The local user may send text-to-speech audio to the target user.
+		</constant>
+		<constant name="RELATIONSHIP_SEND_TEXT" value="4" enum="CommunicationRelationship">
+			The local user may send text to the target user.
+		</constant>
+		<constant name="RELATIONSHIP_RECEIVE_AUDIO" value="8" enum="CommunicationRelationship">
+			The local user may receive audio from the target user.
+		</constant>
+		<constant name="RELATIONSHIP_RECEIVE_TEXT" value="16" enum="CommunicationRelationship">
+			The local user may receive text from the target user.
+		</constant>
+		<constant name="RELATIONSHIP_SEND_ALL" value="7" enum="CommunicationRelationship">
+			Convenience mask allowing the local user to send all communication types (microphone, text-to-speech, and text).
+		</constant>
+		<constant name="RELATIONSHIP_RECEIVE_ALL" value="24" enum="CommunicationRelationship">
+			Convenience mask allowing the local user to receive all communication types (audio and text).
+		</constant>
+		<constant name="RELATIONSHIP_SEND_AND_RECEIVE_ALL" value="31" enum="CommunicationRelationship">
+			Convenience mask allowing the local user to both send and receive all communication types. This is the default relationship used by [method initialize].
+		</constant>
+		<constant name="TRANSPORT_GUARANTEED" value="0" enum="TransportRequirement">
+			The outgoing data frame must be delivered with guaranteed (reliable) delivery.
+		</constant>
+		<constant name="TRANSPORT_BEST_EFFORT" value="1" enum="TransportRequirement">
+			The outgoing data frame may be delivered best-effort; packet loss is acceptable.
+		</constant>
+		<constant name="CHAT_INDICATOR_SILENT" value="0" enum="ChatIndicator">
+			The user is not currently talking.
+		</constant>
+		<constant name="CHAT_INDICATOR_TALKING" value="1" enum="ChatIndicator">
+			The user is currently talking.
+		</constant>
+		<constant name="CHAT_INDICATOR_LOCAL_MICROPHONE_MUTED" value="2" enum="ChatIndicator">
+			The local user's microphone is muted.
+		</constant>
+		<constant name="CHAT_INDICATOR_INCOMING_COMMUNICATIONS_MUTED" value="3" enum="ChatIndicator">
+			The remote user has been muted by all local users.
+		</constant>
+		<constant name="CHAT_INDICATOR_REPUTATION_RESTRICTED" value="4" enum="ChatIndicator">
+			Chat with this user is limited due to an "Avoid Me" reputation.
+		</constant>
+		<constant name="CHAT_INDICATOR_PLATFORM_RESTRICTED" value="5" enum="ChatIndicator">
+			Chat with this user is limited by platform privacy/privilege restrictions.
+		</constant>
+		<constant name="CHAT_INDICATOR_NO_CHAT_FOCUS" value="6" enum="ChatIndicator">
+			The user cannot chat because the app lacks the microphone capability or chat audio focus.
+		</constant>
+		<constant name="CHAT_INDICATOR_NO_MICROPHONE" value="7" enum="ChatIndicator">
+			The user has no microphone available or configured.
+		</constant>
+	</constants>
+</class>

--- a/addons/godot_gdk/doc_classes/GDKGameSave.xml
+++ b/addons/godot_gdk/doc_classes/GDKGameSave.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDKGameSave" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		GDK-native file-style game save service accessed via GDK.game_save.
+	</brief_description>
+	<description>
+		Wraps [code]XGameSaveFiles[/code] to resolve a user's cloud-synced save folder and query the remaining storage quota. This is the simpler file-based variation of the connected-storage API and is distinct from PlayFab Game Saves ([code]godot_playfab[/code]) and from [GDKTitleStorage]. The title's [code]MicrosoftGame.config[/code] must declare a connected-storage/save-folder configuration for these calls to succeed; the service configuration ID (SCID) is supplied automatically from the initialized Xbox services scaffold.
+	</description>
+	<tutorials></tutorials>
+	<methods>
+		<method name="get_folder_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<description>
+				Resolves the local, cloud-synced save folder for [param user] via [code]XGameSaveFilesGetFolderWithUiAsync[/code]. Returns a [Signal] that completes with a [GDKResult] whose [code]data.path[/code] holds the absolute folder path. The platform may show a brief sync UI. Requires a signed-in [GDKUser] and an initialized runtime.
+			</description>
+		</method>
+		<method name="get_remaining_quota">
+			<return type="GDKResult" />
+			<param index="0" name="user" type="GDKUser" />
+			<description>
+				Returns the remaining game-save storage quota for [param user] via [code]XGameSaveFilesGetRemainingQuota[/code]. On success [code]GDKResult.data.bytes[/code] holds the remaining byte count. Synchronous; requires a signed-in [GDKUser] and an initialized runtime.
+			</description>
+		</method>
+	</methods>
+	<members>
+	</members>
+	<signals>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/addons/godot_gdk/doc_classes/GDKGameUI.xml
+++ b/addons/godot_gdk/doc_classes/GDKGameUI.xml
@@ -56,6 +56,44 @@
 				Shows privilege-resolution UI for [param user] and [param privilege]. This forwards to the existing users-service privilege-remediation flow.
 			</description>
 		</method>
+		<method name="show_achievements_async">
+			<return type="Signal" />
+			<param index="0" name="requesting_user" type="GDKUser" />
+			<description>
+				Shows the system achievements UI for [param requesting_user] scoped to the current title. The title ID is resolved automatically via [code]XGameGetXboxTitleId[/code].
+			</description>
+		</method>
+		<method name="show_error_dialog_async">
+			<return type="Signal" />
+			<param index="0" name="error_code" type="int" />
+			<param index="1" name="context" type="String" default="&quot;&quot;" />
+			<description>
+				Shows the system error dialog for the supplied [param error_code] (an HRESULT). [param context] optionally supplies extra context text shown to the user.
+			</description>
+		</method>
+		<method name="show_send_game_invite_async">
+			<return type="Signal" />
+			<param index="0" name="requesting_user" type="GDKUser" />
+			<param index="1" name="session_configuration_id" type="String" />
+			<param index="2" name="session_template_name" type="String" />
+			<param index="3" name="session_id" type="String" />
+			<param index="4" name="invitation_text" type="String" default="&quot;&quot;" />
+			<param index="5" name="custom_activation_context" type="String" default="&quot;&quot;" />
+			<description>
+				Shows the system send-game-invite UI for [param requesting_user]. The session identifiers describe the multiplayer session players are invited into; [param invitation_text] and [param custom_activation_context] are optional. Validation failures return [code]invalid_session[/code] or [code]invalid_user[/code].
+			</description>
+		</method>
+		<method name="show_text_entry_async">
+			<return type="Signal" />
+			<param index="0" name="title_text" type="String" default="&quot;&quot;" />
+			<param index="1" name="description_text" type="String" default="&quot;&quot;" />
+			<param index="2" name="default_text" type="String" default="&quot;&quot;" />
+			<param index="3" name="input_scope" type="String" default="&quot;default&quot;" />
+			<param index="4" name="max_text_length" type="int" default="0" />
+			<description>
+				Shows the system virtual-keyboard text entry UI. [param input_scope] accepts [code]default[/code], [code]url[/code], [code]email[/code], [code]number[/code], [code]password[/code], [code]telephone[/code], [code]alphanumeric[/code], [code]search[/code], or [code]chat[/code]. [param max_text_length] of [code]0[/code] uses the platform default. On success, [code]GDKResult.data.text[/code] holds the entered string.
+			</description>
+		</method>
 	</methods>
 	<members>
 	</members>

--- a/addons/godot_gdk/doc_classes/GDKSocial.xml
+++ b/addons/godot_gdk/doc_classes/GDKSocial.xml
@@ -46,6 +46,22 @@
 				Creates a social group that tracks the specified XUIDs. Returns a [GDKResult]; on success the [code]data[/code] field contains the created [GDKSocialGroup]. On failure the result describes the error and a [code]runtime_error[/code] signal is emitted.
 			</description>
 		</method>
+		<method name="update_social_user_group">
+			<return type="GDKResult" />
+			<param index="0" name="group" type="GDKSocialGroup" />
+			<param index="1" name="xuids" type="PackedStringArray" />
+			<description>
+				Replaces the tracked-user list of an existing list-based [GDKSocialGroup] (one created via [method create_social_group_from_xuids]) with [param xuids], wrapping [code]XblSocialManagerUpdateSocialUserGroup[/code]. Returns a [GDKResult] whose [code]data.count[/code] reports the new tracked-user count. Filter-based groups cannot be updated this way.
+			</description>
+		</method>
+		<method name="set_rich_presence_polling">
+			<return type="GDKResult" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Enables or disables Social Manager rich-presence polling for [param user] via [code]XblSocialManagerSetRichPresencePollingStatus[/code]. When enabled, the Social Manager polls the presence service roughly every 30 seconds so social-graph users' presence stays current. Returns a [GDKResult] whose [code]data.enabled[/code] echoes the requested state. The user's social graph is started if it is not already.
+			</description>
+		</method>
 		<method name="destroy_social_group">
 			<return type="void" />
 			<param index="0" name="group" type="GDKSocialGroup" />

--- a/addons/godot_gdk/doc_classes/GDKSpeechSynthesizer.xml
+++ b/addons/godot_gdk/doc_classes/GDKSpeechSynthesizer.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDKSpeechSynthesizer" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Text-to-speech synthesis through PC GDK.
+	</brief_description>
+	<description>
+		[GDKSpeechSynthesizer] is exposed as [code]GDK.speech[/code]. It wraps the GDK [code]XSpeechSynthesizer[/code] API to turn text or SSML into PCM/WAV audio bytes on the local device, with no network call.
+		The service lazily creates a single native synthesizer the first time a voice is selected or speech is synthesized, and releases it on [method GDK.shutdown]. Selecting a voice with [method set_default_voice] or [method set_custom_voice] affects every subsequent [method synthesize_text] / [method synthesize_ssml] call.
+		[codeblock]
+		var voices: Array = GDK.speech.get_installed_voices()
+		if voices.size() &gt; 0:
+		    GDK.speech.set_custom_voice(voices[0]["id"])
+		var result: GDKResult = GDK.speech.synthesize_text("Welcome to the game.")
+		if result.ok:
+		    var wav: PackedByteArray = result.data["audio_wav"]
+		    # ...persist or decode the WAV bytes...
+		# Convenience: play immediately through a Godot AudioStreamPlayer.
+		$AudioStreamPlayer.stream = GDK.speech.synthesize_to_stream("Welcome to the game.")
+		$AudioStreamPlayer.play()
+		[/codeblock]
+	</description>
+	<tutorials></tutorials>
+	<methods>
+		<method name="get_installed_voices">
+			<return type="Array" />
+			<description>
+				Returns an [Array] of [Dictionary] entries describing the installed TTS voices. Each entry has the keys [code]id[/code], [code]display_name[/code], [code]language[/code], [code]gender[/code] ([code]"male"[/code] or [code]"female"[/code]), and [code]description[/code]. Returns an empty array before [method GDK.initialize] or when enumeration fails.
+			</description>
+		</method>
+		<method name="set_default_voice">
+			<return type="GDKResult" />
+			<description>
+				Selects the platform default voice for subsequent synthesis. Returns an error [GDKResult] before [method GDK.initialize] or when the synthesizer cannot be created.
+			</description>
+		</method>
+		<method name="set_custom_voice">
+			<return type="GDKResult" />
+			<param index="0" name="voice_id" type="String" />
+			<description>
+				Selects a specific voice by its [code]id[/code] (as reported by [method get_installed_voices]). Returns an [code]invalid_voice_id[/code] error when [param voice_id] is empty.
+			</description>
+		</method>
+		<method name="synthesize_text">
+			<return type="GDKResult" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Synthesizes [param text] into audio. On success [member GDKResult.data] contains [code]audio_wav[/code] (a [PackedByteArray] holding RIFF/WAV bytes) and [code]byte_count[/code]. Returns an [code]invalid_input[/code] error for empty input.
+			</description>
+		</method>
+		<method name="synthesize_ssml">
+			<return type="GDKResult" />
+			<param index="0" name="ssml" type="String" />
+			<description>
+				Synthesizes a Speech Synthesis Markup Language (SSML) document into audio. On success [member GDKResult.data] contains [code]audio_wav[/code] (a [PackedByteArray]) and [code]byte_count[/code]. Returns an [code]invalid_input[/code] error for empty input.
+			</description>
+		</method>
+		<method name="synthesize_to_stream">
+			<return type="AudioStreamWAV" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Convenience helper that synthesizes [param text] and returns a ready-to-play [AudioStreamWAV]. Returns [code]null[/code] when synthesis fails or the produced audio cannot be decoded.
+			</description>
+		</method>
+	</methods>
+	<members>
+	</members>
+	<signals>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/addons/godot_gdk/doc_classes/GDKStats.xml
+++ b/addons/godot_gdk/doc_classes/GDKStats.xml
@@ -26,6 +26,14 @@
 				Queries the specified statistics for multiple target XUIDs using [param user] as the local Xbox Services context. On success, [member GDKResult.data] is a [Dictionary] keyed by XUID, with each value a statistic-name dictionary.
 			</description>
 		</method>
+		<method name="get_single_stat_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="stat_name" type="String" />
+			<description>
+				Reads a single named statistic for [param user] via [code]XblUserStatisticsGetSingleUserStatisticAsync[/code]. Await the returned completion [Signal]; on success [member GDKResult.data] holds the statistic payload for [param user]. Use [method query_user_stats_async] to read several stats in one call.
+			</description>
+		</method>
 		<method name="set_stat_integer">
 			<return type="GDKResult" />
 			<param index="0" name="user" type="GDKUser" />
@@ -49,6 +57,22 @@
 			<param index="0" name="user" type="GDKUser" />
 			<description>
 				Submits the staged title-managed statistics for [param user]. Await the returned completion [Signal] directly.
+			</description>
+		</method>
+		<method name="write_stats_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="stats" type="Dictionary" />
+			<description>
+				Replaces all of [param user]'s title-managed statistics with the provided set via [code]XblTitleManagedStatsWriteAsync[/code]. [param stats] maps statistic names to numeric values; any title-managed stat not present in the map is removed by the service. Await the returned completion [Signal]; on success [member GDKResult.data] holds [code]xuid[/code] and [code]count[/code]. This writes online state and is a live-write surface. Contrast with [method flush_stats_async], which merges staged values without removing others.
+			</description>
+		</method>
+		<method name="delete_stats_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="stat_names" type="PackedStringArray" />
+			<description>
+				Deletes the named title-managed statistics for [param user] via [code]XblTitleManagedStatsDeleteStatsAsync[/code]. Names with no matching stat are ignored. Await the returned completion [Signal]; on success [member GDKResult.data] holds [code]xuid[/code] and [code]count[/code]. This writes online state and is a live-write surface.
 			</description>
 		</method>
 		<method name="track_stats">

--- a/addons/godot_gdk/doc_classes/GDKStore.xml
+++ b/addons/godot_gdk/doc_classes/GDKStore.xml
@@ -32,6 +32,50 @@
 				Shows the system purchase UI for the specified Store product ID.
 			</description>
 		</method>
+		<method name="show_product_page_ui_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="store_id" type="String" />
+			<description>
+				Shows the system product page UI for the specified Store product ID. The completion [Signal] emits a [GDKResult] whose [code]data.store_id[/code] echoes the requested product.
+			</description>
+		</method>
+		<method name="show_associated_products_ui_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="store_id" type="String" />
+			<param index="2" name="product_kinds" type="String" default="&quot;&quot;" />
+			<description>
+				Shows the system associated-products UI for the specified Store product ID. [code]product_kinds[/code] is a comma-separated filter drawn from [code]consumable[/code], [code]durable[/code], [code]game[/code], [code]pass[/code], and [code]unmanaged_consumable[/code]; an empty string includes all kinds.
+			</description>
+		</method>
+		<method name="show_rate_and_review_ui_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<description>
+				Shows the system rate-and-review UI for the current title. The completion [Signal] emits a [GDKResult] whose [code]data.was_updated[/code] reports whether the user submitted or changed a review.
+			</description>
+		</method>
+		<method name="show_redeem_token_ui_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="token" type="String" />
+			<param index="2" name="allowed_store_ids" type="PackedStringArray" default="PackedStringArray()" />
+			<param index="3" name="disallow_csv_redemption" type="bool" default="false" />
+			<description>
+				Shows the system token-redemption UI for the supplied 5x5 token or token string. [code]allowed_store_ids[/code] optionally restricts which products may be redeemed; [code]disallow_csv_redemption[/code] blocks redeeming as Store credit.
+			</description>
+		</method>
+		<method name="show_gifting_ui_async">
+			<return type="Signal" />
+			<param index="0" name="user" type="GDKUser" />
+			<param index="1" name="store_id" type="String" />
+			<param index="2" name="name" type="String" default="&quot;&quot;" />
+			<param index="3" name="extended_json" type="String" default="&quot;&quot;" />
+			<description>
+				Shows the system gifting UI for the specified Store product ID. [code]name[/code] and [code]extended_json[/code] are optional gifting metadata forwarded to the Store.
+			</description>
+		</method>
 		<method name="get_cached_license_status" qualifiers="const">
 			<return type="GDKStoreLicenseStatus" />
 			<param index="0" name="store_id" type="String" />

--- a/addons/godot_gdk/doc_classes/GDKSystem.xml
+++ b/addons/godot_gdk/doc_classes/GDKSystem.xml
@@ -39,6 +39,13 @@
 				Returns [code]true[/code] if the shared Xbox services scaffold has been initialized.
 			</description>
 		</method>
+		<method name="is_feature_available" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="feature_name" type="String" />
+			<description>
+				Returns [code]true[/code] if the named GDK runtime feature is available, wrapping [code]XGameRuntimeIsFeatureAvailable[/code]. [param feature_name] is matched case-insensitively against the [code]XGameRuntimeFeature[/code] identifiers (for example [code]"XSpeechSynthesizer"[/code], [code]"XGameEvent"[/code], [code]"XStore"[/code], [code]"XGameSave"[/code]). Unknown names log a warning and return [code]false[/code]. Requires [method GDK.initialize] to have run first.
+			</description>
+		</method>
 	</methods>
 	<members>
 	</members>

--- a/addons/godot_gdk/doc_classes/GDKSystem.xml
+++ b/addons/godot_gdk/doc_classes/GDKSystem.xml
@@ -43,7 +43,7 @@
 			<return type="bool" />
 			<param index="0" name="feature_name" type="String" />
 			<description>
-				Returns [code]true[/code] if the named GDK runtime feature is available, wrapping [code]XGameRuntimeIsFeatureAvailable[/code]. [param feature_name] is matched case-insensitively against the [code]XGameRuntimeFeature[/code] identifiers (for example [code]"XSpeechSynthesizer"[/code], [code]"XGameEvent"[/code], [code]"XStore"[/code], [code]"XGameSave"[/code]). Unknown names log a warning and return [code]false[/code]. Requires [method GDK.initialize] to have run first.
+				Returns [code]true[/code] if the named GDK runtime feature is available, wrapping [code]XGameRuntimeIsFeatureAvailable[/code]. [param feature_name] is matched case-insensitively against the [code]XGameRuntimeFeature[/code] identifiers (for example [code]"XSpeechSynthesizer"[/code], [code]"XGameEvent"[/code], [code]"XStore"[/code], [code]"XGameSave"[/code]). Unknown names log a warning and return [code]false[/code]. This query does not require [method GDK.initialize] and may be called at any time.
 			</description>
 		</method>
 	</methods>

--- a/addons/godot_gdk/src/gdk.cpp
+++ b/addons/godot_gdk/src/gdk.cpp
@@ -7,6 +7,7 @@
 #include "gdk_display.h"
 #include "gdk_error_reporting.h"
 #include "gdk_events.h"
+#include "gdk_game_save.h"
 #include "gdk_game_ui.h"
 #include "gdk_launcher.h"
 #include "gdk_leaderboards.h"
@@ -90,6 +91,8 @@ GDK::GDK() {
     m_speech->set_owner(this);
     m_events.instantiate();
     m_events->set_owner(this);
+    m_game_save.instantiate();
+    m_game_save->set_owner(this);
 }
 
 GDK::~GDK() {
@@ -128,6 +131,7 @@ GDK::~GDK() {
     m_activation.unref();
     m_speech.unref();
     m_events.unref();
+    m_game_save.unref();
     singleton = nullptr;
 }
 
@@ -160,6 +164,7 @@ void GDK::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_activation"), &GDK::get_activation);
     ClassDB::bind_method(D_METHOD("get_speech"), &GDK::get_speech);
     ClassDB::bind_method(D_METHOD("get_events"), &GDK::get_events);
+    ClassDB::bind_method(D_METHOD("get_game_save"), &GDK::get_game_save);
 
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "users", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKUsers"), "", "get_users");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_ui", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameUI"), "", "get_game_ui");
@@ -184,6 +189,7 @@ void GDK::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "activation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKActivation"), "", "get_activation");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "speech", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSpeechSynthesizer"), "", "get_speech");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "events", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKEvents"), "", "get_events");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_save", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameSave"), "", "get_game_save");
 
     ADD_SIGNAL(MethodInfo("initialized"));
     ADD_SIGNAL(MethodInfo("shutdown_completed"));
@@ -240,6 +246,8 @@ const GDKInitStep INIT_STEPS[] = {
       [](GDK *g) { g->get_speech()->shutdown(); } },
     { [](GDK *g) { return g->get_events()->on_runtime_initialized(); },
       [](GDK *g) { g->get_events()->shutdown(); } },
+    { [](GDK *g) { return g->get_game_save()->on_runtime_initialized(); },
+      [](GDK *g) { g->get_game_save()->shutdown(); } },
 };
 
 struct GDKDispatchStep {
@@ -436,6 +444,10 @@ Ref<GDKSpeechSynthesizer> GDK::get_speech() const {
 
 Ref<GDKEvents> GDK::get_events() const {
     return m_events;
+}
+
+Ref<GDKGameSave> GDK::get_game_save() const {
+    return m_game_save;
 }
 
 GDKRuntime *GDK::get_runtime() const {

--- a/addons/godot_gdk/src/gdk.cpp
+++ b/addons/godot_gdk/src/gdk.cpp
@@ -7,6 +7,7 @@
 #include "gdk_display.h"
 #include "gdk_error_reporting.h"
 #include "gdk_events.h"
+#include "gdk_game_chat.h"
 #include "gdk_game_save.h"
 #include "gdk_game_ui.h"
 #include "gdk_launcher.h"
@@ -93,6 +94,8 @@ GDK::GDK() {
     m_events->set_owner(this);
     m_game_save.instantiate();
     m_game_save->set_owner(this);
+    m_game_chat.instantiate();
+    m_game_chat->set_owner(this);
 }
 
 GDK::~GDK() {
@@ -132,6 +135,7 @@ GDK::~GDK() {
     m_speech.unref();
     m_events.unref();
     m_game_save.unref();
+    m_game_chat.unref();
     singleton = nullptr;
 }
 
@@ -165,6 +169,7 @@ void GDK::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_speech"), &GDK::get_speech);
     ClassDB::bind_method(D_METHOD("get_events"), &GDK::get_events);
     ClassDB::bind_method(D_METHOD("get_game_save"), &GDK::get_game_save);
+    ClassDB::bind_method(D_METHOD("get_game_chat"), &GDK::get_game_chat);
 
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "users", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKUsers"), "", "get_users");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_ui", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameUI"), "", "get_game_ui");
@@ -190,6 +195,7 @@ void GDK::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "speech", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSpeechSynthesizer"), "", "get_speech");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "events", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKEvents"), "", "get_events");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_save", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameSave"), "", "get_game_save");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_chat", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameChat"), "", "get_game_chat");
 
     ADD_SIGNAL(MethodInfo("initialized"));
     ADD_SIGNAL(MethodInfo("shutdown_completed"));
@@ -248,6 +254,8 @@ const GDKInitStep INIT_STEPS[] = {
       [](GDK *g) { g->get_events()->shutdown(); } },
     { [](GDK *g) { return g->get_game_save()->on_runtime_initialized(); },
       [](GDK *g) { g->get_game_save()->shutdown(); } },
+    { [](GDK *g) { return g->get_game_chat()->on_runtime_initialized(); },
+      [](GDK *g) { g->get_game_chat()->shutdown(); } },
 };
 
 struct GDKDispatchStep {
@@ -262,6 +270,7 @@ const GDKDispatchStep DISPATCH_STEPS[] = {
     { [](GDK *g) { return g->get_presence()->dispatch(); } },
     { [](GDK *g) { return g->get_social()->dispatch(); } },
     { [](GDK *g) { return g->get_error_reporting()->dispatch(); } },
+    { [](GDK *g) { return g->get_game_chat()->dispatch(); } },
 };
 
 class GDKShutdownGuard {
@@ -448,6 +457,10 @@ Ref<GDKEvents> GDK::get_events() const {
 
 Ref<GDKGameSave> GDK::get_game_save() const {
     return m_game_save;
+}
+
+Ref<GDKGameChat> GDK::get_game_chat() const {
+    return m_game_chat;
 }
 
 GDKRuntime *GDK::get_runtime() const {

--- a/addons/godot_gdk/src/gdk.cpp
+++ b/addons/godot_gdk/src/gdk.cpp
@@ -17,6 +17,7 @@
 #include "gdk_result.h"
 #include "gdk_runtime.h"
 #include "gdk_social.h"
+#include "gdk_speech_synthesizer.h"
 #include "gdk_stats.h"
 #include "gdk_store.h"
 #include "gdk_string_verify.h"
@@ -84,6 +85,8 @@ GDK::GDK() {
     m_display->set_owner(this);
     m_activation.instantiate();
     m_activation->set_owner(this);
+    m_speech.instantiate();
+    m_speech->set_owner(this);
 }
 
 GDK::~GDK() {
@@ -120,6 +123,7 @@ GDK::~GDK() {
     m_system.unref();
     m_display.unref();
     m_activation.unref();
+    m_speech.unref();
     singleton = nullptr;
 }
 
@@ -150,6 +154,7 @@ void GDK::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_system"), &GDK::get_system);
     ClassDB::bind_method(D_METHOD("get_display"), &GDK::get_display);
     ClassDB::bind_method(D_METHOD("get_activation"), &GDK::get_activation);
+    ClassDB::bind_method(D_METHOD("get_speech"), &GDK::get_speech);
 
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "users", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKUsers"), "", "get_users");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_ui", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameUI"), "", "get_game_ui");
@@ -172,6 +177,7 @@ void GDK::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "system", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSystem"), "", "get_system");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "display", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKDisplay"), "", "get_display");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "activation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKActivation"), "", "get_activation");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "speech", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSpeechSynthesizer"), "", "get_speech");
 
     ADD_SIGNAL(MethodInfo("initialized"));
     ADD_SIGNAL(MethodInfo("shutdown_completed"));
@@ -224,6 +230,8 @@ const GDKInitStep INIT_STEPS[] = {
       [](GDK *g) { g->get_capture()->shutdown(); } },
     { [](GDK *g) { return g->get_display()->on_runtime_initialized(); },
       [](GDK *g) { g->get_display()->shutdown(); } },
+    { [](GDK *g) { return g->get_speech()->on_runtime_initialized(); },
+      [](GDK *g) { g->get_speech()->shutdown(); } },
 };
 
 struct GDKDispatchStep {
@@ -412,6 +420,10 @@ Ref<GDKDisplay> GDK::get_display() const {
 
 Ref<GDKActivation> GDK::get_activation() const {
     return m_activation;
+}
+
+Ref<GDKSpeechSynthesizer> GDK::get_speech() const {
+    return m_speech;
 }
 
 GDKRuntime *GDK::get_runtime() const {

--- a/addons/godot_gdk/src/gdk.cpp
+++ b/addons/godot_gdk/src/gdk.cpp
@@ -6,6 +6,7 @@
 #include "gdk_capture.h"
 #include "gdk_display.h"
 #include "gdk_error_reporting.h"
+#include "gdk_events.h"
 #include "gdk_game_ui.h"
 #include "gdk_launcher.h"
 #include "gdk_leaderboards.h"
@@ -87,6 +88,8 @@ GDK::GDK() {
     m_activation->set_owner(this);
     m_speech.instantiate();
     m_speech->set_owner(this);
+    m_events.instantiate();
+    m_events->set_owner(this);
 }
 
 GDK::~GDK() {
@@ -124,6 +127,7 @@ GDK::~GDK() {
     m_display.unref();
     m_activation.unref();
     m_speech.unref();
+    m_events.unref();
     singleton = nullptr;
 }
 
@@ -155,6 +159,7 @@ void GDK::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_display"), &GDK::get_display);
     ClassDB::bind_method(D_METHOD("get_activation"), &GDK::get_activation);
     ClassDB::bind_method(D_METHOD("get_speech"), &GDK::get_speech);
+    ClassDB::bind_method(D_METHOD("get_events"), &GDK::get_events);
 
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "users", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKUsers"), "", "get_users");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "game_ui", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKGameUI"), "", "get_game_ui");
@@ -178,6 +183,7 @@ void GDK::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "display", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKDisplay"), "", "get_display");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "activation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKActivation"), "", "get_activation");
     ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "speech", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKSpeechSynthesizer"), "", "get_speech");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "events", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE, "GDKEvents"), "", "get_events");
 
     ADD_SIGNAL(MethodInfo("initialized"));
     ADD_SIGNAL(MethodInfo("shutdown_completed"));
@@ -232,6 +238,8 @@ const GDKInitStep INIT_STEPS[] = {
       [](GDK *g) { g->get_display()->shutdown(); } },
     { [](GDK *g) { return g->get_speech()->on_runtime_initialized(); },
       [](GDK *g) { g->get_speech()->shutdown(); } },
+    { [](GDK *g) { return g->get_events()->on_runtime_initialized(); },
+      [](GDK *g) { g->get_events()->shutdown(); } },
 };
 
 struct GDKDispatchStep {
@@ -424,6 +432,10 @@ Ref<GDKActivation> GDK::get_activation() const {
 
 Ref<GDKSpeechSynthesizer> GDK::get_speech() const {
     return m_speech;
+}
+
+Ref<GDKEvents> GDK::get_events() const {
+    return m_events;
 }
 
 GDKRuntime *GDK::get_runtime() const {

--- a/addons/godot_gdk/src/gdk.cpp
+++ b/addons/godot_gdk/src/gdk.cpp
@@ -513,6 +513,9 @@ void GDK::notify_user_removed(const Ref<GDKUser> &p_user) {
     if (m_multiplayer_activity.is_valid()) {
         m_multiplayer_activity->on_user_removed(p_user);
     }
+    if (m_game_chat.is_valid()) {
+        m_game_chat->on_user_removed(p_user);
+    }
     if (m_xbox_services != nullptr) {
         XUserLocalId local_id = {};
         local_id.value = static_cast<uint64_t>(p_user->get_local_id());

--- a/addons/godot_gdk/src/gdk.h
+++ b/addons/godot_gdk/src/gdk.h
@@ -19,6 +19,7 @@ class GDKActivation;
 class GDKCapture;
 class GDKDisplay;
 class GDKErrorReporting;
+class GDKEvents;
 class GDKGameUI;
 class GDKLauncher;
 class GDKLeaderboards;
@@ -69,6 +70,7 @@ class GDK : public Object {
     Ref<GDKDisplay> m_display;
     Ref<GDKActivation> m_activation;
     Ref<GDKSpeechSynthesizer> m_speech;
+    Ref<GDKEvents> m_events;
 
 protected:
     static void _bind_methods();
@@ -106,6 +108,7 @@ public:
     Ref<GDKDisplay> get_display() const;
     Ref<GDKActivation> get_activation() const;
     Ref<GDKSpeechSynthesizer> get_speech() const;
+    Ref<GDKEvents> get_events() const;
 
     GDKRuntime *get_runtime() const;
     GDKXboxServices *get_xbox_services() const;

--- a/addons/godot_gdk/src/gdk.h
+++ b/addons/godot_gdk/src/gdk.h
@@ -30,6 +30,7 @@ class GDKProfile;
 class GDKResult;
 class GDKRuntime;
 class GDKSocial;
+class GDKSpeechSynthesizer;
 class GDKStats;
 class GDKStore;
 class GDKStringVerify;
@@ -67,6 +68,7 @@ class GDK : public Object {
     Ref<GDKSystem> m_system;
     Ref<GDKDisplay> m_display;
     Ref<GDKActivation> m_activation;
+    Ref<GDKSpeechSynthesizer> m_speech;
 
 protected:
     static void _bind_methods();
@@ -103,6 +105,7 @@ public:
     Ref<GDKSystem> get_system() const;
     Ref<GDKDisplay> get_display() const;
     Ref<GDKActivation> get_activation() const;
+    Ref<GDKSpeechSynthesizer> get_speech() const;
 
     GDKRuntime *get_runtime() const;
     GDKXboxServices *get_xbox_services() const;

--- a/addons/godot_gdk/src/gdk.h
+++ b/addons/godot_gdk/src/gdk.h
@@ -20,6 +20,7 @@ class GDKCapture;
 class GDKDisplay;
 class GDKErrorReporting;
 class GDKEvents;
+class GDKGameSave;
 class GDKGameUI;
 class GDKLauncher;
 class GDKLeaderboards;
@@ -71,6 +72,7 @@ class GDK : public Object {
     Ref<GDKActivation> m_activation;
     Ref<GDKSpeechSynthesizer> m_speech;
     Ref<GDKEvents> m_events;
+    Ref<GDKGameSave> m_game_save;
 
 protected:
     static void _bind_methods();
@@ -109,6 +111,7 @@ public:
     Ref<GDKActivation> get_activation() const;
     Ref<GDKSpeechSynthesizer> get_speech() const;
     Ref<GDKEvents> get_events() const;
+    Ref<GDKGameSave> get_game_save() const;
 
     GDKRuntime *get_runtime() const;
     GDKXboxServices *get_xbox_services() const;

--- a/addons/godot_gdk/src/gdk.h
+++ b/addons/godot_gdk/src/gdk.h
@@ -20,6 +20,7 @@ class GDKCapture;
 class GDKDisplay;
 class GDKErrorReporting;
 class GDKEvents;
+class GDKGameChat;
 class GDKGameSave;
 class GDKGameUI;
 class GDKLauncher;
@@ -73,6 +74,7 @@ class GDK : public Object {
     Ref<GDKSpeechSynthesizer> m_speech;
     Ref<GDKEvents> m_events;
     Ref<GDKGameSave> m_game_save;
+    Ref<GDKGameChat> m_game_chat;
 
 protected:
     static void _bind_methods();
@@ -112,6 +114,7 @@ public:
     Ref<GDKSpeechSynthesizer> get_speech() const;
     Ref<GDKEvents> get_events() const;
     Ref<GDKGameSave> get_game_save() const;
+    Ref<GDKGameChat> get_game_chat() const;
 
     GDKRuntime *get_runtime() const;
     GDKXboxServices *get_xbox_services() const;

--- a/addons/godot_gdk/src/gdk_achievement.cpp
+++ b/addons/godot_gdk/src/gdk_achievement.cpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <cstdlib>
 
+#include <godot_cpp/variant/dictionary.hpp>
+
 #include "gdk.h"
 #include "gdk_pending_signal.h"
 #include "gdk_result.h"
@@ -31,6 +33,26 @@ String _progress_state_to_string(XblAchievementProgressState p_state) {
         default:
             return "Unknown";
     }
+}
+
+bool _progress_state_from_string(const String &p_value, XblAchievementProgressState *r_state) {
+    if (r_state == nullptr) {
+        return false;
+    }
+
+    const String normalized = p_value.strip_edges().to_lower();
+    if (normalized == "achieved") {
+        *r_state = XblAchievementProgressState::Achieved;
+    } else if (normalized == "notstarted" || normalized == "not_started") {
+        *r_state = XblAchievementProgressState::NotStarted;
+    } else if (normalized == "inprogress" || normalized == "in_progress") {
+        *r_state = XblAchievementProgressState::InProgress;
+    } else if (normalized == "unknown") {
+        *r_state = XblAchievementProgressState::Unknown;
+    } else {
+        return false;
+    }
+    return true;
 }
 
 bool _try_parse_progress_value(const char *p_value, double &r_parsed_value) {
@@ -161,6 +183,7 @@ void GDKAchievements::_bind_methods() {
     ClassDB::bind_method(D_METHOD("query_player_achievements_async", "user"), &GDKAchievements::query_player_achievements_async);
     ClassDB::bind_method(D_METHOD("update_achievement_async", "user", "achievement_id", "percent_complete"), &GDKAchievements::update_achievement_async);
     ClassDB::bind_method(D_METHOD("get_cached_achievements", "user"), &GDKAchievements::get_cached_achievements);
+    ClassDB::bind_method(D_METHOD("get_achievements_by_state", "user", "progress_state"), &GDKAchievements::get_achievements_by_state);
 
     ADD_SIGNAL(MethodInfo("achievement_unlocked",
         PropertyInfo(Variant::OBJECT, "user"),
@@ -773,6 +796,63 @@ Array GDKAchievements::get_cached_achievements(const Ref<GDKUser> &p_user) const
     }
 
     return Array();
+}
+
+Ref<GDKResult> GDKAchievements::get_achievements_by_state(const Ref<GDKUser> &p_user, const String &p_progress_state) {
+    XblAchievementProgressState progress_state = XblAchievementProgressState::Unknown;
+    if (!_progress_state_from_string(p_progress_state, &progress_state)) {
+        return GDKResult::error_result(
+                E_INVALIDARG,
+                "invalid_progress_state",
+                "progress_state must be one of 'Achieved', 'NotStarted', 'InProgress', or 'Unknown'.");
+    }
+
+    UserState *state = nullptr;
+    Ref<GDKResult> ensure_result = _ensure_user_state(p_user, &state);
+    if (!ensure_result->is_ok()) {
+        return ensure_result;
+    }
+
+    if (!state->initialized) {
+        return GDKResult::error_result(
+                E_PENDING,
+                "achievements_not_loaded",
+                "Achievements are not loaded yet. Call query_player_achievements_async() and await it first.");
+    }
+
+    XblAchievementsManagerResultHandle result_handle = nullptr;
+    HRESULT hr = XblAchievementsManagerGetAchievementsByState(
+            state->xbox_user_id,
+            XblAchievementOrderBy::DefaultOrder,
+            XblAchievementsManagerSortOrder::Unsorted,
+            progress_state,
+            &result_handle);
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(hr, "Failed to query achievements by progress state.", "achievement_state_query_failed");
+    }
+
+    const XblAchievement *achievements = nullptr;
+    uint64_t achievements_count = 0;
+    hr = XblAchievementsManagerResultGetAchievements(result_handle, &achievements, &achievements_count);
+    if (FAILED(hr)) {
+        XblAchievementsManagerResultCloseHandle(result_handle);
+        return GDKResult::hresult_error(hr, "Failed to translate the achievements-by-state result.", "achievement_state_translate_failed");
+    }
+
+    Array filtered;
+    for (uint64_t i = 0; i < achievements_count; ++i) {
+        Ref<GDKAchievement> achievement;
+        achievement.instantiate();
+        achievement->populate_from_native(achievements[i]);
+        filtered.push_back(achievement);
+    }
+
+    XblAchievementsManagerResultCloseHandle(result_handle);
+
+    Dictionary data;
+    data["progress_state"] = _progress_state_to_string(progress_state);
+    data["achievements"] = filtered;
+    return GDKResult::ok_result(data);
 }
 
 void GDKAchievements::on_user_removed(const Ref<GDKUser> &p_user) {

--- a/addons/godot_gdk/src/gdk_achievement.h
+++ b/addons/godot_gdk/src/gdk_achievement.h
@@ -122,6 +122,7 @@ public:
     Signal query_player_achievements_async(const Ref<GDKUser> &p_user);
     Signal update_achievement_async(const Ref<GDKUser> &p_user, const String &p_achievement_id, int64_t p_percent_complete);
     Array get_cached_achievements(const Ref<GDKUser> &p_user) const;
+    Ref<GDKResult> get_achievements_by_state(const Ref<GDKUser> &p_user, const String &p_progress_state);
 
     void on_user_removed(const Ref<GDKUser> &p_user);
 };

--- a/addons/godot_gdk/src/gdk_events.cpp
+++ b/addons/godot_gdk/src/gdk_events.cpp
@@ -1,0 +1,172 @@
+#include "gdk_events.h"
+
+#include <array>
+#include <cstdio>
+#include <random>
+#include <string>
+
+#include <XUser.h>
+#include <XGameEvent.h>
+
+#include <godot_cpp/classes/json.hpp>
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+namespace godot {
+
+namespace {
+
+String _generate_play_session_id() {
+    std::random_device device;
+    std::mt19937_64 generator(((static_cast<uint64_t>(device()) << 32) ^ static_cast<uint64_t>(device())));
+    std::uniform_int_distribution<uint32_t> byte_distribution(0, 255);
+
+    std::array<uint8_t, 16> bytes = {};
+    for (uint8_t &value : bytes) {
+        value = static_cast<uint8_t>(byte_distribution(generator));
+    }
+
+    // RFC 4122 version 4 (random) UUID bits.
+    bytes[6] = static_cast<uint8_t>((bytes[6] & 0x0F) | 0x40);
+    bytes[8] = static_cast<uint8_t>((bytes[8] & 0x3F) | 0x80);
+
+    char buffer[37] = {};
+    std::snprintf(
+            buffer,
+            sizeof(buffer),
+            "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]);
+    return String::utf8(buffer);
+}
+
+String _stringify_json_fields(const Dictionary &p_fields) {
+    if (p_fields.is_empty()) {
+        return String();
+    }
+    return JSON::stringify(p_fields);
+}
+
+} // namespace
+
+void GDKEvents::_bind_methods() {
+    ClassDB::bind_method(
+            D_METHOD("write_event", "user", "event_name", "dimensions", "measurements"),
+            &GDKEvents::write_event,
+            DEFVAL(Dictionary()),
+            DEFVAL(Dictionary()));
+    ClassDB::bind_method(D_METHOD("set_play_session_id", "play_session_id"), &GDKEvents::set_play_session_id);
+    ClassDB::bind_method(D_METHOD("get_play_session_id"), &GDKEvents::get_play_session_id);
+
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "play_session_id"), "set_play_session_id", "get_play_session_id");
+}
+
+void GDKEvents::set_owner(GDK *p_owner) {
+    m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKEvents::on_runtime_initialized() {
+    m_runtime_ready = true;
+    _ensure_play_session_id();
+    return GDKResult::ok_result();
+}
+
+void GDKEvents::shutdown() {
+    m_runtime_ready = false;
+}
+
+GDKRuntime *GDKEvents::_get_runtime() const {
+    return m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+}
+
+GDKXboxServices *GDKEvents::_get_xbox_services() const {
+    return m_owner != nullptr ? m_owner->get_xbox_services() : nullptr;
+}
+
+void GDKEvents::_ensure_play_session_id() {
+    if (m_play_session_id.strip_edges().is_empty()) {
+        m_play_session_id = _generate_play_session_id();
+    }
+}
+
+Ref<GDKResult> GDKEvents::write_event(
+        const Ref<GDKUser> &p_user,
+        const String &p_event_name,
+        const Dictionary &p_dimensions,
+        const Dictionary &p_measurements) {
+    const String event_name = p_event_name.strip_edges();
+    if (event_name.is_empty()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_event_name", "A non-empty event name is required.");
+    }
+
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr || !runtime->is_available()) {
+        return GDKResult::error_result(E_FAIL, "runtime_unavailable", "GDK runtime is unavailable in the current process.");
+    }
+    if (!m_runtime_ready || !runtime->is_initialized()) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+    if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+    }
+
+    GDKXboxServices *xbox_services = _get_xbox_services();
+    if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+        return GDKResult::error_result(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+    }
+    const String scid = xbox_services->get_scid();
+    if (scid.is_empty()) {
+        return GDKResult::error_result(E_FAIL, "xbox_service_config_unavailable", "The Xbox Live service configuration ID (SCID) is unavailable.");
+    }
+
+    _ensure_play_session_id();
+
+    const std::string scid_utf8 = scid.utf8().get_data();
+    const std::string play_session_id_utf8 = m_play_session_id.utf8().get_data();
+    const std::string event_name_utf8 = event_name.utf8().get_data();
+    const String dimensions_json = _stringify_json_fields(p_dimensions);
+    const String measurements_json = _stringify_json_fields(p_measurements);
+    const std::string dimensions_utf8 = dimensions_json.utf8().get_data();
+    const std::string measurements_utf8 = measurements_json.utf8().get_data();
+
+    HRESULT hr = XGameEventWrite(
+            p_user->get_handle(),
+            scid_utf8.c_str(),
+            play_session_id_utf8.c_str(),
+            event_name_utf8.c_str(),
+            dimensions_json.is_empty() ? nullptr : dimensions_utf8.c_str(),
+            measurements_json.is_empty() ? nullptr : measurements_utf8.c_str());
+
+    if (hr == E_NOTIMPL) {
+        return GDKResult::error_result(
+                hr,
+                "events_feature_unavailable",
+                "The GDK XGameEvent telemetry feature is unavailable in the current runtime. Events were not written.");
+    }
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(hr, "Failed to write the in-game event.", "event_write_failed");
+    }
+
+    Dictionary data;
+    data["event_name"] = event_name;
+    data["play_session_id"] = m_play_session_id;
+    return GDKResult::ok_result(data);
+}
+
+void GDKEvents::set_play_session_id(const String &p_play_session_id) {
+    const String play_session_id = p_play_session_id.strip_edges();
+    m_play_session_id = play_session_id.is_empty() ? _generate_play_session_id() : play_session_id;
+}
+
+String GDKEvents::get_play_session_id() {
+    _ensure_play_session_id();
+    return m_play_session_id;
+}
+
+} // namespace godot

--- a/addons/godot_gdk/src/gdk_events.h
+++ b/addons/godot_gdk/src/gdk_events.h
@@ -1,0 +1,54 @@
+#ifndef GDK_EVENTS_H
+#define GDK_EVENTS_H
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKEvents : public RefCounted {
+    GDCLASS(GDKEvents, RefCounted);
+
+    GDK *m_owner = nullptr;
+    bool m_runtime_ready = false;
+    String m_play_session_id;
+
+    GDKRuntime *_get_runtime() const;
+    GDKXboxServices *_get_xbox_services() const;
+    void _ensure_play_session_id();
+
+protected:
+    static void _bind_methods();
+
+public:
+    void set_owner(GDK *p_owner);
+
+    Ref<GDKResult> on_runtime_initialized();
+    void shutdown();
+
+    Ref<GDKResult> write_event(
+            const Ref<GDKUser> &p_user,
+            const String &p_event_name,
+            const Dictionary &p_dimensions,
+            const Dictionary &p_measurements);
+    void set_play_session_id(const String &p_play_session_id);
+    String get_play_session_id();
+};
+
+} // namespace godot
+
+#endif // GDK_EVENTS_H

--- a/addons/godot_gdk/src/gdk_game_chat.cpp
+++ b/addons/godot_gdk/src/gdk_game_chat.cpp
@@ -1,6 +1,7 @@
 #include "gdk_game_chat.h"
 
 #include <cstring>
+#include <vector>
 
 #include <godot_cpp/variant/char_string.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
@@ -165,6 +166,18 @@ int GDKGameChat::dispatch() {
 }
 
 int GDKGameChat::_pump_data_frames_count() {
+    // Extract every frame into local storage *before* emitting any Godot
+    // signal. Signals run synchronously, so a handler is free to call back into
+    // GameChat2 (e.g. process_incoming_data_frame, remove_user, cleanup) or
+    // recurse through GDK.dispatch(). GameChat2 forbids re-entering the
+    // start/finish_processing window, so we must close it first and emit after.
+    struct OutgoingFrame {
+        PackedInt64Array targets;
+        PackedByteArray bytes;
+        int transport = TRANSPORT_BEST_EFFORT;
+    };
+    std::vector<OutgoingFrame> outgoing;
+
     uint32_t count = 0;
     game_chat_data_frame_array frames = nullptr;
     chat_manager::singleton_instance().start_processing_data_frames(&count, &frames);
@@ -175,29 +188,42 @@ int GDKGameChat::_pump_data_frames_count() {
             continue;
         }
 
-        PackedInt64Array targets;
-        targets.resize(static_cast<int64_t>(frame->target_endpoint_identifier_count));
+        OutgoingFrame entry;
+        entry.targets.resize(static_cast<int64_t>(frame->target_endpoint_identifier_count));
         for (uint32_t t = 0; t < frame->target_endpoint_identifier_count; ++t) {
-            targets.set(static_cast<int64_t>(t), static_cast<int64_t>(frame->target_endpoint_identifiers[t]));
+            entry.targets.set(static_cast<int64_t>(t), static_cast<int64_t>(frame->target_endpoint_identifiers[t]));
         }
 
-        PackedByteArray bytes;
-        bytes.resize(static_cast<int64_t>(frame->packet_byte_count));
+        entry.bytes.resize(static_cast<int64_t>(frame->packet_byte_count));
         if (frame->packet_byte_count > 0) {
-            memcpy(bytes.ptrw(), frame->packet_buffer, frame->packet_byte_count);
+            memcpy(entry.bytes.ptrw(), frame->packet_buffer, frame->packet_byte_count);
         }
 
-        const int transport = frame->transport_requirement == game_chat_data_transport_requirement::guaranteed
+        entry.transport = frame->transport_requirement == game_chat_data_transport_requirement::guaranteed
                 ? TRANSPORT_GUARANTEED
                 : TRANSPORT_BEST_EFFORT;
-        emit_signal("outgoing_data_frame", targets, bytes, transport);
+        outgoing.push_back(std::move(entry));
     }
 
     chat_manager::singleton_instance().finish_processing_data_frames(frames);
+
+    for (const OutgoingFrame &entry : outgoing) {
+        emit_signal("outgoing_data_frame", entry.targets, entry.bytes, entry.transport);
+    }
     return static_cast<int>(count);
 }
 
 int GDKGameChat::_pump_state_changes_count() {
+    // As with data frames, copy out every state change and close GameChat2's
+    // processing window before emitting signals, so synchronous handlers cannot
+    // re-enter the start/finish_processing_state_changes window.
+    struct ChatMessage {
+        const char *signal_name;
+        String identity;
+        String message;
+    };
+    std::vector<ChatMessage> messages;
+
     uint32_t count = 0;
     game_chat_state_change_array changes = nullptr;
     chat_manager::singleton_instance().start_processing_state_changes(&count, &changes);
@@ -214,7 +240,7 @@ int GDKGameChat::_pump_state_changes_count() {
                 const String sender = change->sender == nullptr
                         ? String()
                         : wide_to_string(change->sender->xbox_user_id());
-                emit_signal("text_chat_received", sender, wide_to_string(change->message));
+                messages.push_back({ "text_chat_received", sender, wide_to_string(change->message) });
                 break;
             }
             case game_chat_state_change_type::transcribed_chat_received: {
@@ -222,7 +248,7 @@ int GDKGameChat::_pump_state_changes_count() {
                 const String speaker = change->speaker == nullptr
                         ? String()
                         : wide_to_string(change->speaker->xbox_user_id());
-                emit_signal("transcribed_chat_received", speaker, wide_to_string(change->message));
+                messages.push_back({ "transcribed_chat_received", speaker, wide_to_string(change->message) });
                 break;
             }
             default:
@@ -231,6 +257,10 @@ int GDKGameChat::_pump_state_changes_count() {
     }
 
     chat_manager::singleton_instance().finish_processing_state_changes(changes);
+
+    for (const ChatMessage &entry : messages) {
+        emit_signal(entry.signal_name, entry.identity, entry.message);
+    }
     return static_cast<int>(count);
 }
 

--- a/addons/godot_gdk/src/gdk_game_chat.cpp
+++ b/addons/godot_gdk/src/gdk_game_chat.cpp
@@ -1,5 +1,6 @@
 #include "gdk_game_chat.h"
 
+#include <cstdint>
 #include <cstring>
 #include <vector>
 
@@ -367,6 +368,27 @@ Ref<GDKResult> GDKGameChat::remove_user(const String &p_xuid) {
     return GDKResult::ok_result();
 }
 
+void GDKGameChat::on_user_removed(const Ref<GDKUser> &p_user) {
+    // Sign-out hook. Critically, return *before* touching
+    // chat_manager::singleton_instance() when chat is not initialized: a
+    // sign-out must never lazily spin up GameChat2. When chat is active, drop
+    // the signed-out user so it cannot linger in GameChat2 after GDK.users has
+    // forgotten it. A user that was never added to chat is simply a no-op.
+    if (!m_initialized || !p_user.is_valid()) {
+        return;
+    }
+
+    const String xuid = p_user->get_xuid();
+    if (xuid.is_empty()) {
+        return;
+    }
+
+    auto *user = static_cast<chat_user *>(_find_user(xuid));
+    if (user != nullptr) {
+        chat_manager::singleton_instance().remove_user(user);
+    }
+}
+
 Ref<GDKResult> GDKGameChat::set_communication_relationship(const String &p_local_xuid, const String &p_target_xuid, int p_relationship) {
     if (!m_initialized) {
         return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
@@ -506,6 +528,9 @@ Ref<GDKResult> GDKGameChat::process_incoming_data_frame(int64_t p_source_endpoin
     }
     if (p_bytes.is_empty()) {
         return GDKResult::error_result(E_INVALIDARG, "invalid_data", "The incoming data frame must contain at least one byte.");
+    }
+    if (p_bytes.size() > static_cast<int64_t>(UINT32_MAX)) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_data", "The incoming data frame exceeds the maximum supported size (UINT32_MAX bytes).");
     }
 
     chat_manager::singleton_instance().process_incoming_data(

--- a/addons/godot_gdk/src/gdk_game_chat.cpp
+++ b/addons/godot_gdk/src/gdk_game_chat.cpp
@@ -1,0 +1,511 @@
+#include "gdk_game_chat.h"
+
+#include <cstring>
+
+#include <godot_cpp/variant/char_string.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/packed_int64_array.hpp>
+
+#include <GameChat2.h>
+// GameChat2's C++ class methods are defined (out-of-line, not inline) in
+// GameChat2Impl.h, which forwards to the C API exported by GameChat2.lib.
+// Include it in exactly one translation unit (this one) to provide those
+// definitions; no other godot_gdk source includes the GameChat2 headers.
+#include <GameChat2Impl.h>
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_user.h"
+
+namespace godot {
+
+using namespace xbox::services::game_chat_2;
+
+namespace {
+
+// GameChat2 XUIDs are PCWSTR (UTF-16). godot::String stores char32_t; utf16()
+// yields a Char16String whose data is layout-compatible with wchar_t on Windows.
+String wide_to_string(PCWSTR p_value) {
+    if (p_value == nullptr) {
+        return String();
+    }
+    return String(reinterpret_cast<const char16_t *>(p_value));
+}
+
+} // namespace
+
+void GDKGameChat::_bind_methods() {
+    ClassDB::bind_method(
+            D_METHOD("initialize", "max_users", "default_relationship"),
+            &GDKGameChat::initialize,
+            DEFVAL(16),
+            DEFVAL(RELATIONSHIP_SEND_AND_RECEIVE_ALL));
+    ClassDB::bind_method(D_METHOD("is_initialized"), &GDKGameChat::is_initialized);
+    ClassDB::bind_method(D_METHOD("cleanup"), &GDKGameChat::cleanup);
+    ClassDB::bind_method(D_METHOD("add_local_user", "user"), &GDKGameChat::add_local_user);
+    ClassDB::bind_method(D_METHOD("add_remote_user", "xuid", "endpoint_id"), &GDKGameChat::add_remote_user);
+    ClassDB::bind_method(D_METHOD("remove_user", "xuid"), &GDKGameChat::remove_user);
+    ClassDB::bind_method(
+            D_METHOD("set_communication_relationship", "local_xuid", "target_xuid", "relationship"),
+            &GDKGameChat::set_communication_relationship);
+    ClassDB::bind_method(D_METHOD("set_microphone_muted", "local_xuid", "muted"), &GDKGameChat::set_microphone_muted);
+    ClassDB::bind_method(
+            D_METHOD("set_remote_user_muted", "local_xuid", "target_xuid", "muted"),
+            &GDKGameChat::set_remote_user_muted);
+    ClassDB::bind_method(
+            D_METHOD("set_audio_render_volume", "local_xuid", "target_xuid", "volume"),
+            &GDKGameChat::set_audio_render_volume);
+    ClassDB::bind_method(D_METHOD("send_text", "local_xuid", "text"), &GDKGameChat::send_text);
+    ClassDB::bind_method(
+            D_METHOD("synthesize_text_to_speech", "local_xuid", "text"),
+            &GDKGameChat::synthesize_text_to_speech);
+    ClassDB::bind_method(
+            D_METHOD("process_incoming_data_frame", "source_endpoint_id", "bytes"),
+            &GDKGameChat::process_incoming_data_frame);
+    ClassDB::bind_method(D_METHOD("get_chat_users"), &GDKGameChat::get_chat_users);
+
+    ADD_SIGNAL(MethodInfo(
+            "outgoing_data_frame",
+            PropertyInfo(Variant::PACKED_INT64_ARRAY, "target_endpoint_ids"),
+            PropertyInfo(Variant::PACKED_BYTE_ARRAY, "bytes"),
+            PropertyInfo(Variant::INT, "transport_requirement")));
+    ADD_SIGNAL(MethodInfo(
+            "text_chat_received",
+            PropertyInfo(Variant::STRING, "sender_xuid"),
+            PropertyInfo(Variant::STRING, "message")));
+    ADD_SIGNAL(MethodInfo(
+            "transcribed_chat_received",
+            PropertyInfo(Variant::STRING, "speaker_xuid"),
+            PropertyInfo(Variant::STRING, "message")));
+
+    BIND_ENUM_CONSTANT(RELATIONSHIP_NONE);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_SEND_MICROPHONE_AUDIO);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_SEND_TEXT_TO_SPEECH_AUDIO);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_SEND_TEXT);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_RECEIVE_AUDIO);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_RECEIVE_TEXT);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_SEND_ALL);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_RECEIVE_ALL);
+    BIND_ENUM_CONSTANT(RELATIONSHIP_SEND_AND_RECEIVE_ALL);
+
+    BIND_ENUM_CONSTANT(TRANSPORT_GUARANTEED);
+    BIND_ENUM_CONSTANT(TRANSPORT_BEST_EFFORT);
+
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_SILENT);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_TALKING);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_LOCAL_MICROPHONE_MUTED);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_INCOMING_COMMUNICATIONS_MUTED);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_REPUTATION_RESTRICTED);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_PLATFORM_RESTRICTED);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_NO_CHAT_FOCUS);
+    BIND_ENUM_CONSTANT(CHAT_INDICATOR_NO_MICROPHONE);
+}
+
+void GDKGameChat::set_owner(GDK *p_owner) {
+    m_owner = p_owner;
+}
+
+GDKRuntime *GDKGameChat::_get_runtime() const {
+    return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+void *GDKGameChat::_find_user(const String &p_xuid) const {
+    if (!m_initialized || p_xuid.is_empty()) {
+        return nullptr;
+    }
+
+    uint32_t count = 0;
+    chat_user_array users = nullptr;
+    chat_manager::singleton_instance().get_chat_users(&count, &users);
+    for (uint32_t i = 0; i < count; ++i) {
+        chat_user *user = users[i];
+        if (user == nullptr) {
+            continue;
+        }
+        if (wide_to_string(user->xbox_user_id()) == p_xuid) {
+            return user;
+        }
+    }
+    return nullptr;
+}
+
+Ref<GDKResult> GDKGameChat::on_runtime_initialized() {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr || !runtime->is_initialized()) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "runtime_not_initialized",
+                "Cannot ready the game chat service before the GDK runtime.");
+    }
+
+    m_runtime_ready = true;
+    return GDKResult::ok_result();
+}
+
+void GDKGameChat::shutdown() {
+    cleanup();
+    m_runtime_ready = false;
+}
+
+int GDKGameChat::dispatch() {
+    if (!m_initialized) {
+        return 0;
+    }
+
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime != nullptr && runtime->is_shutting_down()) {
+        return 0;
+    }
+
+    int handled = 0;
+    handled += _pump_data_frames_count();
+    handled += _pump_state_changes_count();
+    return handled;
+}
+
+int GDKGameChat::_pump_data_frames_count() {
+    uint32_t count = 0;
+    game_chat_data_frame_array frames = nullptr;
+    chat_manager::singleton_instance().start_processing_data_frames(&count, &frames);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        const game_chat_data_frame *frame = frames[i];
+        if (frame == nullptr) {
+            continue;
+        }
+
+        PackedInt64Array targets;
+        targets.resize(static_cast<int64_t>(frame->target_endpoint_identifier_count));
+        for (uint32_t t = 0; t < frame->target_endpoint_identifier_count; ++t) {
+            targets.set(static_cast<int64_t>(t), static_cast<int64_t>(frame->target_endpoint_identifiers[t]));
+        }
+
+        PackedByteArray bytes;
+        bytes.resize(static_cast<int64_t>(frame->packet_byte_count));
+        if (frame->packet_byte_count > 0) {
+            memcpy(bytes.ptrw(), frame->packet_buffer, frame->packet_byte_count);
+        }
+
+        const int transport = frame->transport_requirement == game_chat_data_transport_requirement::guaranteed
+                ? TRANSPORT_GUARANTEED
+                : TRANSPORT_BEST_EFFORT;
+        emit_signal("outgoing_data_frame", targets, bytes, transport);
+    }
+
+    chat_manager::singleton_instance().finish_processing_data_frames(frames);
+    return static_cast<int>(count);
+}
+
+int GDKGameChat::_pump_state_changes_count() {
+    uint32_t count = 0;
+    game_chat_state_change_array changes = nullptr;
+    chat_manager::singleton_instance().start_processing_state_changes(&count, &changes);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        const game_chat_state_change *base = changes[i];
+        if (base == nullptr) {
+            continue;
+        }
+
+        switch (base->state_change_type) {
+            case game_chat_state_change_type::text_chat_received: {
+                const auto *change = static_cast<const game_chat_text_chat_received_state_change *>(base);
+                const String sender = change->sender == nullptr
+                        ? String()
+                        : wide_to_string(change->sender->xbox_user_id());
+                emit_signal("text_chat_received", sender, wide_to_string(change->message));
+                break;
+            }
+            case game_chat_state_change_type::transcribed_chat_received: {
+                const auto *change = static_cast<const game_chat_transcribed_chat_received_state_change *>(base);
+                const String speaker = change->speaker == nullptr
+                        ? String()
+                        : wide_to_string(change->speaker->xbox_user_id());
+                emit_signal("transcribed_chat_received", speaker, wide_to_string(change->message));
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    chat_manager::singleton_instance().finish_processing_state_changes(changes);
+    return static_cast<int>(count);
+}
+
+Ref<GDKResult> GDKGameChat::initialize(int p_max_users, int p_default_relationship) {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "not_initialized",
+                "GDK is not initialized. Call GDK.initialize() before GDK.game_chat.initialize().");
+    }
+    if (m_initialized) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "already_initialized",
+                "Game chat is already initialized. Call cleanup() before re-initializing.");
+    }
+    if (p_max_users <= 0) {
+        return GDKResult::error_result(
+                E_INVALIDARG,
+                "invalid_max_users",
+                "max_users must be greater than zero.");
+    }
+
+    const auto default_relationship = static_cast<game_chat_communication_relationship_flags>(p_default_relationship);
+    chat_manager::singleton_instance().initialize(
+            static_cast<uint32_t>(p_max_users),
+            1.0f,
+            default_relationship);
+    m_initialized = true;
+    return GDKResult::ok_result();
+}
+
+bool GDKGameChat::is_initialized() const {
+    return m_initialized;
+}
+
+void GDKGameChat::cleanup() {
+    if (!m_initialized) {
+        return;
+    }
+    chat_manager::singleton_instance().cleanup();
+    m_initialized = false;
+}
+
+Ref<GDKResult> GDKGameChat::add_local_user(const Ref<GDKUser> &p_user) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+    if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to add a local chat user.");
+    }
+
+    const String xuid = p_user->get_xuid();
+    if (xuid.is_empty()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_user", "The GDKUser does not have a valid Xbox User ID.");
+    }
+
+    const Char16String wide_xuid = xuid.utf16();
+    chat_user *user = chat_manager::singleton_instance().add_local_user(
+            reinterpret_cast<PCWSTR>(wide_xuid.get_data()));
+    if (user == nullptr) {
+        return GDKResult::error_result(E_FAIL, "add_user_failed", "Game chat could not add the local user.");
+    }
+
+    Dictionary data;
+    data["xuid"] = xuid;
+    return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKGameChat::add_remote_user(const String &p_xuid, int64_t p_endpoint_id) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+    if (p_xuid.is_empty()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_xuid", "A non-empty Xbox User ID is required.");
+    }
+
+    const Char16String wide_xuid = p_xuid.utf16();
+    chat_user *user = chat_manager::singleton_instance().add_remote_user(
+            reinterpret_cast<PCWSTR>(wide_xuid.get_data()),
+            static_cast<uint64_t>(p_endpoint_id));
+    if (user == nullptr) {
+        return GDKResult::error_result(E_FAIL, "add_user_failed", "Game chat could not add the remote user.");
+    }
+
+    Dictionary data;
+    data["xuid"] = p_xuid;
+    data["endpoint_id"] = p_endpoint_id;
+    return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKGameChat::remove_user(const String &p_xuid) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+
+    auto *user = static_cast<chat_user *>(_find_user(p_xuid));
+    if (user == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the supplied Xbox User ID.");
+    }
+
+    chat_manager::singleton_instance().remove_user(user);
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::set_communication_relationship(const String &p_local_xuid, const String &p_target_xuid, int p_relationship) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+
+    auto *local = static_cast<chat_user *>(_find_user(p_local_xuid));
+    if (local == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the local Xbox User ID.");
+    }
+    chat_user::chat_user_local *local_state = local->local();
+    if (local_state == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "not_local_user", "The local Xbox User ID does not refer to a local chat user.");
+    }
+    auto *target = static_cast<chat_user *>(_find_user(p_target_xuid));
+    if (target == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "target_not_found", "No chat user matches the target Xbox User ID.");
+    }
+
+    local_state->set_communication_relationship(
+            target,
+            static_cast<game_chat_communication_relationship_flags>(p_relationship));
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::set_microphone_muted(const String &p_local_xuid, bool p_muted) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+
+    auto *local = static_cast<chat_user *>(_find_user(p_local_xuid));
+    if (local == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the local Xbox User ID.");
+    }
+    chat_user::chat_user_local *local_state = local->local();
+    if (local_state == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "not_local_user", "The local Xbox User ID does not refer to a local chat user.");
+    }
+
+    local_state->set_microphone_muted(p_muted);
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::set_remote_user_muted(const String &p_local_xuid, const String &p_target_xuid, bool p_muted) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+
+    auto *local = static_cast<chat_user *>(_find_user(p_local_xuid));
+    if (local == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the local Xbox User ID.");
+    }
+    chat_user::chat_user_local *local_state = local->local();
+    if (local_state == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "not_local_user", "The local Xbox User ID does not refer to a local chat user.");
+    }
+    auto *target = static_cast<chat_user *>(_find_user(p_target_xuid));
+    if (target == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "target_not_found", "No chat user matches the target Xbox User ID.");
+    }
+
+    local_state->set_remote_user_muted(target, p_muted);
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::set_audio_render_volume(const String &p_local_xuid, const String &p_target_xuid, float p_volume) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+
+    auto *local = static_cast<chat_user *>(_find_user(p_local_xuid));
+    if (local == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the local Xbox User ID.");
+    }
+    chat_user::chat_user_local *local_state = local->local();
+    if (local_state == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "not_local_user", "The local Xbox User ID does not refer to a local chat user.");
+    }
+    auto *target = static_cast<chat_user *>(_find_user(p_target_xuid));
+    if (target == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "target_not_found", "No chat user matches the target Xbox User ID.");
+    }
+
+    local_state->set_audio_render_volume(target, p_volume);
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::send_text(const String &p_local_xuid, const String &p_text) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+    if (p_text.is_empty() || p_text.length() > c_maxChatTextMessageLength) {
+        return GDKResult::error_result(
+                E_INVALIDARG,
+                "invalid_text",
+                "Chat text must contain between 1 and 1023 characters.");
+    }
+
+    auto *local = static_cast<chat_user *>(_find_user(p_local_xuid));
+    if (local == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the local Xbox User ID.");
+    }
+    chat_user::chat_user_local *local_state = local->local();
+    if (local_state == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "not_local_user", "The local Xbox User ID does not refer to a local chat user.");
+    }
+
+    const Char16String wide_text = p_text.utf16();
+    local_state->send_chat_text(reinterpret_cast<PCWSTR>(wide_text.get_data()));
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::synthesize_text_to_speech(const String &p_local_xuid, const String &p_text) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+    if (p_text.is_empty()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_text", "Text to synthesize must be non-empty.");
+    }
+
+    auto *local = static_cast<chat_user *>(_find_user(p_local_xuid));
+    if (local == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "user_not_found", "No chat user matches the local Xbox User ID.");
+    }
+    chat_user::chat_user_local *local_state = local->local();
+    if (local_state == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "not_local_user", "The local Xbox User ID does not refer to a local chat user.");
+    }
+
+    const Char16String wide_text = p_text.utf16();
+    local_state->synthesize_text_to_speech(reinterpret_cast<PCWSTR>(wide_text.get_data()));
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKGameChat::process_incoming_data_frame(int64_t p_source_endpoint_id, const PackedByteArray &p_bytes) {
+    if (!m_initialized) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "Call GDK.game_chat.initialize() first.");
+    }
+    if (p_bytes.is_empty()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_data", "The incoming data frame must contain at least one byte.");
+    }
+
+    chat_manager::singleton_instance().process_incoming_data(
+            static_cast<uint64_t>(p_source_endpoint_id),
+            static_cast<uint32_t>(p_bytes.size()),
+            p_bytes.ptr());
+    return GDKResult::ok_result();
+}
+
+Array GDKGameChat::get_chat_users() const {
+    Array result;
+    if (!m_initialized) {
+        return result;
+    }
+
+    uint32_t count = 0;
+    chat_user_array users = nullptr;
+    chat_manager::singleton_instance().get_chat_users(&count, &users);
+    for (uint32_t i = 0; i < count; ++i) {
+        chat_user *user = users[i];
+        if (user == nullptr) {
+            continue;
+        }
+        Dictionary entry;
+        entry["xuid"] = wide_to_string(user->xbox_user_id());
+        entry["is_local"] = user->local() != nullptr;
+        entry["chat_indicator"] = static_cast<int>(user->chat_indicator());
+        result.push_back(entry);
+    }
+    return result;
+}
+
+} // namespace godot

--- a/addons/godot_gdk/src/gdk_game_chat.h
+++ b/addons/godot_gdk/src/gdk_game_chat.h
@@ -1,0 +1,110 @@
+#ifndef GDK_GAME_CHAT_H
+#define GDK_GAME_CHAT_H
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+
+// Wraps the Game Chat 2 (GameChat2.h) chat_manager singleton as a GDK service.
+// Game Chat encodes its own opaque audio/text data frames; it does NOT pick or
+// build a network transport. This wrapper exposes that data-frame surface --
+// outgoing frames are emitted via the outgoing_data_frame signal and inbound
+// frames are fed back in via process_incoming_data_frame() -- so titles can
+// ferry frames over whatever transport they already have. Tests/sample use a
+// single-process loopback.
+class GDKGameChat : public RefCounted {
+    GDCLASS(GDKGameChat, RefCounted);
+
+    GDK *m_owner = nullptr;
+    bool m_runtime_ready = false;
+    bool m_initialized = false;
+
+    GDKRuntime *_get_runtime() const;
+    // Returns the chat_user* matching p_xuid (cast to void* to keep GameChat2
+    // types out of the header), or nullptr if no such user is present.
+    void *_find_user(const String &p_xuid) const;
+    // Drains queued outgoing data frames / inbound state changes, emitting the
+    // matching signals. Each returns the number of items handled.
+    int _pump_data_frames_count();
+    int _pump_state_changes_count();
+
+protected:
+    static void _bind_methods();
+
+public:
+    enum CommunicationRelationship {
+        RELATIONSHIP_NONE = 0x0,
+        RELATIONSHIP_SEND_MICROPHONE_AUDIO = 0x1,
+        RELATIONSHIP_SEND_TEXT_TO_SPEECH_AUDIO = 0x2,
+        RELATIONSHIP_SEND_TEXT = 0x4,
+        RELATIONSHIP_RECEIVE_AUDIO = 0x8,
+        RELATIONSHIP_RECEIVE_TEXT = 0x10,
+        RELATIONSHIP_SEND_ALL = 0x7,
+        RELATIONSHIP_RECEIVE_ALL = 0x18,
+        RELATIONSHIP_SEND_AND_RECEIVE_ALL = 0x1F,
+    };
+
+    enum TransportRequirement {
+        TRANSPORT_GUARANTEED = 0,
+        TRANSPORT_BEST_EFFORT = 1,
+    };
+
+    enum ChatIndicator {
+        CHAT_INDICATOR_SILENT = 0,
+        CHAT_INDICATOR_TALKING = 1,
+        CHAT_INDICATOR_LOCAL_MICROPHONE_MUTED = 2,
+        CHAT_INDICATOR_INCOMING_COMMUNICATIONS_MUTED = 3,
+        CHAT_INDICATOR_REPUTATION_RESTRICTED = 4,
+        CHAT_INDICATOR_PLATFORM_RESTRICTED = 5,
+        CHAT_INDICATOR_NO_CHAT_FOCUS = 6,
+        CHAT_INDICATOR_NO_MICROPHONE = 7,
+    };
+
+    void set_owner(GDK *p_owner);
+
+    Ref<GDKResult> on_runtime_initialized();
+    void shutdown();
+    int dispatch();
+
+    Ref<GDKResult> initialize(int p_max_users = 16, int p_default_relationship = RELATIONSHIP_SEND_AND_RECEIVE_ALL);
+    bool is_initialized() const;
+    void cleanup();
+
+    Ref<GDKResult> add_local_user(const Ref<GDKUser> &p_user);
+    Ref<GDKResult> add_remote_user(const String &p_xuid, int64_t p_endpoint_id);
+    Ref<GDKResult> remove_user(const String &p_xuid);
+
+    Ref<GDKResult> set_communication_relationship(const String &p_local_xuid, const String &p_target_xuid, int p_relationship);
+    Ref<GDKResult> set_microphone_muted(const String &p_local_xuid, bool p_muted);
+    Ref<GDKResult> set_remote_user_muted(const String &p_local_xuid, const String &p_target_xuid, bool p_muted);
+    Ref<GDKResult> set_audio_render_volume(const String &p_local_xuid, const String &p_target_xuid, float p_volume);
+
+    Ref<GDKResult> send_text(const String &p_local_xuid, const String &p_text);
+    Ref<GDKResult> synthesize_text_to_speech(const String &p_local_xuid, const String &p_text);
+
+    Ref<GDKResult> process_incoming_data_frame(int64_t p_source_endpoint_id, const PackedByteArray &p_bytes);
+    Array get_chat_users() const;
+};
+
+} // namespace godot
+
+VARIANT_ENUM_CAST(godot::GDKGameChat::CommunicationRelationship);
+VARIANT_ENUM_CAST(godot::GDKGameChat::TransportRequirement);
+VARIANT_ENUM_CAST(godot::GDKGameChat::ChatIndicator);
+
+#endif // GDK_GAME_CHAT_H

--- a/addons/godot_gdk/src/gdk_game_chat.h
+++ b/addons/godot_gdk/src/gdk_game_chat.h
@@ -89,6 +89,8 @@ public:
     Ref<GDKResult> add_remote_user(const String &p_xuid, int64_t p_endpoint_id);
     Ref<GDKResult> remove_user(const String &p_xuid);
 
+    void on_user_removed(const Ref<GDKUser> &p_user);
+
     Ref<GDKResult> set_communication_relationship(const String &p_local_xuid, const String &p_target_xuid, int p_relationship);
     Ref<GDKResult> set_microphone_muted(const String &p_local_xuid, bool p_muted);
     Ref<GDKResult> set_remote_user_muted(const String &p_local_xuid, const String &p_target_xuid, bool p_muted);

--- a/addons/godot_gdk/src/gdk_game_save.cpp
+++ b/addons/godot_gdk/src/gdk_game_save.cpp
@@ -1,0 +1,200 @@
+#include "gdk_game_save.h"
+
+#include <vector>
+
+#include <godot_cpp/variant/dictionary.hpp>
+
+#include <XGameSaveFiles.h>
+
+#include "gdk.h"
+#include "gdk_pending_signal.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+#include "gdk_signal_xasync_context.h"
+#include "gdk_user.h"
+#include "gdk_xbox_services.h"
+
+namespace godot {
+
+namespace {
+
+class GetFolderAsyncContext final : public GDKSignalXAsyncContext {
+    CharString m_configuration_id_utf8;
+
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Game save folder request cancelled."));
+            return;
+        }
+
+        char folder[MAX_PATH] = {};
+        HRESULT result_hr = XGameSaveFilesGetFolderWithUiResult(p_async_block, sizeof(folder), folder);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Game save folder request cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to resolve the game save folder.",
+                    "game_save_folder_failed"));
+            return;
+        }
+
+        folder[sizeof(folder) - 1] = '\0';
+        Dictionary data;
+        data["path"] = String::utf8(folder);
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    GetFolderAsyncContext(
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const String &p_configuration_id) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+            m_configuration_id_utf8(p_configuration_id.utf8()) {}
+
+    const char *get_configuration_id() const {
+        return m_configuration_id_utf8.get_data();
+    }
+};
+
+} // namespace
+
+void GDKGameSave::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("get_folder_async", "user"), &GDKGameSave::get_folder_async);
+    ClassDB::bind_method(D_METHOD("get_remaining_quota", "user"), &GDKGameSave::get_remaining_quota);
+}
+
+void GDKGameSave::set_owner(GDK *p_owner) {
+    m_owner = p_owner;
+}
+
+GDKRuntime *GDKGameSave::_get_runtime() const {
+    return m_owner == nullptr ? nullptr : m_owner->get_runtime();
+}
+
+GDKXboxServices *GDKGameSave::_get_xbox_services() const {
+    return m_owner == nullptr ? nullptr : m_owner->get_xbox_services();
+}
+
+Ref<GDKResult> GDKGameSave::_resolve_configuration_id(String *r_configuration_id) const {
+    GDKXboxServices *xbox_services = _get_xbox_services();
+    if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+        return GDKResult::error_result(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+    }
+
+    const String scid = xbox_services->get_scid();
+    if (scid.is_empty()) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "service_configuration_id_unavailable",
+                "Service configuration ID is unavailable for game saves.");
+    }
+
+    if (r_configuration_id != nullptr) {
+        *r_configuration_id = scid;
+    }
+    return GDKResult::ok_result();
+}
+
+Signal GDKGameSave::_make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime != nullptr) {
+        return runtime->make_error_signal(p_hresult, p_code, p_message);
+    }
+
+    Ref<GDKPendingSignal> pending_signal;
+    pending_signal.instantiate();
+    pending_signal->complete_deferred(GDKResult::error_result(p_hresult, p_code, p_message));
+    return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKGameSave::on_runtime_initialized() {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr || !runtime->is_initialized()) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "runtime_not_initialized",
+                "Cannot initialize the game save service before the GDK runtime.");
+    }
+
+    m_runtime_ready = true;
+    return GDKResult::ok_result();
+}
+
+void GDKGameSave::shutdown() {
+    m_runtime_ready = false;
+}
+
+Signal GDKGameSave::get_folder_async(const Ref<GDKUser> &p_user) {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+    if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+        return _make_error_signal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to resolve the game save folder.");
+    }
+
+    String configuration_id;
+    Ref<GDKResult> config_result = _resolve_configuration_id(&configuration_id);
+    if (!config_result->is_ok()) {
+        return _make_error_signal(static_cast<HRESULT>(config_result->get_hresult()), config_result->get_code(), config_result->get_message());
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new GetFolderAsyncContext(runtime, pending_signal, configuration_id);
+    context->bind_cancel_handler();
+
+    HRESULT hr = XGameSaveFilesGetFolderWithUiAsync(
+            p_user->get_handle(),
+            context->get_configuration_id(),
+            context->get_async_block());
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                hr,
+                "Failed to start the game save folder request.",
+                "game_save_folder_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Ref<GDKResult> GDKGameSave::get_remaining_quota(const Ref<GDKUser> &p_user) {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return GDKResult::error_result(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+    if (!p_user.is_valid() || p_user->get_handle() == nullptr || !p_user->is_signed_in()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to query the game save quota.");
+    }
+
+    String configuration_id;
+    Ref<GDKResult> config_result = _resolve_configuration_id(&configuration_id);
+    if (!config_result->is_ok()) {
+        return config_result;
+    }
+
+    const CharString configuration_id_utf8 = configuration_id.utf8();
+    int64_t remaining_quota = 0;
+    HRESULT hr = XGameSaveFilesGetRemainingQuota(
+            p_user->get_handle(),
+            configuration_id_utf8.get_data(),
+            &remaining_quota);
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(
+                hr,
+                "Failed to query the remaining game save quota.",
+                "game_save_quota_failed");
+    }
+
+    Dictionary data;
+    data["bytes"] = remaining_quota;
+    return GDKResult::ok_result(data);
+}
+
+} // namespace godot

--- a/addons/godot_gdk/src/gdk_game_save.h
+++ b/addons/godot_gdk/src/gdk_game_save.h
@@ -1,0 +1,48 @@
+#ifndef GDK_GAME_SAVE_H
+#define GDK_GAME_SAVE_H
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+class GDK;
+class GDKResult;
+class GDKRuntime;
+class GDKUser;
+class GDKXboxServices;
+
+class GDKGameSave : public RefCounted {
+    GDCLASS(GDKGameSave, RefCounted);
+
+    GDK *m_owner = nullptr;
+    bool m_runtime_ready = false;
+
+    GDKRuntime *_get_runtime() const;
+    GDKXboxServices *_get_xbox_services() const;
+    Ref<GDKResult> _resolve_configuration_id(String *r_configuration_id) const;
+    Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message) const;
+
+protected:
+    static void _bind_methods();
+
+public:
+    void set_owner(GDK *p_owner);
+
+    Ref<GDKResult> on_runtime_initialized();
+    void shutdown();
+
+    Signal get_folder_async(const Ref<GDKUser> &p_user);
+    Ref<GDKResult> get_remaining_quota(const Ref<GDKUser> &p_user);
+};
+
+} // namespace godot
+
+#endif // GDK_GAME_SAVE_H

--- a/addons/godot_gdk/src/gdk_game_ui.cpp
+++ b/addons/godot_gdk/src/gdk_game_ui.cpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <XGame.h>
 #include <XGameUI.h>
 
 #include "gdk.h"
@@ -319,6 +320,172 @@ public:
             GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
 };
 
+class AchievementsUiAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Achievements UI cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XGameUiShowAchievementsResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Achievements UI cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the achievements UI flow.",
+                    "game_ui_achievements_result_failed"));
+            return;
+        }
+
+        get_pending_signal()->complete(GDKResult::ok_result());
+    }
+
+public:
+    AchievementsUiAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+class ErrorDialogAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Error dialog cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XGameUiShowErrorDialogResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Error dialog cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the error dialog flow.",
+                    "game_ui_error_dialog_result_failed"));
+            return;
+        }
+
+        get_pending_signal()->complete(GDKResult::ok_result());
+    }
+
+public:
+    ErrorDialogAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+class SendGameInviteAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Send game invite UI cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XGameUiShowSendGameInviteResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Send game invite UI cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the send game invite UI flow.",
+                    "game_ui_send_game_invite_result_failed"));
+            return;
+        }
+
+        get_pending_signal()->complete(GDKResult::ok_result());
+    }
+
+public:
+    SendGameInviteAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+class TextEntryAsyncContext final : public GDKSignalXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Text entry UI cancelled."));
+            return;
+        }
+
+        uint32_t buffer_size = 0;
+        HRESULT size_hr = XGameUiShowTextEntryResultSize(p_async_block, &buffer_size);
+        if (size_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Text entry UI cancelled."));
+            return;
+        }
+        if (FAILED(size_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    size_hr,
+                    "Failed to size the text entry UI result.",
+                    "game_ui_text_entry_size_failed"));
+            return;
+        }
+
+        std::vector<char> buffer(buffer_size > 0 ? buffer_size : 1, '\0');
+        uint32_t used = 0;
+        HRESULT result_hr = XGameUiShowTextEntryResult(p_async_block, static_cast<uint32_t>(buffer.size()), buffer.data(), &used);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Text entry UI cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to read the text entry UI result.",
+                    "game_ui_text_entry_result_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["text"] = String::utf8(buffer.data());
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    TextEntryAsyncContext(GDKRuntime *p_runtime, const Ref<GDKPendingSignal> &p_pending_signal) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal) {}
+};
+
+XGameUiTextEntryInputScope _parse_text_entry_input_scope(const String &p_input_scope) {
+    const String normalized = p_input_scope.strip_edges().to_lower();
+    if (normalized.is_empty() || normalized == "default") {
+        return XGameUiTextEntryInputScope::Default;
+    }
+    if (normalized == "url") {
+        return XGameUiTextEntryInputScope::Url;
+    }
+    if (normalized == "email" || normalized == "email_smtp_address") {
+        return XGameUiTextEntryInputScope::EmailSmtpAddress;
+    }
+    if (normalized == "number") {
+        return XGameUiTextEntryInputScope::Number;
+    }
+    if (normalized == "password") {
+        return XGameUiTextEntryInputScope::Password;
+    }
+    if (normalized == "telephone" || normalized == "telephone_number") {
+        return XGameUiTextEntryInputScope::TelephoneNumber;
+    }
+    if (normalized == "alphanumeric") {
+        return XGameUiTextEntryInputScope::Alphanumeric;
+    }
+    if (normalized == "search") {
+        return XGameUiTextEntryInputScope::Search;
+    }
+    if (normalized == "chat" || normalized == "chat_without_emoji") {
+        return XGameUiTextEntryInputScope::ChatWithoutEmoji;
+    }
+    return XGameUiTextEntryInputScope::Default;
+}
+
 } // namespace
 
 void GDKGameUI::_bind_methods() {
@@ -339,6 +506,21 @@ void GDKGameUI::_bind_methods() {
             DEFVAL(static_cast<int64_t>(1)),
             DEFVAL(static_cast<int64_t>(1)));
     ClassDB::bind_method(D_METHOD("resolve_privilege_with_ui_async", "user", "privilege"), &GDKGameUI::resolve_privilege_with_ui_async);
+    ClassDB::bind_method(D_METHOD("show_achievements_async", "requesting_user"), &GDKGameUI::show_achievements_async);
+    ClassDB::bind_method(D_METHOD("show_error_dialog_async", "error_code", "context"), &GDKGameUI::show_error_dialog_async, DEFVAL(String()));
+    ClassDB::bind_method(
+            D_METHOD("show_send_game_invite_async", "requesting_user", "session_configuration_id", "session_template_name", "session_id", "invitation_text", "custom_activation_context"),
+            &GDKGameUI::show_send_game_invite_async,
+            DEFVAL(String()),
+            DEFVAL(String()));
+    ClassDB::bind_method(
+            D_METHOD("show_text_entry_async", "title_text", "description_text", "default_text", "input_scope", "max_text_length"),
+            &GDKGameUI::show_text_entry_async,
+            DEFVAL(String()),
+            DEFVAL(String()),
+            DEFVAL(String()),
+            DEFVAL(String("default")),
+            DEFVAL(static_cast<int64_t>(0)));
 }
 
 void GDKGameUI::set_owner(GDK *p_owner) {
@@ -634,6 +816,168 @@ Signal GDKGameUI::resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, in
     }
 
     return users->resolve_privilege_with_ui_async(p_user, p_privilege);
+}
+
+Signal GDKGameUI::show_achievements_async(const Ref<GDKUser> &p_requesting_user) {
+    GDKRuntime *runtime = get_runtime_internal();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+    if (!p_requesting_user.is_valid() || p_requesting_user->get_handle() == nullptr) {
+        return make_error_signal_internal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to show achievements UI.");
+    }
+
+    uint32_t title_id = 0;
+    HRESULT title_hr = XGameGetXboxTitleId(&title_id);
+    if (FAILED(title_hr)) {
+        return make_error_signal_internal(title_hr, "xbox_title_id_unavailable", "Failed to resolve the Xbox title ID for the achievements UI.");
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new AchievementsUiAsyncContext(runtime, pending_signal);
+    context->bind_cancel_handler();
+
+    HRESULT hr = XGameUiShowAchievementsAsync(
+            context->get_async_block(),
+            p_requesting_user->get_handle(),
+            title_id);
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                hr,
+                "Failed to start the achievements UI flow.",
+                "game_ui_achievements_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKGameUI::show_error_dialog_async(int64_t p_error_code, const String &p_context) {
+    GDKRuntime *runtime = get_runtime_internal();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new ErrorDialogAsyncContext(runtime, pending_signal);
+    context->bind_cancel_handler();
+
+    const String context_text = p_context.strip_edges();
+    const CharString context_utf8 = context_text.utf8();
+
+    HRESULT hr = XGameUiShowErrorDialogAsync(
+            context->get_async_block(),
+            static_cast<HRESULT>(p_error_code),
+            context_text.is_empty() ? nullptr : context_utf8.get_data());
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                hr,
+                "Failed to start the error dialog flow.",
+                "game_ui_error_dialog_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKGameUI::show_send_game_invite_async(
+        const Ref<GDKUser> &p_requesting_user,
+        const String &p_session_configuration_id,
+        const String &p_session_template_name,
+        const String &p_session_id,
+        const String &p_invitation_text,
+        const String &p_custom_activation_context) {
+    const String session_configuration_id = p_session_configuration_id.strip_edges();
+    const String session_template_name = p_session_template_name.strip_edges();
+    const String session_id = p_session_id.strip_edges();
+    if (session_configuration_id.is_empty() || session_template_name.is_empty() || session_id.is_empty()) {
+        return make_error_signal_internal(E_INVALIDARG, "invalid_session", "session_configuration_id, session_template_name, and session_id are all required.");
+    }
+
+    GDKRuntime *runtime = get_runtime_internal();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+    if (!p_requesting_user.is_valid() || p_requesting_user->get_handle() == nullptr) {
+        return make_error_signal_internal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required to send a game invite.");
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new SendGameInviteAsyncContext(runtime, pending_signal);
+    context->bind_cancel_handler();
+
+    const String invitation_text = p_invitation_text.strip_edges();
+    const String custom_activation_context = p_custom_activation_context.strip_edges();
+    const CharString session_configuration_id_utf8 = session_configuration_id.utf8();
+    const CharString session_template_name_utf8 = session_template_name.utf8();
+    const CharString session_id_utf8 = session_id.utf8();
+    const CharString invitation_text_utf8 = invitation_text.utf8();
+    const CharString custom_activation_context_utf8 = custom_activation_context.utf8();
+
+    HRESULT hr = XGameUiShowSendGameInviteAsync(
+            context->get_async_block(),
+            p_requesting_user->get_handle(),
+            session_configuration_id_utf8.get_data(),
+            session_template_name_utf8.get_data(),
+            session_id_utf8.get_data(),
+            invitation_text.is_empty() ? nullptr : invitation_text_utf8.get_data(),
+            custom_activation_context.is_empty() ? nullptr : custom_activation_context_utf8.get_data());
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                hr,
+                "Failed to start the send game invite UI flow.",
+                "game_ui_send_game_invite_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKGameUI::show_text_entry_async(
+        const String &p_title_text,
+        const String &p_description_text,
+        const String &p_default_text,
+        const String &p_input_scope,
+        int64_t p_max_text_length) {
+    if (p_max_text_length < 0) {
+        return make_error_signal_internal(E_INVALIDARG, "invalid_max_length", "max_text_length must be zero or greater.");
+    }
+
+    GDKRuntime *runtime = get_runtime_internal();
+    if (runtime == nullptr || !runtime->is_initialized() || !m_runtime_ready) {
+        return make_error_signal_internal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new TextEntryAsyncContext(runtime, pending_signal);
+    context->bind_cancel_handler();
+
+    const String title_text = p_title_text.strip_edges();
+    const String description_text = p_description_text.strip_edges();
+    const CharString title_text_utf8 = title_text.utf8();
+    const CharString description_text_utf8 = description_text.utf8();
+    const CharString default_text_utf8 = p_default_text.utf8();
+
+    HRESULT hr = XGameUiShowTextEntryAsync(
+            context->get_async_block(),
+            title_text.is_empty() ? nullptr : title_text_utf8.get_data(),
+            description_text.is_empty() ? nullptr : description_text_utf8.get_data(),
+            p_default_text.is_empty() ? nullptr : default_text_utf8.get_data(),
+            _parse_text_entry_input_scope(p_input_scope),
+            static_cast<uint32_t>(p_max_text_length));
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                hr,
+                "Failed to start the text entry UI flow.",
+                "game_ui_text_entry_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
 }
 
 GDKRuntime *GDKGameUI::get_runtime_internal() const {

--- a/addons/godot_gdk/src/gdk_game_ui.h
+++ b/addons/godot_gdk/src/gdk_game_ui.h
@@ -55,6 +55,21 @@ public:
             int64_t p_min_selection_count = 1,
             int64_t p_max_selection_count = 1);
     Signal resolve_privilege_with_ui_async(const Ref<GDKUser> &p_user, int64_t p_privilege);
+    Signal show_achievements_async(const Ref<GDKUser> &p_requesting_user);
+    Signal show_error_dialog_async(int64_t p_error_code, const String &p_context);
+    Signal show_send_game_invite_async(
+            const Ref<GDKUser> &p_requesting_user,
+            const String &p_session_configuration_id,
+            const String &p_session_template_name,
+            const String &p_session_id,
+            const String &p_invitation_text,
+            const String &p_custom_activation_context);
+    Signal show_text_entry_async(
+            const String &p_title_text,
+            const String &p_description_text,
+            const String &p_default_text,
+            const String &p_input_scope,
+            int64_t p_max_text_length);
 
     GDKRuntime *get_runtime_internal() const;
     GDKUsers *get_users_internal() const;

--- a/addons/godot_gdk/src/gdk_social.cpp
+++ b/addons/godot_gdk/src/gdk_social.cpp
@@ -562,6 +562,8 @@ void GDKSocial::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_friends_async", "user"), &GDKSocial::get_friends_async);
     ClassDB::bind_method(D_METHOD("create_social_group", "user", "filter"), &GDKSocial::create_social_group, DEFVAL(Ref<GDKSocialFilter>()));
     ClassDB::bind_method(D_METHOD("create_social_group_from_xuids", "user", "xuids"), &GDKSocial::create_social_group_from_xuids);
+    ClassDB::bind_method(D_METHOD("update_social_user_group", "group", "xuids"), &GDKSocial::update_social_user_group);
+    ClassDB::bind_method(D_METHOD("set_rich_presence_polling", "user", "enabled"), &GDKSocial::set_rich_presence_polling);
     ClassDB::bind_method(D_METHOD("destroy_social_group", "group"), &GDKSocial::destroy_social_group);
     ClassDB::bind_method(D_METHOD("get_group_users", "group"), &GDKSocial::get_group_users);
     ClassDB::bind_method(D_METHOD("submit_reputation_feedback_async", "user", "target_xuid", "feedback_type", "reason", "evidence_id"), &GDKSocial::submit_reputation_feedback_async, DEFVAL(String()), DEFVAL(String()));
@@ -1016,6 +1018,66 @@ Ref<GDKResult> GDKSocial::create_social_group_from_xuids(const Ref<GDKUser> &p_u
 
 void GDKSocial::destroy_social_group(const Ref<GDKSocialGroup> &p_group) {
     _destroy_group_internal(p_group, true);
+}
+
+Ref<GDKResult> GDKSocial::update_social_user_group(const Ref<GDKSocialGroup> &p_group, const PackedStringArray &p_xuids) {
+    if (!p_group.is_valid() || p_group->get_handle() == nullptr) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_social_group", "A valid, loaded social group is required.");
+    }
+    Ref<GDKResult> validation = _ensure_ready_user(p_group->get_local_user());
+    if (!validation->is_ok()) {
+        return validation;
+    }
+    if (_find_group_by_handle(p_group->get_handle()).is_null()) {
+        return GDKResult::error_result(E_INVALIDARG, "unknown_social_group", "The social group is not tracked by this service.");
+    }
+    if (p_group->get_group_type() != GDKSocialGroup::GROUP_TYPE_USER_LIST) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_social_group_type", "Only list-based social groups can be updated.");
+    }
+    if (p_xuids.size() > XBL_SOCIAL_MANAGER_MAX_USERS_FROM_LIST) {
+        return GDKResult::error_result(E_INVALIDARG, "too_many_social_group_xuids", "Social list groups cannot exceed the XSAPI maximum tracked user count.");
+    }
+
+    std::vector<uint64_t> native_xuids;
+    native_xuids.reserve(static_cast<size_t>(p_xuids.size()));
+    for (int64_t i = 0; i < p_xuids.size(); ++i) {
+        uint64_t xuid = 0;
+        if (!_try_parse_xuid(p_xuids[i], &xuid)) {
+            return GDKResult::error_result(E_INVALIDARG, "invalid_social_group_xuid", "Social list groups require numeric XUID strings.");
+        }
+        native_xuids.push_back(xuid);
+    }
+
+    HRESULT hr = XblSocialManagerUpdateSocialUserGroup(
+            p_group->get_handle(),
+            native_xuids.empty() ? nullptr : native_xuids.data(),
+            native_xuids.size());
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(hr, "Failed to update the list-based social group.", "social_group_update_failed");
+    }
+
+    p_group->set_tracked_xuids(p_xuids);
+
+    Dictionary data;
+    data["count"] = static_cast<int64_t>(native_xuids.size());
+    return GDKResult::ok_result(data);
+}
+
+Ref<GDKResult> GDKSocial::set_rich_presence_polling(const Ref<GDKUser> &p_user, bool p_enabled) {
+    LocalUserState *state = nullptr;
+    Ref<GDKResult> ensure_result = _ensure_local_user_state(p_user, &state, true);
+    if (!ensure_result->is_ok()) {
+        return ensure_result;
+    }
+
+    HRESULT hr = XblSocialManagerSetRichPresencePollingStatus(p_user->get_handle(), p_enabled);
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(hr, "Failed to update rich-presence polling status.", "social_rich_presence_polling_failed");
+    }
+
+    Dictionary data;
+    data["enabled"] = p_enabled;
+    return GDKResult::ok_result(data);
 }
 
 Ref<GDKResult> GDKSocial::get_group_users(const Ref<GDKSocialGroup> &p_group) {

--- a/addons/godot_gdk/src/gdk_social.h
+++ b/addons/godot_gdk/src/gdk_social.h
@@ -215,6 +215,8 @@ public:
     Signal get_friends_async(const Ref<GDKUser> &p_user);
     Ref<GDKResult> create_social_group(const Ref<GDKUser> &p_user, const Ref<GDKSocialFilter> &p_filter = Ref<GDKSocialFilter>());
     Ref<GDKResult> create_social_group_from_xuids(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids);
+    Ref<GDKResult> update_social_user_group(const Ref<GDKSocialGroup> &p_group, const PackedStringArray &p_xuids);
+    Ref<GDKResult> set_rich_presence_polling(const Ref<GDKUser> &p_user, bool p_enabled);
     void destroy_social_group(const Ref<GDKSocialGroup> &p_group);
     Ref<GDKResult> get_group_users(const Ref<GDKSocialGroup> &p_group);
     Signal submit_reputation_feedback_async(const Ref<GDKUser> &p_user, const String &p_target_xuid, const String &p_feedback_type, const String &p_reason = String(), const String &p_evidence_id = String());

--- a/addons/godot_gdk/src/gdk_speech_synthesizer.cpp
+++ b/addons/godot_gdk/src/gdk_speech_synthesizer.cpp
@@ -1,0 +1,311 @@
+#include "gdk_speech_synthesizer.h"
+
+#include "gdk.h"
+#include "gdk_result.h"
+#include "gdk_runtime.h"
+
+#include <godot_cpp/classes/audio_stream_wav.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
+
+#include <cstring>
+
+namespace godot {
+
+namespace {
+
+bool CALLBACK collect_installed_voice(const XSpeechSynthesizerVoiceInformation *p_info, void *p_context) {
+    if (p_info == nullptr || p_context == nullptr) {
+        return true;
+    }
+
+    Array *voices = static_cast<Array *>(p_context);
+    Dictionary voice;
+    voice["id"] = p_info->VoiceId != nullptr ? String::utf8(p_info->VoiceId) : String();
+    voice["display_name"] = p_info->DisplayName != nullptr ? String::utf8(p_info->DisplayName) : String();
+    voice["language"] = p_info->Language != nullptr ? String::utf8(p_info->Language) : String();
+    voice["description"] = p_info->Description != nullptr ? String::utf8(p_info->Description) : String();
+    voice["gender"] = p_info->Gender == XSpeechSynthesizerVoiceGender::Male ? "male" : "female";
+    voices->push_back(voice);
+    return true;
+}
+
+uint16_t read_u16_le(const uint8_t *p_data) {
+    return static_cast<uint16_t>(p_data[0]) | (static_cast<uint16_t>(p_data[1]) << 8);
+}
+
+uint32_t read_u32_le(const uint8_t *p_data) {
+    return static_cast<uint32_t>(p_data[0]) |
+            (static_cast<uint32_t>(p_data[1]) << 8) |
+            (static_cast<uint32_t>(p_data[2]) << 16) |
+            (static_cast<uint32_t>(p_data[3]) << 24);
+}
+
+bool parse_wav(const PackedByteArray &p_wav, PackedByteArray &r_pcm, int &r_channels, int &r_sample_rate, int &r_bits) {
+    const int64_t size = p_wav.size();
+    if (size < 12) {
+        return false;
+    }
+
+    const uint8_t *data = p_wav.ptr();
+    if (!(data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F')) {
+        return false;
+    }
+    if (!(data[8] == 'W' && data[9] == 'A' && data[10] == 'V' && data[11] == 'E')) {
+        return false;
+    }
+
+    bool have_fmt = false;
+    bool have_data = false;
+    int64_t offset = 12;
+    while (offset + 8 <= size) {
+        const uint8_t *chunk = data + offset;
+        const uint32_t chunk_size = read_u32_le(chunk + 4);
+        const int64_t chunk_data = offset + 8;
+
+        if (chunk[0] == 'f' && chunk[1] == 'm' && chunk[2] == 't' && chunk[3] == ' ') {
+            if (chunk_data + 16 <= size) {
+                const uint8_t *fmt = data + chunk_data;
+                r_channels = static_cast<int>(read_u16_le(fmt + 2));
+                r_sample_rate = static_cast<int>(read_u32_le(fmt + 4));
+                r_bits = static_cast<int>(read_u16_le(fmt + 14));
+                have_fmt = true;
+            }
+        } else if (chunk[0] == 'd' && chunk[1] == 'a' && chunk[2] == 't' && chunk[3] == 'a') {
+            const int64_t available = size - chunk_data;
+            int64_t copy = static_cast<int64_t>(chunk_size);
+            if (copy > available) {
+                copy = available;
+            }
+            if (copy < 0) {
+                copy = 0;
+            }
+            r_pcm.resize(copy);
+            if (copy > 0) {
+                std::memcpy(r_pcm.ptrw(), data + chunk_data, static_cast<size_t>(copy));
+            }
+            have_data = true;
+        }
+
+        int64_t advance = 8 + static_cast<int64_t>(chunk_size) + ((chunk_size & 1u) ? 1 : 0);
+        if (advance <= 0) {
+            break;
+        }
+        offset += advance;
+    }
+
+    return have_fmt && have_data;
+}
+
+} // namespace
+
+void GDKSpeechSynthesizer::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("get_installed_voices"), &GDKSpeechSynthesizer::get_installed_voices);
+    ClassDB::bind_method(D_METHOD("set_default_voice"), &GDKSpeechSynthesizer::set_default_voice);
+    ClassDB::bind_method(D_METHOD("set_custom_voice", "voice_id"), &GDKSpeechSynthesizer::set_custom_voice);
+    ClassDB::bind_method(D_METHOD("synthesize_text", "text"), &GDKSpeechSynthesizer::synthesize_text);
+    ClassDB::bind_method(D_METHOD("synthesize_ssml", "ssml"), &GDKSpeechSynthesizer::synthesize_ssml);
+    ClassDB::bind_method(D_METHOD("synthesize_to_stream", "text"), &GDKSpeechSynthesizer::synthesize_to_stream);
+}
+
+void GDKSpeechSynthesizer::set_owner(GDK *p_owner) {
+    m_owner = p_owner;
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::on_runtime_initialized() {
+    GDKRuntime *runtime = m_owner != nullptr ? m_owner->get_runtime() : nullptr;
+    if (runtime == nullptr || !runtime->is_initialized()) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "runtime_not_initialized",
+                "Cannot initialize the speech synthesizer service before the GDK runtime.");
+    }
+
+    m_runtime_ready = true;
+    return GDKResult::ok_result();
+}
+
+void GDKSpeechSynthesizer::shutdown() {
+    if (m_synthesizer != nullptr) {
+        XSpeechSynthesizerCloseHandle(m_synthesizer);
+        m_synthesizer = nullptr;
+    }
+    m_runtime_ready = false;
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::ensure_synthesizer_internal() {
+    if (!m_runtime_ready) {
+        return GDKResult::error_result(
+                E_FAIL,
+                "not_initialized",
+                "GDK is not initialized. Call GDK.initialize() first.");
+    }
+
+    if (m_synthesizer != nullptr) {
+        return GDKResult::ok_result();
+    }
+
+    HRESULT hr = XSpeechSynthesizerCreate(&m_synthesizer);
+    if (FAILED(hr)) {
+        m_synthesizer = nullptr;
+        return GDKResult::hresult_error(
+                hr,
+                "Failed to create the speech synthesizer.",
+                "speech_synthesizer_unavailable");
+    }
+    return GDKResult::ok_result();
+}
+
+Array GDKSpeechSynthesizer::get_installed_voices() {
+    Array voices;
+    if (!m_runtime_ready) {
+        return voices;
+    }
+
+    HRESULT hr = XSpeechSynthesizerEnumerateInstalledVoices(&voices, &collect_installed_voice);
+    if (FAILED(hr)) {
+        return Array();
+    }
+    return voices;
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::set_default_voice() {
+    Ref<GDKResult> ensured = ensure_synthesizer_internal();
+    if (!ensured->is_ok()) {
+        return ensured;
+    }
+
+    HRESULT hr = XSpeechSynthesizerSetDefaultVoice(m_synthesizer);
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(hr, "Failed to set the default voice.", "set_default_voice_failed");
+    }
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::set_custom_voice(const String &p_voice_id) {
+    const String voice_id = p_voice_id.strip_edges();
+    if (voice_id.is_empty()) {
+        return GDKResult::error_result(E_INVALIDARG, "invalid_voice_id", "A non-empty voice id is required.");
+    }
+
+    Ref<GDKResult> ensured = ensure_synthesizer_internal();
+    if (!ensured->is_ok()) {
+        return ensured;
+    }
+
+    const CharString voice_utf8 = voice_id.utf8();
+    HRESULT hr = XSpeechSynthesizerSetCustomVoice(m_synthesizer, voice_utf8.get_data());
+    if (FAILED(hr)) {
+        Dictionary data;
+        data["voice_id"] = voice_id;
+        return GDKResult::hresult_error(hr, "Failed to set the requested custom voice.", "set_custom_voice_failed", data);
+    }
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::synthesize_text(const String &p_text) {
+    return synthesize_internal(p_text, false);
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::synthesize_ssml(const String &p_ssml) {
+    return synthesize_internal(p_ssml, true);
+}
+
+Ref<GDKResult> GDKSpeechSynthesizer::synthesize_internal(const String &p_input, bool p_is_ssml) {
+    if (p_input.strip_edges().is_empty()) {
+        return GDKResult::error_result(
+                E_INVALIDARG,
+                "invalid_input",
+                p_is_ssml ? "A non-empty SSML document is required." : "A non-empty text string is required.");
+    }
+
+    Ref<GDKResult> ensured = ensure_synthesizer_internal();
+    if (!ensured->is_ok()) {
+        return ensured;
+    }
+
+    const CharString input_utf8 = p_input.utf8();
+    XSpeechSynthesizerStreamHandle stream = nullptr;
+    HRESULT hr = p_is_ssml
+            ? XSpeechSynthesizerCreateStreamFromSsml(m_synthesizer, input_utf8.get_data(), &stream)
+            : XSpeechSynthesizerCreateStreamFromText(m_synthesizer, input_utf8.get_data(), &stream);
+    if (FAILED(hr)) {
+        return GDKResult::hresult_error(hr, "Failed to synthesize speech.", "synthesize_failed");
+    }
+
+    size_t buffer_size = 0;
+    hr = XSpeechSynthesizerGetStreamDataSize(stream, &buffer_size);
+    if (FAILED(hr)) {
+        XSpeechSynthesizerCloseStreamHandle(stream);
+        return GDKResult::hresult_error(hr, "Failed to read the synthesized audio size.", "synthesize_failed");
+    }
+
+    PackedByteArray audio;
+    audio.resize(static_cast<int64_t>(buffer_size));
+    if (buffer_size > 0) {
+        size_t buffer_used = 0;
+        hr = XSpeechSynthesizerGetStreamData(stream, buffer_size, audio.ptrw(), &buffer_used);
+        if (FAILED(hr)) {
+            XSpeechSynthesizerCloseStreamHandle(stream);
+            return GDKResult::hresult_error(hr, "Failed to read the synthesized audio data.", "synthesize_failed");
+        }
+        if (static_cast<int64_t>(buffer_used) != audio.size()) {
+            audio.resize(static_cast<int64_t>(buffer_used));
+        }
+    }
+
+    XSpeechSynthesizerCloseStreamHandle(stream);
+
+    Dictionary data;
+    data["audio_wav"] = audio;
+    data["byte_count"] = static_cast<int64_t>(audio.size());
+    return GDKResult::ok_result(data);
+}
+
+Ref<AudioStreamWAV> GDKSpeechSynthesizer::synthesize_to_stream(const String &p_text) {
+    Ref<GDKResult> result = synthesize_internal(p_text, false);
+    if (!result->is_ok()) {
+        return Ref<AudioStreamWAV>();
+    }
+
+    Dictionary data = result->get_data();
+    PackedByteArray wav = data["audio_wav"];
+
+    PackedByteArray pcm;
+    int channels = 1;
+    int sample_rate = 24000;
+    int bits = 16;
+    if (!parse_wav(wav, pcm, channels, sample_rate, bits)) {
+        return Ref<AudioStreamWAV>();
+    }
+
+    Ref<AudioStreamWAV> stream;
+    stream.instantiate();
+    if (bits == 16) {
+        stream->set_format(AudioStreamWAV::FORMAT_16_BITS);
+        stream->set_data(pcm);
+    } else if (bits == 8) {
+        PackedByteArray signed_pcm;
+        signed_pcm.resize(pcm.size());
+        for (int64_t i = 0; i < pcm.size(); ++i) {
+            signed_pcm.set(i, static_cast<uint8_t>(static_cast<int>(pcm[i]) - 128));
+        }
+        stream->set_format(AudioStreamWAV::FORMAT_8_BITS);
+        stream->set_data(signed_pcm);
+    } else {
+        return Ref<AudioStreamWAV>();
+    }
+
+    stream->set_mix_rate(sample_rate);
+    stream->set_stereo(channels == 2);
+    return stream;
+}
+
+GDKSpeechSynthesizer::~GDKSpeechSynthesizer() {
+    if (m_synthesizer != nullptr) {
+        XSpeechSynthesizerCloseHandle(m_synthesizer);
+        m_synthesizer = nullptr;
+    }
+}
+
+} // namespace godot

--- a/addons/godot_gdk/src/gdk_speech_synthesizer.h
+++ b/addons/godot_gdk/src/gdk_speech_synthesizer.h
@@ -1,0 +1,54 @@
+#ifndef GDK_SPEECH_SYNTHESIZER_H
+#define GDK_SPEECH_SYNTHESIZER_H
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+#include <XSpeechSynthesizer.h>
+
+namespace godot {
+
+class GDK;
+class GDKResult;
+class AudioStreamWAV;
+
+class GDKSpeechSynthesizer : public RefCounted {
+    GDCLASS(GDKSpeechSynthesizer, RefCounted);
+
+    GDK *m_owner = nullptr;
+    bool m_runtime_ready = false;
+    XSpeechSynthesizerHandle m_synthesizer = nullptr;
+
+    Ref<GDKResult> ensure_synthesizer_internal();
+    Ref<GDKResult> synthesize_internal(const String &p_input, bool p_is_ssml);
+
+protected:
+    static void _bind_methods();
+
+public:
+    void set_owner(GDK *p_owner);
+    Ref<GDKResult> on_runtime_initialized();
+    void shutdown();
+
+    Array get_installed_voices();
+    Ref<GDKResult> set_default_voice();
+    Ref<GDKResult> set_custom_voice(const String &p_voice_id);
+    Ref<GDKResult> synthesize_text(const String &p_text);
+    Ref<GDKResult> synthesize_ssml(const String &p_ssml);
+    Ref<AudioStreamWAV> synthesize_to_stream(const String &p_text);
+
+    GDKSpeechSynthesizer() = default;
+    ~GDKSpeechSynthesizer();
+};
+
+} // namespace godot
+
+#endif // GDK_SPEECH_SYNTHESIZER_H

--- a/addons/godot_gdk/src/gdk_stats.cpp
+++ b/addons/godot_gdk/src/gdk_stats.cpp
@@ -5,6 +5,8 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <godot_cpp/variant/array.hpp>
+
 #include "gdk.h"
 #include "gdk_pending_signal.h"
 #include "gdk_result.h"
@@ -129,6 +131,7 @@ class QueryStatsAsyncContext final : public GDKSignalXAsyncContext {
     std::vector<uint64_t> m_xuids;
     bool m_single_user_payload = true;
     bool m_multiple_user_result = false;
+    bool m_single_stat_query = false;
 
 protected:
     void finalize(XAsyncBlock *p_async_block) override {
@@ -141,9 +144,11 @@ protected:
         }
 
         size_t result_size = 0;
-        HRESULT result_hr = m_multiple_user_result ?
-                XblUserStatisticsGetMultipleUserStatisticsResultSize(p_async_block, &result_size) :
-                XblUserStatisticsGetSingleUserStatisticsResultSize(p_async_block, &result_size);
+        HRESULT result_hr = m_single_stat_query ?
+                XblUserStatisticsGetSingleUserStatisticResultSize(p_async_block, &result_size) :
+                (m_multiple_user_result ?
+                        XblUserStatisticsGetMultipleUserStatisticsResultSize(p_async_block, &result_size) :
+                        XblUserStatisticsGetSingleUserStatisticsResultSize(p_async_block, &result_size));
         if (result_hr == E_ABORT) {
             result = GDKResult::cancelled("Statistic query cancelled.");
             get_pending_signal()->complete(result);
@@ -159,7 +164,15 @@ protected:
         XblUserStatisticsResult *results = nullptr;
         size_t results_count = 0;
         size_t buffer_used = 0;
-        if (m_multiple_user_result) {
+        if (m_single_stat_query) {
+            result_hr = XblUserStatisticsGetSingleUserStatisticResult(
+                    p_async_block,
+                    buffer.size(),
+                    buffer.empty() ? nullptr : buffer.data(),
+                    &results,
+                    &buffer_used);
+            results_count = results != nullptr ? 1 : 0;
+        } else if (m_multiple_user_result) {
             result_hr = XblUserStatisticsGetMultipleUserStatisticsResult(
                     p_async_block,
                     buffer.size(),
@@ -252,6 +265,14 @@ public:
 
     uint64_t get_xbox_user_id() const {
         return m_xbox_user_id;
+    }
+
+    void set_single_stat_query(bool p_single_stat_query) {
+        m_single_stat_query = p_single_stat_query;
+    }
+
+    const char *get_single_stat_name() const {
+        return m_stat_name_ptrs.empty() ? nullptr : m_stat_name_ptrs.front();
     }
 
     uint64_t *get_xuids() {
@@ -354,14 +375,167 @@ public:
     }
 };
 
+class WriteStatsAsyncContext final : public GDKSignalXAsyncContext {
+    Ref<GDKUser> m_user;
+    XblContextHandle m_context = nullptr;
+    uint64_t m_xbox_user_id = 0;
+    std::vector<CharString> m_name_utf8;
+    std::vector<XblTitleManagedStatistic> m_native_stats;
+
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Statistic write cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Statistic write cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(result_hr, "Failed to write title-managed statistics.", "stats_write_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["xuid"] = m_user.is_valid() ? m_user->get_xuid() : String();
+        data["count"] = static_cast<int64_t>(m_native_stats.size());
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    WriteStatsAsyncContext(
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const Ref<GDKUser> &p_user,
+            XblContextHandle p_context,
+            uint64_t p_xbox_user_id,
+            const std::vector<GDKStats::StagedStat> &p_stats) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+            m_user(p_user),
+            m_context(p_context),
+            m_xbox_user_id(p_xbox_user_id) {
+        m_name_utf8.reserve(p_stats.size());
+        m_native_stats.reserve(p_stats.size());
+        for (const GDKStats::StagedStat &stat : p_stats) {
+            m_name_utf8.push_back(stat.name.utf8());
+        }
+        for (size_t i = 0; i < p_stats.size(); ++i) {
+            XblTitleManagedStatistic native_stat = {};
+            native_stat.statisticName = m_name_utf8[i].get_data();
+            native_stat.statisticType = XblTitleManagedStatType::Number;
+            native_stat.numberValue = p_stats[i].value;
+            native_stat.stringValue = nullptr;
+            m_native_stats.push_back(native_stat);
+        }
+    }
+
+    ~WriteStatsAsyncContext() override {
+        if (m_context != nullptr) {
+            XblContextCloseHandle(m_context);
+            m_context = nullptr;
+        }
+    }
+
+    XblContextHandle get_context() const {
+        return m_context;
+    }
+
+    uint64_t get_xbox_user_id() const {
+        return m_xbox_user_id;
+    }
+
+    const XblTitleManagedStatistic *get_native_stats() const {
+        return m_native_stats.empty() ? nullptr : m_native_stats.data();
+    }
+
+    size_t get_native_stats_count() const {
+        return m_native_stats.size();
+    }
+};
+
+class DeleteStatsAsyncContext final : public GDKSignalXAsyncContext {
+    Ref<GDKUser> m_user;
+    XblContextHandle m_context = nullptr;
+    std::vector<CharString> m_name_utf8;
+    std::vector<const char *> m_name_ptrs;
+
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Statistic delete cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XAsyncGetStatus(p_async_block, false);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Statistic delete cancelled."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(result_hr, "Failed to delete title-managed statistics.", "stats_delete_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["xuid"] = m_user.is_valid() ? m_user->get_xuid() : String();
+        data["count"] = static_cast<int64_t>(m_name_ptrs.size());
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    DeleteStatsAsyncContext(
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const Ref<GDKUser> &p_user,
+            XblContextHandle p_context,
+            const std::vector<String> &p_stat_names) :
+            GDKSignalXAsyncContext(p_runtime, p_pending_signal),
+            m_user(p_user),
+            m_context(p_context) {
+        m_name_utf8.reserve(p_stat_names.size());
+        m_name_ptrs.reserve(p_stat_names.size());
+        for (const String &stat_name : p_stat_names) {
+            m_name_utf8.push_back(stat_name.utf8());
+        }
+        for (const CharString &stat_name_utf8 : m_name_utf8) {
+            m_name_ptrs.push_back(stat_name_utf8.get_data());
+        }
+    }
+
+    ~DeleteStatsAsyncContext() override {
+        if (m_context != nullptr) {
+            XblContextCloseHandle(m_context);
+            m_context = nullptr;
+        }
+    }
+
+    XblContextHandle get_context() const {
+        return m_context;
+    }
+
+    const char **get_name_ptrs() {
+        return m_name_ptrs.empty() ? nullptr : m_name_ptrs.data();
+    }
+
+    size_t get_name_count() const {
+        return m_name_ptrs.size();
+    }
+};
+
 } // namespace
 
 void GDKStats::_bind_methods() {
     ClassDB::bind_method(D_METHOD("query_user_stats_async", "user", "stat_names"), &GDKStats::query_user_stats_async, DEFVAL(PackedStringArray()));
     ClassDB::bind_method(D_METHOD("query_users_stats_async", "user", "xuids", "stat_names"), &GDKStats::query_users_stats_async, DEFVAL(PackedStringArray()));
+    ClassDB::bind_method(D_METHOD("get_single_stat_async", "user", "stat_name"), &GDKStats::get_single_stat_async);
     ClassDB::bind_method(D_METHOD("set_stat_integer", "user", "stat_name", "value"), &GDKStats::set_stat_integer);
     ClassDB::bind_method(D_METHOD("set_stat_number", "user", "stat_name", "value"), &GDKStats::set_stat_number);
     ClassDB::bind_method(D_METHOD("flush_stats_async", "user"), &GDKStats::flush_stats_async);
+    ClassDB::bind_method(D_METHOD("write_stats_async", "user", "stats"), &GDKStats::write_stats_async);
+    ClassDB::bind_method(D_METHOD("delete_stats_async", "user", "stat_names"), &GDKStats::delete_stats_async);
     ClassDB::bind_method(D_METHOD("track_stats", "user", "stat_names"), &GDKStats::track_stats);
     ClassDB::bind_method(D_METHOD("stop_tracking_stats", "user", "stat_names"), &GDKStats::stop_tracking_stats, DEFVAL(PackedStringArray()));
     ClassDB::bind_method(D_METHOD("get_cached_stats", "user"), &GDKStats::get_cached_stats);
@@ -830,6 +1004,171 @@ Signal GDKStats::flush_stats_async(const Ref<GDKUser> &p_user) {
         async_context->clear_cancel_handler();
         delete async_context;
         return _make_error_signal(hr, "stats_flush_start_failed", "Failed to start title-managed statistic flush.");
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStats::get_single_stat_async(const Ref<GDKUser> &p_user, const String &p_stat_name) {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr) {
+        return Signal();
+    }
+
+    Ref<GDKResult> validation = _ensure_ready_user(p_user);
+    if (!validation->is_ok()) {
+        return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+    }
+
+    const String stat_name = p_stat_name.strip_edges();
+    if (stat_name.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "invalid_stat_name", "A non-empty statistic name is required.");
+    }
+
+    GDKXboxServices *xbox_services = _get_xbox_services();
+    if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+        return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+    }
+
+    XblContextHandle context = nullptr;
+    uint64_t xbox_user_id = 0;
+    HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+    if (FAILED(hr)) {
+        return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+    }
+
+    std::vector<String> stat_names = { stat_name };
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    QueryStatsAsyncContext *async_context = new QueryStatsAsyncContext(this, p_user, runtime, pending_signal, context, xbox_services->get_scid(), stat_names, xbox_user_id, std::vector<uint64_t>(), true, false);
+    async_context->set_single_stat_query(true);
+    async_context->bind_cancel_handler();
+
+    hr = XblUserStatisticsGetSingleUserStatisticAsync(
+            async_context->get_context(),
+            async_context->get_xbox_user_id(),
+            async_context->get_scid(),
+            async_context->get_single_stat_name(),
+            async_context->get_async_block());
+    if (FAILED(hr)) {
+        async_context->clear_cancel_handler();
+        delete async_context;
+        return _make_error_signal(hr, "stats_query_failed", "Failed to start single-statistic query.");
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStats::write_stats_async(const Ref<GDKUser> &p_user, const Dictionary &p_stats) {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr) {
+        return Signal();
+    }
+
+    Ref<GDKResult> validation = _ensure_ready_user(p_user);
+    if (!validation->is_ok()) {
+        return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+    }
+    if (p_stats.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "no_stats", "write_stats_async() requires at least one statistic.");
+    }
+
+    std::vector<StagedStat> stats;
+    stats.reserve(static_cast<size_t>(p_stats.size()));
+    const Array keys = p_stats.keys();
+    for (int64_t i = 0; i < keys.size(); ++i) {
+        const String name = String(keys[i]).strip_edges();
+        if (name.is_empty()) {
+            return _make_error_signal(E_INVALIDARG, "invalid_stat_name", "Statistic names must be non-empty strings.");
+        }
+        const Variant value = p_stats[keys[i]];
+        if (value.get_type() != Variant::INT && value.get_type() != Variant::FLOAT) {
+            return _make_error_signal(E_INVALIDARG, "invalid_stat_value", "write_stats_async() only accepts numeric statistic values.");
+        }
+        StagedStat stat;
+        stat.name = name;
+        stat.value = static_cast<double>(value);
+        stats.push_back(stat);
+    }
+
+    GDKXboxServices *xbox_services = _get_xbox_services();
+    if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+        return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+    }
+
+    XblContextHandle context = nullptr;
+    uint64_t xbox_user_id = 0;
+    HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context, &xbox_user_id);
+    if (FAILED(hr)) {
+        return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    WriteStatsAsyncContext *async_context = new WriteStatsAsyncContext(runtime, pending_signal, p_user, context, xbox_user_id, stats);
+    async_context->bind_cancel_handler();
+
+    hr = XblTitleManagedStatsWriteAsync(
+            async_context->get_context(),
+            async_context->get_xbox_user_id(),
+            async_context->get_native_stats(),
+            async_context->get_native_stats_count(),
+            async_context->get_async_block());
+    if (FAILED(hr)) {
+        async_context->clear_cancel_handler();
+        delete async_context;
+        return _make_error_signal(hr, "stats_write_start_failed", "Failed to start title-managed statistic write.");
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStats::delete_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names) {
+    GDKRuntime *runtime = _get_runtime();
+    if (runtime == nullptr) {
+        return Signal();
+    }
+
+    Ref<GDKResult> validation = _ensure_ready_user(p_user);
+    if (!validation->is_ok()) {
+        return _make_error_signal(static_cast<HRESULT>(validation->get_hresult()), validation->get_code(), validation->get_message());
+    }
+    if (p_stat_names.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "no_stat_names", "delete_stats_async() requires at least one statistic name.");
+    }
+
+    std::vector<String> stat_names;
+    stat_names.reserve(static_cast<size_t>(p_stat_names.size()));
+    for (int64_t i = 0; i < p_stat_names.size(); ++i) {
+        const String name = String(p_stat_names[i]).strip_edges();
+        if (name.is_empty()) {
+            return _make_error_signal(E_INVALIDARG, "invalid_stat_name", "Statistic names must be non-empty strings.");
+        }
+        stat_names.push_back(name);
+    }
+
+    GDKXboxServices *xbox_services = _get_xbox_services();
+    if (xbox_services == nullptr || !xbox_services->is_initialized()) {
+        return _make_error_signal(E_FAIL, "xbox_services_uninitialized", "Xbox services are not initialized.");
+    }
+
+    XblContextHandle context = nullptr;
+    HRESULT hr = xbox_services->duplicate_context_for_user(p_user, &context);
+    if (FAILED(hr)) {
+        return _make_error_signal(hr, "xbox_context_unavailable", "Failed to create an Xbox services context for the user.");
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    DeleteStatsAsyncContext *async_context = new DeleteStatsAsyncContext(runtime, pending_signal, p_user, context, stat_names);
+    async_context->bind_cancel_handler();
+
+    hr = XblTitleManagedStatsDeleteStatsAsync(
+            async_context->get_context(),
+            async_context->get_name_ptrs(),
+            async_context->get_name_count(),
+            async_context->get_async_block());
+    if (FAILED(hr)) {
+        async_context->clear_cancel_handler();
+        delete async_context;
+        return _make_error_signal(hr, "stats_delete_start_failed", "Failed to start title-managed statistic delete.");
     }
 
     return pending_signal->get_completed_signal();

--- a/addons/godot_gdk/src/gdk_stats.h
+++ b/addons/godot_gdk/src/gdk_stats.h
@@ -120,9 +120,12 @@ public:
 
     Signal query_user_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names = PackedStringArray());
     Signal query_users_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_xuids, const PackedStringArray &p_stat_names = PackedStringArray());
+    Signal get_single_stat_async(const Ref<GDKUser> &p_user, const String &p_stat_name);
     Ref<GDKResult> set_stat_integer(const Ref<GDKUser> &p_user, const String &p_stat_name, int64_t p_value);
     Ref<GDKResult> set_stat_number(const Ref<GDKUser> &p_user, const String &p_stat_name, double p_value);
     Signal flush_stats_async(const Ref<GDKUser> &p_user);
+    Signal write_stats_async(const Ref<GDKUser> &p_user, const Dictionary &p_stats);
+    Signal delete_stats_async(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names);
     Ref<GDKResult> track_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names);
     Ref<GDKResult> stop_tracking_stats(const Ref<GDKUser> &p_user, const PackedStringArray &p_stat_names = PackedStringArray());
     Dictionary get_cached_stats(const Ref<GDKUser> &p_user) const;

--- a/addons/godot_gdk/src/gdk_store.cpp
+++ b/addons/godot_gdk/src/gdk_store.cpp
@@ -132,6 +132,268 @@ public:
             StoreXAsyncContext(p_service, p_runtime, p_pending_signal, p_store_id) {}
 };
 
+class StoreProductPageUiAsyncContext final : public StoreXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store product page UI request cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XStoreShowProductPageUIResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store product page UI was dismissed."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the store product page UI flow.",
+                    "store_product_page_result_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["store_id"] = get_store_id();
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    StoreProductPageUiAsyncContext(
+            GDKStore *p_service,
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const String &p_store_id) :
+            StoreXAsyncContext(p_service, p_runtime, p_pending_signal, p_store_id) {}
+};
+
+class StoreAssociatedProductsUiAsyncContext final : public StoreXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store associated products UI request cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XStoreShowAssociatedProductsUIResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store associated products UI was dismissed."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the store associated products UI flow.",
+                    "store_associated_products_result_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["store_id"] = get_store_id();
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    StoreAssociatedProductsUiAsyncContext(
+            GDKStore *p_service,
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const String &p_store_id) :
+            StoreXAsyncContext(p_service, p_runtime, p_pending_signal, p_store_id) {}
+};
+
+class StoreRateAndReviewUiAsyncContext final : public StoreXAsyncContext {
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store rate and review UI request cancelled."));
+            return;
+        }
+
+        XStoreRateAndReviewResult native_result = {};
+        HRESULT result_hr = XStoreShowRateAndReviewUIResult(p_async_block, &native_result);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store rate and review UI was dismissed."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the store rate and review UI flow.",
+                    "store_rate_and_review_result_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["was_updated"] = native_result.wasUpdated;
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    StoreRateAndReviewUiAsyncContext(
+            GDKStore *p_service,
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal) :
+            StoreXAsyncContext(p_service, p_runtime, p_pending_signal, String()) {}
+};
+
+class StoreRedeemTokenUiAsyncContext final : public StoreXAsyncContext {
+    std::string m_token_utf8;
+    std::vector<std::string> m_allowed_store_ids_utf8;
+    std::vector<const char *> m_allowed_store_id_ptrs;
+    bool m_disallow_csv_redemption = false;
+
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store redeem token UI request cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XStoreShowRedeemTokenUIResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store redeem token UI was dismissed."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the store redeem token UI flow.",
+                    "store_redeem_token_result_failed"));
+            return;
+        }
+
+        get_pending_signal()->complete(GDKResult::ok_result(Dictionary()));
+    }
+
+public:
+    StoreRedeemTokenUiAsyncContext(
+            GDKStore *p_service,
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const String &p_token,
+            const PackedStringArray &p_allowed_store_ids,
+            bool p_disallow_csv_redemption) :
+            StoreXAsyncContext(p_service, p_runtime, p_pending_signal, String()),
+            m_token_utf8(p_token.utf8().get_data()),
+            m_disallow_csv_redemption(p_disallow_csv_redemption) {
+        for (int64_t i = 0; i < p_allowed_store_ids.size(); ++i) {
+            const String entry = p_allowed_store_ids[i].strip_edges();
+            if (!entry.is_empty()) {
+                m_allowed_store_ids_utf8.push_back(entry.utf8().get_data());
+            }
+        }
+        m_allowed_store_id_ptrs.reserve(m_allowed_store_ids_utf8.size());
+        for (const std::string &id : m_allowed_store_ids_utf8) {
+            m_allowed_store_id_ptrs.push_back(id.c_str());
+        }
+    }
+
+    const char *get_token_utf8() const {
+        return m_token_utf8.c_str();
+    }
+
+    const char **get_allowed_store_ids() {
+        return m_allowed_store_id_ptrs.empty() ? nullptr : m_allowed_store_id_ptrs.data();
+    }
+
+    size_t get_allowed_store_ids_count() const {
+        return m_allowed_store_id_ptrs.size();
+    }
+
+    bool get_disallow_csv_redemption() const {
+        return m_disallow_csv_redemption;
+    }
+};
+
+class StoreGiftingUiAsyncContext final : public StoreXAsyncContext {
+    std::string m_name_utf8;
+    std::string m_extended_json_utf8;
+    bool m_has_name = false;
+    bool m_has_extended_json = false;
+
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store gifting UI request cancelled."));
+            return;
+        }
+
+        HRESULT result_hr = XStoreShowGiftingUIResult(p_async_block);
+        if (result_hr == E_ABORT) {
+            get_pending_signal()->complete(GDKResult::cancelled("Store gifting UI was dismissed."));
+            return;
+        }
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(GDKResult::hresult_error(
+                    result_hr,
+                    "Failed to complete the store gifting UI flow.",
+                    "store_gifting_result_failed"));
+            return;
+        }
+
+        Dictionary data;
+        data["store_id"] = get_store_id();
+        get_pending_signal()->complete(GDKResult::ok_result(data));
+    }
+
+public:
+    StoreGiftingUiAsyncContext(
+            GDKStore *p_service,
+            GDKRuntime *p_runtime,
+            const Ref<GDKPendingSignal> &p_pending_signal,
+            const String &p_store_id,
+            const String &p_name,
+            const String &p_extended_json) :
+            StoreXAsyncContext(p_service, p_runtime, p_pending_signal, p_store_id) {
+        const String name = p_name.strip_edges();
+        if (!name.is_empty()) {
+            m_name_utf8 = name.utf8().get_data();
+            m_has_name = true;
+        }
+        const String extended_json = p_extended_json.strip_edges();
+        if (!extended_json.is_empty()) {
+            m_extended_json_utf8 = extended_json.utf8().get_data();
+            m_has_extended_json = true;
+        }
+    }
+
+    const char *get_name_utf8() const {
+        return m_has_name ? m_name_utf8.c_str() : nullptr;
+    }
+
+    const char *get_extended_json_utf8() const {
+        return m_has_extended_json ? m_extended_json_utf8.c_str() : nullptr;
+    }
+};
+
+XStoreProductKind parse_product_kinds(const String &p_product_kinds) {
+    const String normalized = p_product_kinds.strip_edges().to_lower();
+    if (normalized.is_empty()) {
+        return XStoreProductKind::Consumable | XStoreProductKind::Durable |
+                XStoreProductKind::Game | XStoreProductKind::Pass |
+                XStoreProductKind::UnmanagedConsumable;
+    }
+
+    XStoreProductKind kinds = XStoreProductKind::None;
+    const PackedStringArray tokens = normalized.split(",", false);
+    for (int64_t i = 0; i < tokens.size(); ++i) {
+        const String token = tokens[i].strip_edges();
+        if (token == "consumable") {
+            kinds |= XStoreProductKind::Consumable;
+        } else if (token == "durable") {
+            kinds |= XStoreProductKind::Durable;
+        } else if (token == "game") {
+            kinds |= XStoreProductKind::Game;
+        } else if (token == "pass") {
+            kinds |= XStoreProductKind::Pass;
+        } else if (token == "unmanaged_consumable" || token == "unmanagedconsumable") {
+            kinds |= XStoreProductKind::UnmanagedConsumable;
+        }
+    }
+    return kinds;
+}
+
 } // namespace
 
 void GDKStoreLicenseStatus::_bind_methods() {
@@ -166,6 +428,11 @@ void GDKStore::_bind_methods() {
     ClassDB::bind_method(D_METHOD("query_license_status_async", "user", "store_id"), &GDKStore::query_license_status_async);
     ClassDB::bind_method(D_METHOD("refresh_entitlements_async", "user", "store_id"), &GDKStore::refresh_entitlements_async);
     ClassDB::bind_method(D_METHOD("show_purchase_ui_async", "user", "store_id"), &GDKStore::show_purchase_ui_async);
+    ClassDB::bind_method(D_METHOD("show_product_page_ui_async", "user", "store_id"), &GDKStore::show_product_page_ui_async);
+    ClassDB::bind_method(D_METHOD("show_associated_products_ui_async", "user", "store_id", "product_kinds"), &GDKStore::show_associated_products_ui_async, DEFVAL(String()));
+    ClassDB::bind_method(D_METHOD("show_rate_and_review_ui_async", "user"), &GDKStore::show_rate_and_review_ui_async);
+    ClassDB::bind_method(D_METHOD("show_redeem_token_ui_async", "user", "token", "allowed_store_ids", "disallow_csv_redemption"), &GDKStore::show_redeem_token_ui_async, DEFVAL(PackedStringArray()), DEFVAL(false));
+    ClassDB::bind_method(D_METHOD("show_gifting_ui_async", "user", "store_id", "name", "extended_json"), &GDKStore::show_gifting_ui_async, DEFVAL(String()), DEFVAL(String()));
     ClassDB::bind_method(D_METHOD("get_cached_license_status", "store_id"), &GDKStore::get_cached_license_status);
     ClassDB::bind_method(D_METHOD("check_cached_license_status", "store_id"), &GDKStore::check_cached_license_status);
 }
@@ -247,6 +514,191 @@ Signal GDKStore::show_purchase_ui_async(const Ref<GDKUser> &p_user, const String
                 "Failed to start the store purchase UI flow.",
                 "store_purchase_start_failed");
         pending_signal->complete_deferred(result);
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+bool GDKStore::_prepare_store_ui_call(const Ref<GDKUser> &p_user, GDKRuntime *&r_runtime, XStoreContextHandle &r_store_context, Signal &r_error_signal) {
+    r_runtime = _get_runtime();
+    if (r_runtime == nullptr || !r_runtime->is_available()) {
+        r_error_signal = _make_error_signal(E_FAIL, "runtime_unavailable", "GDK runtime is unavailable in the current process.");
+        return false;
+    }
+    if (!m_runtime_ready || !r_runtime->is_initialized()) {
+        r_error_signal = _make_error_signal(E_FAIL, "not_initialized", "GDK is not initialized. Call GDK.initialize() first.");
+        return false;
+    }
+    if (!p_user.is_valid() || p_user->get_handle() == nullptr) {
+        r_error_signal = _make_error_signal(E_INVALIDARG, "invalid_user", "A signed-in GDKUser is required.");
+        return false;
+    }
+
+    // PC GDK uses the Microsoft Store signed-in account for XStore context and
+    // expects a nullptr user handle here. We still validate p_user above so the
+    // public Godot API keeps a consistent "signed-in local user required"
+    // contract across store calls.
+    HRESULT context_hr = S_OK;
+    r_store_context = _get_or_create_store_context(context_hr);
+    if (FAILED(context_hr) || r_store_context == nullptr) {
+        r_error_signal = _make_error_signal(context_hr, "store_context_create_failed", "Failed to create an XStore context for the user.");
+        return false;
+    }
+
+    return true;
+}
+
+Signal GDKStore::show_product_page_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id) {
+    const String store_id = _normalize_store_id(p_store_id);
+    if (store_id.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "invalid_product_id", "A non-empty Store product ID is required.");
+    }
+
+    GDKRuntime *runtime = nullptr;
+    XStoreContextHandle store_context = nullptr;
+    Signal error_signal;
+    if (!_prepare_store_ui_call(p_user, runtime, store_context, error_signal)) {
+        return error_signal;
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new StoreProductPageUiAsyncContext(this, runtime, pending_signal, store_id);
+    context->bind_cancel_handler();
+
+    HRESULT start_hr = XStoreShowProductPageUIAsync(store_context, context->get_store_id_utf8(), context->get_async_block());
+    if (FAILED(start_hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                start_hr,
+                "Failed to start the store product page UI flow.",
+                "store_product_page_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStore::show_associated_products_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id, const String &p_product_kinds) {
+    const String store_id = _normalize_store_id(p_store_id);
+    if (store_id.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "invalid_product_id", "A non-empty Store product ID is required.");
+    }
+
+    GDKRuntime *runtime = nullptr;
+    XStoreContextHandle store_context = nullptr;
+    Signal error_signal;
+    if (!_prepare_store_ui_call(p_user, runtime, store_context, error_signal)) {
+        return error_signal;
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new StoreAssociatedProductsUiAsyncContext(this, runtime, pending_signal, store_id);
+    context->bind_cancel_handler();
+
+    HRESULT start_hr = XStoreShowAssociatedProductsUIAsync(store_context, context->get_store_id_utf8(), parse_product_kinds(p_product_kinds), context->get_async_block());
+    if (FAILED(start_hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                start_hr,
+                "Failed to start the store associated products UI flow.",
+                "store_associated_products_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStore::show_rate_and_review_ui_async(const Ref<GDKUser> &p_user) {
+    GDKRuntime *runtime = nullptr;
+    XStoreContextHandle store_context = nullptr;
+    Signal error_signal;
+    if (!_prepare_store_ui_call(p_user, runtime, store_context, error_signal)) {
+        return error_signal;
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new StoreRateAndReviewUiAsyncContext(this, runtime, pending_signal);
+    context->bind_cancel_handler();
+
+    HRESULT start_hr = XStoreShowRateAndReviewUIAsync(store_context, context->get_async_block());
+    if (FAILED(start_hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                start_hr,
+                "Failed to start the store rate and review UI flow.",
+                "store_rate_and_review_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStore::show_redeem_token_ui_async(const Ref<GDKUser> &p_user, const String &p_token, const PackedStringArray &p_allowed_store_ids, bool p_disallow_csv_redemption) {
+    const String token = p_token.strip_edges();
+    if (token.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "invalid_token", "A non-empty redemption token is required.");
+    }
+
+    GDKRuntime *runtime = nullptr;
+    XStoreContextHandle store_context = nullptr;
+    Signal error_signal;
+    if (!_prepare_store_ui_call(p_user, runtime, store_context, error_signal)) {
+        return error_signal;
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new StoreRedeemTokenUiAsyncContext(this, runtime, pending_signal, token, p_allowed_store_ids, p_disallow_csv_redemption);
+    context->bind_cancel_handler();
+
+    HRESULT start_hr = XStoreShowRedeemTokenUIAsync(
+            store_context,
+            context->get_token_utf8(),
+            context->get_allowed_store_ids(),
+            context->get_allowed_store_ids_count(),
+            context->get_disallow_csv_redemption(),
+            context->get_async_block());
+    if (FAILED(start_hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                start_hr,
+                "Failed to start the store redeem token UI flow.",
+                "store_redeem_token_start_failed"));
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal GDKStore::show_gifting_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id, const String &p_name, const String &p_extended_json) {
+    const String store_id = _normalize_store_id(p_store_id);
+    if (store_id.is_empty()) {
+        return _make_error_signal(E_INVALIDARG, "invalid_product_id", "A non-empty Store product ID is required.");
+    }
+
+    GDKRuntime *runtime = nullptr;
+    XStoreContextHandle store_context = nullptr;
+    Signal error_signal;
+    if (!_prepare_store_ui_call(p_user, runtime, store_context, error_signal)) {
+        return error_signal;
+    }
+
+    Ref<GDKPendingSignal> pending_signal = runtime->make_pending_signal();
+    auto *context = new StoreGiftingUiAsyncContext(this, runtime, pending_signal, store_id, p_name, p_extended_json);
+    context->bind_cancel_handler();
+
+    HRESULT start_hr = XStoreShowGiftingUIAsync(
+            store_context,
+            context->get_store_id_utf8(),
+            context->get_name_utf8(),
+            context->get_extended_json_utf8(),
+            context->get_async_block());
+    if (FAILED(start_hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+        pending_signal->complete_deferred(GDKResult::hresult_error(
+                start_hr,
+                "Failed to start the store gifting UI flow.",
+                "store_gifting_start_failed"));
     }
 
     return pending_signal->get_completed_signal();

--- a/addons/godot_gdk/src/gdk_store.h
+++ b/addons/godot_gdk/src/gdk_store.h
@@ -11,6 +11,7 @@
 #include <godot_cpp/classes/ref.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
@@ -59,6 +60,7 @@ class GDKStore : public RefCounted {
     void _close_store_context();
     XStoreContextHandle _get_or_create_store_context(HRESULT &r_hresult);
     Signal _make_error_signal(HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant()) const;
+    bool _prepare_store_ui_call(const Ref<GDKUser> &p_user, GDKRuntime *&r_runtime, XStoreContextHandle &r_store_context, Signal &r_error_signal);
     Signal _start_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id, bool p_is_refresh);
     static String _normalize_store_id(const String &p_store_id);
 
@@ -78,6 +80,11 @@ public:
     Signal query_license_status_async(const Ref<GDKUser> &p_user, const String &p_store_id);
     Signal refresh_entitlements_async(const Ref<GDKUser> &p_user, const String &p_store_id);
     Signal show_purchase_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id);
+    Signal show_product_page_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id);
+    Signal show_associated_products_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id, const String &p_product_kinds);
+    Signal show_rate_and_review_ui_async(const Ref<GDKUser> &p_user);
+    Signal show_redeem_token_ui_async(const Ref<GDKUser> &p_user, const String &p_token, const PackedStringArray &p_allowed_store_ids, bool p_disallow_csv_redemption);
+    Signal show_gifting_ui_async(const Ref<GDKUser> &p_user, const String &p_store_id, const String &p_name, const String &p_extended_json);
 
     Ref<GDKStoreLicenseStatus> get_cached_license_status(const String &p_store_id) const;
     Ref<GDKResult> check_cached_license_status(const String &p_store_id) const;

--- a/addons/godot_gdk/src/gdk_system.cpp
+++ b/addons/godot_gdk/src/gdk_system.cpp
@@ -2,7 +2,10 @@
 
 #include <cstdio>
 
+#include <godot_cpp/variant/utility_functions.hpp>
+
 #include <XGame.h>
+#include <XGameRuntimeFeature.h>
 #include <XSystem.h>
 
 #include "gdk.h"
@@ -19,6 +22,51 @@ String _format_title_id_hex(uint32_t p_title_id) {
     return String(buffer);
 }
 
+struct FeatureNameEntry {
+    const char *name;
+    XGameRuntimeFeature feature;
+};
+
+const FeatureNameEntry kFeatureNames[] = {
+    { "XAccessibility", XGameRuntimeFeature::XAccessibility },
+    { "XAppCapture", XGameRuntimeFeature::XAppCapture },
+    { "XAsync", XGameRuntimeFeature::XAsync },
+    { "XAsyncProvider", XGameRuntimeFeature::XAsyncProvider },
+    { "XDisplay", XGameRuntimeFeature::XDisplay },
+    { "XGame", XGameRuntimeFeature::XGame },
+    { "XGameInvite", XGameRuntimeFeature::XGameInvite },
+    { "XGameSave", XGameRuntimeFeature::XGameSave },
+    { "XGameUI", XGameRuntimeFeature::XGameUI },
+    { "XLauncher", XGameRuntimeFeature::XLauncher },
+    { "XNetworking", XGameRuntimeFeature::XNetworking },
+    { "XPackage", XGameRuntimeFeature::XPackage },
+    { "XPersistentLocalStorage", XGameRuntimeFeature::XPersistentLocalStorage },
+    { "XSpeechSynthesizer", XGameRuntimeFeature::XSpeechSynthesizer },
+    { "XStore", XGameRuntimeFeature::XStore },
+    { "XSystem", XGameRuntimeFeature::XSystem },
+    { "XTaskQueue", XGameRuntimeFeature::XTaskQueue },
+    { "XThread", XGameRuntimeFeature::XThread },
+    { "XUser", XGameRuntimeFeature::XUser },
+    { "XError", XGameRuntimeFeature::XError },
+    { "XGameEvent", XGameRuntimeFeature::XGameEvent },
+    { "XGameStreaming", XGameRuntimeFeature::XGameStreaming },
+};
+
+bool _resolve_feature(const String &p_feature_name, XGameRuntimeFeature *r_feature) {
+    const String normalized = p_feature_name.strip_edges().to_lower();
+    if (normalized.is_empty()) {
+        return false;
+    }
+
+    for (const FeatureNameEntry &entry : kFeatureNames) {
+        if (normalized == String(entry.name).to_lower()) {
+            *r_feature = entry.feature;
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace
 
 void GDKSystem::_bind_methods() {
@@ -27,6 +75,7 @@ void GDKSystem::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_sandbox_id"), &GDKSystem::get_sandbox_id);
     ClassDB::bind_method(D_METHOD("get_service_configuration_id"), &GDKSystem::get_service_configuration_id);
     ClassDB::bind_method(D_METHOD("is_xbox_services_initialized"), &GDKSystem::is_xbox_services_initialized);
+    ClassDB::bind_method(D_METHOD("is_feature_available", "feature_name"), &GDKSystem::is_feature_available);
 }
 
 void GDKSystem::set_owner(GDK *p_owner) {
@@ -113,6 +162,17 @@ bool GDKSystem::is_xbox_services_initialized() const {
     }
 
     return xbox_services->is_initialized();
+}
+
+bool GDKSystem::is_feature_available(const String &p_feature_name) const {
+    XGameRuntimeFeature feature = {};
+    if (!_resolve_feature(p_feature_name, &feature)) {
+        UtilityFunctions::push_warning(
+                "GDK.system.is_feature_available: unknown feature name '" + p_feature_name + "'.");
+        return false;
+    }
+
+    return XGameRuntimeIsFeatureAvailable(feature);
 }
 
 } // namespace godot

--- a/addons/godot_gdk/src/gdk_system.h
+++ b/addons/godot_gdk/src/gdk_system.h
@@ -9,6 +9,7 @@
 #include <godot_cpp/classes/ref.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/string.hpp>
 
 namespace godot {
 
@@ -34,6 +35,7 @@ public:
     Ref<GDKResult> get_sandbox_id() const;
     Ref<GDKResult> get_service_configuration_id() const;
     bool is_xbox_services_initialized() const;
+    bool is_feature_available(const String &p_feature_name) const;
 };
 
 } // namespace godot

--- a/addons/godot_gdk/src/register_types.cpp
+++ b/addons/godot_gdk/src/register_types.cpp
@@ -13,6 +13,7 @@
 #include "gdk_capture.h"
 #include "gdk_display.h"
 #include "gdk_error_reporting.h"
+#include "gdk_events.h"
 #include "gdk_game_ui.h"
 #include "gdk_launcher.h"
 #include "gdk_leaderboards.h"
@@ -150,6 +151,7 @@ void initialize_gdk_extension(ModuleInitializationLevel p_level) {
     ClassDB::register_class<GDKDisplay>();
     ClassDB::register_class<GDKActivation>();
     ClassDB::register_class<GDKSpeechSynthesizer>();
+    ClassDB::register_class<GDKEvents>();
 
     gdk_singleton = memnew(GDK);
     Engine::get_singleton()->register_singleton("GDK", GDK::get_singleton());

--- a/addons/godot_gdk/src/register_types.cpp
+++ b/addons/godot_gdk/src/register_types.cpp
@@ -14,6 +14,7 @@
 #include "gdk_display.h"
 #include "gdk_error_reporting.h"
 #include "gdk_events.h"
+#include "gdk_game_save.h"
 #include "gdk_game_ui.h"
 #include "gdk_launcher.h"
 #include "gdk_leaderboards.h"
@@ -152,6 +153,7 @@ void initialize_gdk_extension(ModuleInitializationLevel p_level) {
     ClassDB::register_class<GDKActivation>();
     ClassDB::register_class<GDKSpeechSynthesizer>();
     ClassDB::register_class<GDKEvents>();
+    ClassDB::register_class<GDKGameSave>();
 
     gdk_singleton = memnew(GDK);
     Engine::get_singleton()->register_singleton("GDK", GDK::get_singleton());

--- a/addons/godot_gdk/src/register_types.cpp
+++ b/addons/godot_gdk/src/register_types.cpp
@@ -24,6 +24,7 @@
 #include "gdk_privacy.h"
 #include "gdk_result.h"
 #include "gdk_social.h"
+#include "gdk_speech_synthesizer.h"
 #include "gdk_stats.h"
 #include "gdk_store.h"
 #include "gdk_string_verify.h"
@@ -148,6 +149,7 @@ void initialize_gdk_extension(ModuleInitializationLevel p_level) {
     ClassDB::register_class<GDKDisplayTimeoutDeferral>();
     ClassDB::register_class<GDKDisplay>();
     ClassDB::register_class<GDKActivation>();
+    ClassDB::register_class<GDKSpeechSynthesizer>();
 
     gdk_singleton = memnew(GDK);
     Engine::get_singleton()->register_singleton("GDK", GDK::get_singleton());

--- a/addons/godot_gdk/src/register_types.cpp
+++ b/addons/godot_gdk/src/register_types.cpp
@@ -14,6 +14,7 @@
 #include "gdk_display.h"
 #include "gdk_error_reporting.h"
 #include "gdk_events.h"
+#include "gdk_game_chat.h"
 #include "gdk_game_save.h"
 #include "gdk_game_ui.h"
 #include "gdk_launcher.h"
@@ -154,6 +155,7 @@ void initialize_gdk_extension(ModuleInitializationLevel p_level) {
     ClassDB::register_class<GDKSpeechSynthesizer>();
     ClassDB::register_class<GDKEvents>();
     ClassDB::register_class<GDKGameSave>();
+    ClassDB::register_class<GDKGameChat>();
 
     gdk_singleton = memnew(GDK);
     Engine::get_singleton()->register_singleton("GDK", GDK::get_singleton());

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -411,7 +411,7 @@ real-time statistic tracking, and a per-user in-memory cache.
 | `set_stat_integer(user, stat_name, value)` | `GDKResult` | Stage an integer title-managed statistic for the user |
 | `set_stat_number(user, stat_name, value)` | `GDKResult` | Stage a numeric title-managed statistic for the user |
 | `flush_stats_async(user)` | `Signal` | Submit staged title-managed statistics for the user (merge semantics) |
-| `write_stats_async(user, stats)` | `Signal` | Replace-all write: the `stats` `Dictionary` (name → number/string) becomes the user's complete title-managed stat document. Live-write surface |
+| `write_stats_async(user, stats)` | `Signal` | Replace-all write: the `stats` `Dictionary` (name → number) becomes the user's complete title-managed stat document. Non-numeric values are rejected with `invalid_stat_value`. Live-write surface |
 | `delete_stats_async(user, stat_names)` | `Signal` | Delete the named title-managed stats for the user. Live-write surface |
 | `track_stats(user, stat_names)` | `GDKResult` | Start tracking real-time changes for named stats |
 | `stop_tracking_stats(user, stat_names := PackedStringArray())` | `GDKResult` | Stop tracking named stats, or all tracked stats for the user when empty |
@@ -1504,14 +1504,17 @@ var me: GDKUser = GDK.users.get_primary_user()
 var local := GDK.game_chat.add_local_user(me)
 GDK.game_chat.add_remote_user("2814639011419087", 1001)
 
-# Ferry Game Chat's encoded frames over your own transport. Here we loop them
-# straight back (single-process loopback) to exercise the round trip.
+# Ferry Game Chat's encoded frames over your own networking transport. Game Chat
+# hands each outgoing frame to this handler; forward it to the listed endpoints.
 GDK.game_chat.outgoing_data_frame.connect(
     func(target_endpoint_ids, bytes, transport_requirement):
         for endpoint in target_endpoint_ids:
-            my_transport.send(endpoint, bytes)  # or, for loopback:
-        GDK.game_chat.process_incoming_data_frame(1001, bytes)
+            my_transport.send(endpoint, bytes)
 )
+
+# On the receiving peer, feed bytes that arrive on your transport back into Game
+# Chat (for a single-process loopback test, call this with your own frames):
+#     GDK.game_chat.process_incoming_data_frame(source_endpoint_id, received_bytes)
 
 GDK.game_chat.text_chat_received.connect(
     func(sender_xuid, message): print("%s: %s" % [sender_xuid, message])

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -116,6 +116,7 @@ peer test-account XUIDs from the checklist in
 | `get_sandbox_id()` | `GDKResult` | Read the current sandbox ID (`data` is `String`) |
 | `get_service_configuration_id()` | `GDKResult` | Read the current SCID from the shared XBOX services scaffold (`data` is `String`) |
 | `is_xbox_services_initialized()` | `bool` | Check whether the shared XBOX services scaffold is initialized |
+| `is_feature_available(name)` | `bool` | Check whether an optional GDK runtime feature is available (`XGameRuntimeIsFeatureAvailable`). `name` is a case-insensitive feature id such as `"XAccessibility"`, `"XGameUI"`, `"XGameSave"`, or `"XGameStreaming"`. Unknown names push a warning and return `false`. |
 
 ### Usage
 
@@ -282,6 +283,7 @@ with direct-await completion signals.
 | `query_player_achievements_async(user)` | `Signal` | Query achievements for a user |
 | `update_achievement_async(user, achievement_id, percent_complete)` | `Signal` | Update achievement progress |
 | `get_cached_achievements(user)` | `Array` | Get cached achievement list |
+| `get_achievements_by_state(user, progress_state)` | `GDKResult` | Filter the cached achievements by progress state (`"Achieved"`, `"NotStarted"`, `"InProgress"`, `"Unknown"`; case-insensitive). `data.achievements` is an `Array` of `GDKAchievement`. Returns `achievements_not_loaded` until `query_player_achievements_async()` has warmed the cache for `user`. |
 
 ### Signals
 
@@ -405,9 +407,12 @@ real-time statistic tracking, and a per-user in-memory cache.
 |--------|---------|-------------|
 | `query_user_stats_async(user, stat_names := PackedStringArray())` | `Signal` | Query named stats for one local user; success data is a `Dictionary` keyed by stat name |
 | `query_users_stats_async(user, xuids, stat_names := PackedStringArray())` | `Signal` | Query named stats for multiple target XUIDs using the local user as caller context; success data is keyed by XUID |
+| `get_single_stat_async(user, stat_name)` | `Signal` | Read a single named stat for the signed-in user; success data is a `Dictionary` keyed by stat name (one entry) |
 | `set_stat_integer(user, stat_name, value)` | `GDKResult` | Stage an integer title-managed statistic for the user |
 | `set_stat_number(user, stat_name, value)` | `GDKResult` | Stage a numeric title-managed statistic for the user |
-| `flush_stats_async(user)` | `Signal` | Submit staged title-managed statistics for the user |
+| `flush_stats_async(user)` | `Signal` | Submit staged title-managed statistics for the user (merge semantics) |
+| `write_stats_async(user, stats)` | `Signal` | Replace-all write: the `stats` `Dictionary` (name → number/string) becomes the user's complete title-managed stat document. Live-write surface |
+| `delete_stats_async(user, stat_names)` | `Signal` | Delete the named title-managed stats for the user. Live-write surface |
 | `track_stats(user, stat_names)` | `GDKResult` | Start tracking real-time changes for named stats |
 | `stop_tracking_stats(user, stat_names := PackedStringArray())` | `GDKResult` | Stop tracking named stats, or all tracked stats for the user when empty |
 | `get_cached_stats(user)` | `Dictionary` | Return cached stats for the user keyed by stat name |
@@ -626,6 +631,8 @@ and broadcast fields when XBOX Services reports them.
 | `get_friends_async(user)` | `Signal` | Query the default friends group |
 | `create_social_group(user, filter)` | `GDKResult` | Create a filtered social group. On success `result.data` is the `GDKSocialGroup`; on failure `result.ok` is false and `runtime_error` is also emitted on `GDK.social`. |
 | `create_social_group_from_xuids(user, xuids)` | `GDKResult` | Create a social group from explicit XUIDs. On success `result.data` is the `GDKSocialGroup`; on failure `result.ok` is false and `runtime_error` is also emitted on `GDK.social`. |
+| `update_social_user_group(group, xuids)` | `GDKResult` | Replace the tracked-user list of a list-based `GDKSocialGroup` (one created via `create_social_group_from_xuids`). `result.data.count` is the new tracked-user count. Filter-based groups cannot be updated this way. |
+| `set_rich_presence_polling(user, enabled)` | `GDKResult` | Enable or disable Social Manager rich-presence polling for `user`. `result.data.enabled` echoes the requested state; the user's social graph is started if needed. |
 | `destroy_social_group(group)` | `void` | Destroy a social group |
 | `get_group_users(group)` | `GDKResult` | Get the `GDKSocialUser` list for a group. `result.data` is always an `Array` (possibly empty); `result.ok` is false when the underlying lookup fails. |
 | `submit_reputation_feedback_async(user, target_xuid, feedback_type, reason := "", evidence_id := "")` | `Signal` | Submit one reputation feedback item |
@@ -1379,4 +1386,44 @@ if not result.ok:
     push_warning("Event not written: %s" % result.code)
 ```
 
+## Game Save service: `GDK.game_save`
 
+`GDK.game_save` is a `RefCounted` service object returned by
+`GDK.get_game_save()`. It wraps the GDK-native file-style save API
+(`XGameSaveFiles.h`). This is distinct from PlayFab Game Saves
+(`godot_playfab`) and from Xbox Services Title Storage (`GDK.title_storage`).
+
+The title must declare connected storage / a `SaveFolder` in its
+`MicrosoftGame.config`; without it the native calls fail and the propagated
+`HRESULT` error is returned.
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get_folder_async(user)` | `Signal` | Resolve the user's save folder (may surface a system UI) via `XGameSaveFilesGetFolderWithUiAsync`. Success data is `data.path` (absolute folder path). Titles then read/write ordinary files under that folder. |
+| `get_remaining_quota(user)` | `GDKResult` | Read the remaining save quota in bytes via `XGameSaveFilesGetRemainingQuota`. Success data is `data.bytes`. |
+
+### Validation notes
+
+- `not_initialized` when the GDK runtime is not yet initialized.
+- `invalid_user` when `user` is null or has no underlying handle.
+- `xbox_services_uninitialized` when the shared XBOX services scaffold (SCID)
+  is unavailable.
+
+### Usage
+
+```gdscript
+var user: GDKUser = GDK.users.get_primary_user()
+
+var folder_result: GDKResult = await GDK.game_save.get_folder_async(user)
+if folder_result.ok:
+    var save_path: String = folder_result.data.path
+    var f := FileAccess.open(save_path.path_join("save1.dat"), FileAccess.WRITE)
+    f.store_var({"level": 3, "score": 1450})
+    f.close()
+
+var quota_result: GDKResult = GDK.game_save.get_remaining_quota(user)
+if quota_result.ok:
+    print("Remaining save quota: %d bytes" % quota_result.data.bytes)
+```

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -1338,3 +1338,45 @@ if stream != null:
     $AudioStreamPlayer.play()
 ```
 
+## Events service: `GDK.events`
+
+`GDK.events` is a `RefCounted` service object returned by `GDK.get_events()`.
+It writes GDK-native in-game telemetry through `XGameEventWrite`. Events are
+batched and uploaded asynchronously by the runtime. This is complementary to
+PlayFab analytics (`godot_playfab`); titles may use either or both.
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `write_event(user, event_name, dimensions, measurements)` | `GDKResult` | Write a telemetry event for `user`. `dimensions`/`measurements` are `Dictionary` payloads serialized to JSON. Success data includes `event_name` and `play_session_id`. |
+| `set_play_session_id(play_session_id)` | `void` | Set the play-session GUID used to group events. Pass `""` to regenerate a fresh GUID. |
+| `get_play_session_id()` | `String` | Return the current play-session GUID (auto-generated on first access). |
+
+### Notes
+
+- The event name and every `dimensions`/`measurements` field name must match the
+  title's Xbox Live service-configuration event manifest (case-insensitive).
+  Events whose names do not match are **silently dropped** by the service.
+- When the GDK XGameEvent telemetry feature is unavailable in the current
+  runtime, `write_event()` returns `events_feature_unavailable` (HRESULT
+  `E_NOTIMPL`) without writing.
+
+### Usage
+
+```gdscript
+var user: GDKUser = GDK.users.get_primary_user()
+
+# Tag the play session (optional; a GUID is generated automatically otherwise)
+GDK.events.set_play_session_id("")  # regenerate, or pass your own id
+
+var result: GDKResult = GDK.events.write_event(
+    user,
+    "LevelComplete",
+    {"level_id": "forest_01", "difficulty": "hard"},   # dimensions
+    {"score": 1450, "time_seconds": 92.5})             # measurements
+if not result.ok:
+    push_warning("Event not written: %s" % result.code)
+```
+
+

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -199,6 +199,10 @@ func _on_user_changed(user: GDKUser, change_kind: String):
 | `show_player_profile_card_async(requesting_user, target_xuid)` | `Signal` | Show the profile card UI for a target XUID |
 | `show_player_picker_async(requesting_user, prompt, selectable_xuids, preselected_xuids, min_selection_count, max_selection_count)` | `Signal` | Show player picker UI; success data includes `selected_xuids` and `selection_count` |
 | `resolve_privilege_with_ui_async(user, privilege)` | `Signal` | Forward to users-service privilege remediation UI flow |
+| `show_achievements_async(requesting_user)` | `Signal` | Show the system achievements UI for the current title |
+| `show_error_dialog_async(error_code, context)` | `Signal` | Show the system error dialog for an HRESULT `error_code` with optional `context` text |
+| `show_send_game_invite_async(requesting_user, session_configuration_id, session_template_name, session_id, invitation_text, custom_activation_context)` | `Signal` | Show the system send-game-invite UI for a multiplayer session |
+| `show_text_entry_async(title_text, description_text, default_text, input_scope, max_text_length)` | `Signal` | Show the virtual-keyboard text entry UI; success data includes `text` |
 
 ### Validation
 
@@ -770,6 +774,11 @@ signed-in [`GDKUser`](#users-service-gdkusers) and an initialized [`GDK`](#root-
 | `query_license_status_async(user, store_id)` | `Signal` | Query whether `user` can acquire a license for `store_id`. Completion `GDKResult.data` is a `GDKStoreLicenseStatus` on success. |
 | `refresh_entitlements_async(user, store_id)` | `Signal` | Refresh entitlements for `store_id` by re-querying license-acquire status. |
 | `show_purchase_ui_async(user, store_id)` | `Signal` | Show the system purchase UI for `store_id`. |
+| `show_product_page_ui_async(user, store_id)` | `Signal` | Show the system product page UI for `store_id`. |
+| `show_associated_products_ui_async(user, store_id, product_kinds)` | `Signal` | Show the associated-products UI. `product_kinds` is a comma-separated filter (`consumable`, `durable`, `game`, `pass`, `unmanaged_consumable`); empty includes all kinds. |
+| `show_rate_and_review_ui_async(user)` | `Signal` | Show the rate-and-review UI; success data includes `was_updated`. |
+| `show_redeem_token_ui_async(user, token, allowed_store_ids, disallow_csv_redemption)` | `Signal` | Show the token-redemption UI for `token`. `allowed_store_ids` optionally restricts redeemable products. |
+| `show_gifting_ui_async(user, store_id, name, extended_json)` | `Signal` | Show the gifting UI for `store_id` with optional gifting metadata. |
 | `get_cached_license_status(store_id)` | `GDKStoreLicenseStatus` | Returns the cached license status for `store_id`, or `null` when no cached value exists. |
 | `check_cached_license_status(store_id)` | `GDKResult` | Synchronous cache-only check; returns `license_status_not_cached` when no cached status exists. |
 
@@ -1281,3 +1290,51 @@ fan-out so both services see the same parsed invite dictionary.
 - If activation registration fails on this host (e.g., a partially registered
   package), the synchronous `accept_pending_invite` API still works; the
   signal-driven flow simply emits no events. A `push_warning` is logged once.
+
+## Speech service: `GDK.speech`
+
+`GDK.speech` is a `RefCounted` service object returned by `GDK.get_speech()`. It
+wraps `XSpeechSynthesizer.h` to turn text or SSML into PCM/WAV audio bytes on the
+local device with no network call, which makes it usable for accessibility
+narration, prompts, and announcer lines. The service lazily creates a single
+native synthesizer the first time a voice is selected or speech is synthesized,
+and releases it on `GDK.shutdown()`.
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get_installed_voices()` | `Array` | Installed voices as dictionaries with `id`, `display_name`, `language`, `gender` (`"male"`/`"female"`), and `description`. Empty before `GDK.initialize()` |
+| `set_default_voice()` | `GDKResult` | Select the platform default voice for subsequent synthesis |
+| `set_custom_voice(voice_id)` | `GDKResult` | Select a voice by `id`; rejects an empty id with `invalid_voice_id` |
+| `synthesize_text(text)` | `GDKResult` | Synthesize plain text; `data.audio_wav` is a `PackedByteArray` of RIFF/WAV bytes and `data.byte_count` is its length |
+| `synthesize_ssml(ssml)` | `GDKResult` | Synthesize an SSML document; same payload shape as `synthesize_text` |
+| `synthesize_to_stream(text)` | `AudioStreamWAV` | Convenience helper returning a ready-to-play stream, or `null` on failure |
+
+### Validation notes
+
+- Calls before `GDK.initialize()` return `not_initialized`.
+- Empty `text`/`ssml` returns `invalid_input`; an empty `voice_id` returns `invalid_voice_id`.
+- If the synthesizer cannot be created on this host, calls return `speech_synthesizer_unavailable`.
+
+### Usage
+
+```gdscript
+# Enumerate voices and pick one
+var voices: Array = GDK.speech.get_installed_voices()
+if voices.size() > 0:
+    GDK.speech.set_custom_voice(voices[0]["id"])
+
+# Synthesize to raw WAV bytes
+var result: GDKResult = GDK.speech.synthesize_text("Welcome to the game.")
+if result.ok:
+    var wav_bytes: PackedByteArray = result.data["audio_wav"]
+    # ...persist or hand off the WAV bytes...
+
+# Or play immediately through a Godot AudioStreamPlayer
+var stream := GDK.speech.synthesize_to_stream("Welcome to the game.")
+if stream != null:
+    $AudioStreamPlayer.stream = stream
+    $AudioStreamPlayer.play()
+```
+

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -1427,3 +1427,96 @@ var quota_result: GDKResult = GDK.game_save.get_remaining_quota(user)
 if quota_result.ok:
     print("Remaining save quota: %d bytes" % quota_result.data.bytes)
 ```
+
+## Game Chat service: `GDK.game_chat`
+
+`GDK.game_chat` is a `RefCounted` service object returned by
+`GDK.get_game_chat()`. It wraps the Game Chat 2 (`GameChat2.h`) `chat_manager`
+for GDK-native voice and text chat. It is the GDK-native alternative to PlayFab
+Party (`godot_playfab`), which is the batteries-included option that owns its
+own transport.
+
+**No transport is built or selected.** Game Chat encodes its own opaque
+audio/text data frames; this wrapper only exposes that surface. While the
+manager is pumped each frame (driven automatically by `GDK.dispatch()`), every
+frame Game Chat wants to send is emitted on the `outgoing_data_frame` signal.
+Deliver those bytes over whatever transport your title already has, then call
+`process_incoming_data_frame()` on each receiving instance. The sample and tests
+demonstrate this with single-process **loopback** (feeding each
+`outgoing_data_frame` straight back into `process_incoming_data_frame`).
+
+Real voice capture and rendering require multi-machine audio hardware and cannot
+be validated headlessly; headless coverage exercises the service surface, enum
+constants, lifecycle, and data-frame plumbing.
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `initialize(max_users := 16, default_relationship := RELATIONSHIP_SEND_AND_RECEIVE_ALL)` | `GDKResult` | Initialize the `chat_manager` for `max_users` combined local + remote users. Errors: `not_initialized`, `already_initialized`, `invalid_max_users`. |
+| `is_initialized()` | `bool` | `true` between a successful `initialize()` and `cleanup()`. |
+| `cleanup()` | `void` | Release all Game Chat resources (also called on `GDK.shutdown`). |
+| `add_local_user(user)` | `GDKResult` | Add a signed-in `GDKUser` as a local chat user. Success data is `data.xuid`. |
+| `add_remote_user(xuid, endpoint_id)` | `GDKResult` | Add a remote user by XUID reachable on a title-assigned `endpoint_id`. Success data is `{xuid, endpoint_id}`. |
+| `remove_user(xuid)` | `GDKResult` | Remove the local or remote user matching `xuid`. |
+| `set_communication_relationship(local_xuid, target_xuid, relationship)` | `GDKResult` | Set the bitwise `CommunicationRelationship` flags from a local user toward a target. |
+| `set_microphone_muted(local_xuid, muted)` | `GDKResult` | Mute/unmute a local user's microphone. |
+| `set_remote_user_muted(local_xuid, target_xuid, muted)` | `GDKResult` | Mute/unmute a remote user for a local user. |
+| `set_audio_render_volume(local_xuid, target_xuid, volume)` | `GDKResult` | Set the render volume (0.0–1.0) for audio from a remote user. |
+| `send_text(local_xuid, text)` | `GDKResult` | Send a 1–1023 character chat text message. |
+| `synthesize_text_to_speech(local_xuid, text)` | `GDKResult` | Synthesize text as speech from the local user (when TTS is enabled). |
+| `process_incoming_data_frame(source_endpoint_id, bytes)` | `GDKResult` | Hand Game Chat a frame received from a remote endpoint. |
+| `get_chat_users()` | `Array` | Snapshot of current users as `{xuid, is_local, chat_indicator}` dictionaries. |
+
+### Signals
+
+| Signal | Description |
+|--------|-------------|
+| `outgoing_data_frame(target_endpoint_ids, bytes, transport_requirement)` | A frame the title must transmit to each endpoint in `target_endpoint_ids`. `transport_requirement` is a `TransportRequirement` value. |
+| `text_chat_received(sender_xuid, message)` | A text message addressed to one or more local users. |
+| `transcribed_chat_received(speaker_xuid, message)` | A remote speaker's transcribed voice for local users who requested speech-to-text. |
+
+### Independent voice and text control
+
+Like PlayFab Party, Game Chat tracks voice and text independently. The
+`CommunicationRelationship` flags carry separate send/receive bits for
+microphone audio, text-to-speech audio, and text, and per-user mute/volume is
+controlled via `set_microphone_muted()`, `set_remote_user_muted()`, and
+`set_audio_render_volume()`.
+
+### Validation notes
+
+- `not_initialized` before `GDK.initialize()` (for `initialize()`) or before
+  `GDK.game_chat.initialize()` (for every other method).
+- `invalid_max_users` when `max_users <= 0`; `already_initialized` on re-init.
+- `invalid_xuid` / `invalid_user` for empty XUIDs or non-signed-in users;
+  `invalid_text` for empty/over-long text; `invalid_data` for an empty frame.
+- `user_not_found`, `not_local_user`, `target_not_found`, `add_user_failed` for
+  user-lookup and add failures.
+
+### Usage
+
+```gdscript
+GDK.game_chat.initialize()
+
+# Local (signed-in) user plus a remote peer reachable on endpoint 1001.
+var me: GDKUser = GDK.users.get_primary_user()
+var local := GDK.game_chat.add_local_user(me)
+GDK.game_chat.add_remote_user("2814639011419087", 1001)
+
+# Ferry Game Chat's encoded frames over your own transport. Here we loop them
+# straight back (single-process loopback) to exercise the round trip.
+GDK.game_chat.outgoing_data_frame.connect(
+    func(target_endpoint_ids, bytes, transport_requirement):
+        for endpoint in target_endpoint_ids:
+            my_transport.send(endpoint, bytes)  # or, for loopback:
+        GDK.game_chat.process_incoming_data_frame(1001, bytes)
+)
+
+GDK.game_chat.text_chat_received.connect(
+    func(sender_xuid, message): print("%s: %s" % [sender_xuid, message])
+)
+
+GDK.game_chat.send_text(local.data.xuid, "hello over game chat")
+```
+

--- a/sample/tutorial_gdk/g05_speech.gd
+++ b/sample/tutorial_gdk/g05_speech.gd
@@ -1,0 +1,114 @@
+extends Control
+
+const AddonApi = preload("res://shared/addon_api.gd")
+
+## GDK Tutorial 5 reference scene — Text-to-Speech (GDK.speech).
+##
+## GDK-only, no PlayFab and no network: XSpeechSynthesizer runs locally and
+## produces WAV/PCM bytes. Buttons drive each step:
+##   - List the installed system voices (GDK.speech.get_installed_voices).
+##   - Synthesize the text box to an AudioStreamWAV and play it back
+##     (GDK.speech.synthesize_to_stream → AudioStreamPlayer).
+##   - Synthesize SSML markup so prosody/voice control is demonstrated
+##     (GDK.speech.synthesize_ssml → GDKResult.data.audio_wav).
+##
+## Text-to-speech only needs the GDK runtime initialized; it does NOT require a
+## signed-in user, so the scene works even if Xbox sign-in is unavailable.
+##
+## NOTE: scene scripts use `get_node("/root/GdkAuth")` instead of the bare
+## `GdkAuth.` reference so the headless parse gate stays clean.
+##
+## Source: docs/gdk/api-reference.md (Speech service: GDK.speech)
+
+@onready var _log: RichTextLabel = $Root/LogPanel/Log
+@onready var _text_input: LineEdit = $Root/TextInput
+@onready var _voices_btn: Button = $Root/Buttons/VoicesBtn
+@onready var _speak_btn: Button = $Root/Buttons/SpeakBtn
+@onready var _ssml_btn: Button = $Root/Buttons/SsmlBtn
+@onready var _back_btn: Button = $Root/Buttons/BackBtn
+@onready var _player: AudioStreamPlayer = $AudioPlayer
+
+var _auth: Node = null
+
+func _ready() -> void:
+	_back_btn.pressed.connect(_on_back_pressed)
+	_voices_btn.pressed.connect(_on_voices_pressed)
+	_speak_btn.pressed.connect(_on_speak_pressed)
+	_ssml_btn.pressed.connect(_on_ssml_pressed)
+
+	_auth = get_node_or_null("/root/GdkAuth")
+	if not Engine.has_singleton("GDK"):
+		_append("[color=red]GDK extension is not loaded.[/color]")
+		_set_buttons_enabled(false)
+		return
+
+	_set_buttons_enabled(false)
+	_append("Initializing GDK runtime…")
+
+	# TTS only needs GDK.initialize() (done by GdkAuth.sign_in()); a signed-in
+	# user is not required, so a failed sign-in still leaves speech usable.
+	if _auth != null:
+		await _auth.call("sign_in")
+
+	if AddonApi.singleton("GDK").is_initialized():
+		_append("GDK runtime ready — text-to-speech is available (no user required).")
+		_set_buttons_enabled(true)
+	else:
+		_append("[color=red]GDK runtime is not initialized — check MicrosoftGame.config.[/color]")
+
+func _on_voices_pressed() -> void:
+	var voices: Array = AddonApi.singleton("GDK").speech.get_installed_voices()
+	if voices.is_empty():
+		_append("[color=orange][Voices] No installed voices reported.[/color]")
+		return
+	_append("[Voices] %d installed voice(s):" % voices.size())
+	for voice in voices:
+		_append("  • %s (%s, %s)" % [
+				voice.get("display_name", "?"),
+				voice.get("language", "?"),
+				voice.get("gender", "?")])
+
+func _on_speak_pressed() -> void:
+	var text := _text_input.text.strip_edges()
+	if text.is_empty():
+		text = "Hello from the Xbox GDK text to speech engine."
+
+	# Make sure we are using the system default voice for this pass.
+	var pick = AddonApi.singleton("GDK").speech.set_default_voice()
+	if not pick.ok:
+		_append("[color=orange][Speak] set_default_voice failed: %s[/color]" % pick.message)
+
+	# synthesize_to_stream wraps synthesize_text and packs the WAV bytes into a
+	# ready-to-play AudioStreamWAV.
+	var stream: AudioStreamWAV = AddonApi.singleton("GDK").speech.synthesize_to_stream(text)
+	if stream == null:
+		_append("[color=orange][Speak] Synthesis returned no audio.[/color]")
+		return
+	_player.stream = stream
+	_player.play()
+	_append("[color=green][Speak] Playing %d sample(s): \"%s\"[/color]" % [
+			stream.data.size(), text])
+
+func _on_ssml_pressed() -> void:
+	# SSML lets the title control prosody, emphasis, and voice selection inline.
+	var ssml := "<speak version='1.0' xml:lang='en-US'>" + \
+			"GDK speech also supports <emphasis level='strong'>SSML</emphasis>, " + \
+			"<break time='300ms'/> for full prosody control.</speak>"
+	var result = AddonApi.singleton("GDK").speech.synthesize_ssml(ssml)
+	if not result.ok:
+		_append("[color=orange][SSML] synthesize_ssml failed: %s (%s)[/color]" % [result.message, result.code])
+		return
+	var wav: PackedByteArray = result.data.get("audio_wav", PackedByteArray())
+	_append("[color=green][SSML] Synthesized %d WAV byte(s).[/color]" % wav.size())
+
+func _set_buttons_enabled(enabled: bool) -> void:
+	_voices_btn.disabled = not enabled
+	_speak_btn.disabled = not enabled
+	_ssml_btn.disabled = not enabled
+
+func _append(line: String) -> void:
+	_log.append_text(line + "\n")
+	print(line)
+
+func _on_back_pressed() -> void:
+	get_tree().change_scene_to_file("res://shared/tutorial_picker.tscn")

--- a/sample/tutorial_gdk/g05_speech.tscn
+++ b/sample/tutorial_gdk/g05_speech.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=2 format=3 uid="uid://bg05speechtts"]
+
+[ext_resource type="Script" path="res://g05_speech.gd" id="1_g05"]
+
+[node name="G05Speech" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_g05")
+
+[node name="Root" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+offset_left = 24.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = -24.0
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Root"]
+layout_mode = 2
+text = "G5 — Text-to-Speech"
+theme_override_font_sizes/font_size = 24
+
+[node name="Subtitle" type="Label" parent="Root"]
+layout_mode = 2
+text = "GDK.speech wraps XSpeechSynthesizer: list voices, synthesize text/SSML to WAV, and play it back. Local-only — no network or signed-in user required."
+autowrap_mode = 3
+
+[node name="TextInput" type="LineEdit" parent="Root"]
+layout_mode = 2
+text = "Hello from the Xbox GDK text to speech engine."
+placeholder_text = "Text to speak"
+
+[node name="Buttons" type="HBoxContainer" parent="Root"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="VoicesBtn" type="Button" parent="Root/Buttons"]
+layout_mode = 2
+text = "List voices"
+
+[node name="SpeakBtn" type="Button" parent="Root/Buttons"]
+layout_mode = 2
+text = "Speak (default voice)"
+
+[node name="SsmlBtn" type="Button" parent="Root/Buttons"]
+layout_mode = 2
+text = "Synthesize SSML"
+
+[node name="BackBtn" type="Button" parent="Root/Buttons"]
+layout_mode = 2
+text = "← Back"
+
+[node name="LogPanel" type="PanelContainer" parent="Root"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Log" type="RichTextLabel" parent="Root/LogPanel"]
+layout_mode = 2
+bbcode_enabled = true
+scroll_following = true
+
+[node name="AudioPlayer" type="AudioStreamPlayer" parent="."]

--- a/sample/tutorial_gdk/shared/tutorial_picker.gd
+++ b/sample/tutorial_gdk/shared/tutorial_picker.gd
@@ -15,6 +15,7 @@ const TUTORIALS := [
 	{ "label": "G2 — Unlock an achievement",     "scene": "res://g02_achievement.tscn",   "needs_auth": true },
 	{ "label": "G3 — Title storage & stats",     "scene": "res://g03_storage_stats.tscn", "needs_auth": true },
 	{ "label": "G4 — Multiplayer Activity",      "scene": "res://g04_mpa.tscn",           "needs_auth": true },
+	{ "label": "G5 — Text-to-Speech",            "scene": "res://g05_speech.tscn",        "needs_auth": false },
 ]
 
 @onready var _status: Label = $Root/Status

--- a/sample/tutorial_integrated/i02_integration/i02_integration.tscn
+++ b/sample/tutorial_integrated/i02_integration/i02_integration.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="Script" path="res://i02_integration/panel_lobby.gd" id="5_lob"]
 [ext_resource type="Script" path="res://i02_integration/panel_mpa.gd" id="6_mpa"]
 [ext_resource type="Script" path="res://i02_integration/panel_party.gd" id="7_pty"]
+[ext_resource type="Script" path="res://i02_integration/panel_game_chat.gd" id="8_gc"]
 
 [node name="TechDemo" type="Control"]
 layout_mode = 3
@@ -257,5 +258,40 @@ layout_mode = 2
 placeholder_text = "Broadcast a message"
 
 [node name="Send" type="Button" parent="Root/Tabs/Party"]
+layout_mode = 2
+text = "Send"
+
+[node name="GameChat" type="VBoxContainer" parent="Root/Tabs"]
+visible = false
+script = ExtResource("8_gc")
+
+[node name="Status" type="Label" parent="Root/Tabs/GameChat"]
+layout_mode = 2
+text = "Signing in…"
+
+[node name="Hint" type="Label" parent="Root/Tabs/GameChat"]
+layout_mode = 2
+text = "GDK-native voice + text chat (vs. the Party tab's batteries-included transport). No transport is built — outgoing frames loop back in-process."
+autowrap_mode = 3
+
+[node name="MuteMic" type="CheckButton" parent="Root/Tabs/GameChat"]
+layout_mode = 2
+text = "Mute microphone (text chat still works)"
+
+[node name="ChatLogLabel" type="Label" parent="Root/Tabs/GameChat"]
+layout_mode = 2
+text = "Chat"
+
+[node name="ChatLog" type="RichTextLabel" parent="Root/Tabs/GameChat"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+scroll_following = true
+
+[node name="ChatInput" type="LineEdit" parent="Root/Tabs/GameChat"]
+layout_mode = 2
+placeholder_text = "Send a chat message"
+
+[node name="Send" type="Button" parent="Root/Tabs/GameChat"]
 layout_mode = 2
 text = "Send"

--- a/sample/tutorial_integrated/i02_integration/panel_game_chat.gd
+++ b/sample/tutorial_integrated/i02_integration/panel_game_chat.gd
@@ -1,0 +1,143 @@
+extends VBoxContainer
+
+const AddonApi = preload("res://shared/addon_api.gd")
+
+## Integration tech demo — GDK Game Chat panel (GDK.game_chat).
+##
+## The GDK-native voice + text chat option, shown next to the PlayFab Party
+## panel so the two approaches can be compared directly:
+##   - PlayFab Party (panel_party.gd) owns its own transport end-to-end.
+##   - GDK Game Chat (this panel) encodes opaque data frames but builds NO
+##     transport; the title ferries frames over whatever network it already
+##     has. Here we feed each outgoing frame straight back in (single-process
+##     loopback) so the data-frame plumbing is demonstrable without a peer.
+##
+## Independent voice/text control mirrors Party: the mic-mute toggle stops
+## microphone audio (voice) while text chat keeps working, because Game Chat
+## tracks send/receive bits for microphone, text-to-speech, and text
+## separately via CommunicationRelationship flags.
+##
+## Source: docs/gdk/api-reference.md (Game Chat service: GDK.game_chat)
+
+# A synthetic loopback peer. In a real title this XUID + endpoint would belong
+# to a remote player reached over the title's transport.
+const LOOPBACK_XUID := "2814639011419087"
+const LOOPBACK_ENDPOINT := 1
+
+@onready var _status: Label = $Status
+@onready var _chat_log: RichTextLabel = $ChatLog
+@onready var _chat_input: LineEdit = $ChatInput
+@onready var _send: Button = $Send
+@onready var _mute_mic: CheckButton = $MuteMic
+
+var _auth: Node = null
+var _chat = null
+var _local_xuid: String = ""
+var _initialized: bool = false
+
+func _ready() -> void:
+	_auth = get_node_or_null("/root/Auth")
+	if _auth == null:
+		_status.text = "[ERR] Auth autoload missing"
+		return
+	if not Engine.has_singleton("GDK"):
+		_status.text = "[ERR] godot_gdk extension not loaded"
+		return
+	_auth.state_changed.connect(_on_auth_state_changed)
+	if _auth.is_signed_in():
+		_initialize_after_sign_in()
+		return
+	await _auth.sign_in()
+	if is_inside_tree() and _auth.is_signed_in():
+		_initialize_after_sign_in()
+
+func _exit_tree() -> void:
+	if _auth != null and _auth.state_changed.is_connected(_on_auth_state_changed):
+		_auth.state_changed.disconnect(_on_auth_state_changed)
+	if not _initialized or _chat == null:
+		return
+	if _chat.outgoing_data_frame.is_connected(_on_outgoing_data_frame):
+		_chat.outgoing_data_frame.disconnect(_on_outgoing_data_frame)
+	if _chat.text_chat_received.is_connected(_on_text_chat_received):
+		_chat.text_chat_received.disconnect(_on_text_chat_received)
+	if _chat.transcribed_chat_received.is_connected(_on_transcribed_chat_received):
+		_chat.transcribed_chat_received.disconnect(_on_transcribed_chat_received)
+	_chat.cleanup()
+
+func _on_auth_state_changed(_state) -> void:
+	if _initialized or _auth == null:
+		return
+	if _auth.is_signed_in():
+		_initialize_after_sign_in()
+
+func _initialize_after_sign_in() -> void:
+	if _initialized:
+		return
+	_initialized = true
+	_send.pressed.connect(_on_send_pressed)
+	_mute_mic.toggled.connect(_on_mute_mic_toggled)
+
+	_chat = AddonApi.singleton("GDK").game_chat
+
+	var init = _chat.initialize()
+	if not init.ok:
+		_status.text = "game_chat.initialize() failed: %s (%s)" % [init.message, init.code]
+		return
+
+	# Loopback wiring: every frame Game Chat wants to send is fed straight back
+	# in as if it had arrived from the peer. A real title would transmit it.
+	_chat.outgoing_data_frame.connect(_on_outgoing_data_frame)
+	_chat.text_chat_received.connect(_on_text_chat_received)
+	_chat.transcribed_chat_received.connect(_on_transcribed_chat_received)
+
+	var xbox = _auth.get("xbox_user")
+	var add_local = _chat.add_local_user(xbox)
+	if not add_local.ok:
+		_status.text = "add_local_user() failed: %s (%s)" % [add_local.message, add_local.code]
+		return
+	_local_xuid = add_local.data.get("xuid", "")
+
+	var add_remote = _chat.add_remote_user(LOOPBACK_XUID, LOOPBACK_ENDPOINT)
+	if not add_remote.ok:
+		_status.text = "add_remote_user() failed: %s" % add_remote.message
+		return
+
+	_status.text = "Game Chat ready — local %s + loopback peer on endpoint %d" % [
+			_local_xuid.left(8), LOOPBACK_ENDPOINT]
+	_chat_log.append_text("[i]No transport built: outgoing frames are looped back to the local manager.[/i]\n")
+
+func _on_send_pressed() -> void:
+	var text: String = _chat_input.text.strip_edges()
+	if text.is_empty() or _chat == null or _local_xuid.is_empty():
+		return
+	var result = _chat.send_text(_local_xuid, text)
+	if result.ok:
+		_chat_log.append_text("[me] %s\n" % text)
+		_chat_input.text = ""
+	else:
+		_chat_log.append_text("[i]send_text failed: %s (%s)[/i]\n" % [result.message, result.code])
+
+func _on_mute_mic_toggled(button_pressed: bool) -> void:
+	# Voice and text are independent: muting the mic leaves text chat working.
+	if _chat == null or _local_xuid.is_empty():
+		return
+	var result = _chat.set_microphone_muted(_local_xuid, button_pressed)
+	if result.ok:
+		_chat_log.append_text("[i]microphone %s (text chat still works)[/i]\n" % [
+				"muted" if button_pressed else "unmuted"])
+	else:
+		_chat_log.append_text("[i]set_microphone_muted failed: %s[/i]\n" % result.message)
+
+func _on_outgoing_data_frame(target_endpoint_ids: PackedInt64Array, bytes: PackedByteArray, _transport_requirement: int) -> void:
+	# A real title would deliver these bytes to each endpoint over its transport.
+	# Loopback: hand them right back to Game Chat as inbound frames.
+	for endpoint in target_endpoint_ids:
+		_chat.process_incoming_data_frame(endpoint, bytes)
+	_chat_log.append_text("[frame] looped %d byte(s) back to %d endpoint(s)\n" % [
+			bytes.size(), target_endpoint_ids.size()])
+
+func _on_text_chat_received(sender_xuid: String, message: String) -> void:
+	_chat_log.append_text("[%s] %s\n" % [sender_xuid.left(8), message])
+
+func _on_transcribed_chat_received(speaker_xuid: String, message: String) -> void:
+	_chat_log.append_text("[%s ~voice] %s\n" % [speaker_xuid.left(8), message])

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -39,7 +39,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Display | Implemented | `GDK.display` wraps `XDisplay.h`: HDR mode probe/enable and idle display-timeout deferrals |
 | Game activation events | Implemented | `GDK.activation` wraps `XGameActivation.h` (modern replacement for the deprecated `XGameProtocol.h`) |
 | Text-to-speech | Implemented | `GDK.speech` wraps `XSpeechSynthesizer.h`: enumerate installed voices, select default/custom voice, and synthesize text/SSML to WAV/PCM bytes locally (no network) |
-| Events | Excluded | Do not wrap `events_c.h` Xbox Services telemetry/configuration APIs or the per-title `XGameEvent.h` writer; titles that need event telemetry should use PlayFab or a separate analytics integration |
+| Events | Implemented | `GDK.events` wraps the per-title `XGameEvent.h` writer (`XGameEventWrite`) for GDK-native in-game telemetry. Complementary to PlayFab analytics. The `events_c.h` Xbox Services configuration/tuning APIs (`XblEventsSet*`) remain internal-gated and unwrapped |
 | Multiplayer/session/matchmaking | Excluded | Do not wrap matchmaking, MPSD, multiplayer sessions, lobby/session transport, or legacy invite APIs |
 | Store/commerce/licensing | Implemented (XStore-only) | Exposed via `GDK.store` using public XStore APIs; excluded from the Xbox Services coverage matrix below |
 
@@ -71,7 +71,8 @@ Do not expose wrappers for:
 
 - `XGameProtocol.h` — both `XGameProtocolRegisterForActivation` and `XGameProtocolUnregisterForActivation` are explicitly `__declspec(deprecated)` in the SDK and are superseded by `XGameActivationRegisterForEvent` / `XGameActivationUnregisterForEvent`. Use `GDK.activation.protocol_activated` for the modern protocol-activation event.
 - `XGameInvite.h` — every entry point (`XGameInviteRegisterForEvent`, `XGameInviteRegisterForPendingEvent`, the matching `Unregister` calls, and `XGameInviteAcceptPendingInvite`) is `__declspec(deprecated)` and the SDK explicitly points each one at the `XGameActivation*` equivalent. Use `GDK.activation` (the `pending_invite_received` and `invite_accepted` signals plus `accept_pending_invite()`); `GDKMultiplayerActivity` subscribes to `GDK.activation`'s internal event fan-out and must not register its own native activation callback.
-- `XGameEvent.h` — the per-title `XGameEventWrite` writer ships in PC GDK but is part of the broader Xbox Services events pipeline that this addon does not cover. Titles that need event telemetry should either author it through PlayFab (see the `godot_playfab` addon) or integrate a separate analytics SDK.
+
+> Note: `XGameEvent.h`'s `XGameEventWrite` is **wrapped** by `GDK.events` (see the Events scope row and the `GDK.events` service section) and is intentionally not listed here.
 
 #### Explicit no-wrap Xbox Services APIs
 
@@ -82,7 +83,7 @@ Do not expose wrappers for:
 - `multiplayer_manager_c.h`
 - MPSD, multiplayer sessions, lobby/session transport APIs
 - `game_invite_c.h` legacy/deprecated invite APIs
-- `events_c.h` telemetry/configuration APIs
+- `events_c.h` Xbox Services configuration/tuning APIs (`XblEventsSet*`); the per-title in-game event *writer* is wrapped instead via `GDK.events` → `XGameEventWrite` (`XGameEvent.h`). `XblEventsWriteInGameEvent` is an alternate write path and remains unwrapped in favor of the primary `XGameEventWrite`
 - generic public `notification_c.h` subscription wrappers; use notification/RTA plumbing internally only if a wrapped service requires it
 - `XblPrivacyAddMuteListChangedHandler`, `XblPrivacyRemoveMuteListChangedHandler`, `XblPrivacyAddBlockListChangedHandler`, and `XblPrivacyRemoveBlockListChangedHandler` while the addon links against `Microsoft.Xbox.Services.C.Thunks`; these header-declared APIs are not exported by the public thunk libraries
 - deprecated social, presence, and statistics subscription APIs
@@ -470,6 +471,34 @@ synthesize_to_stream(text: String) -> AudioStreamWAV   # convenience; null on fa
 | `synthesize_ssml()` | `XSpeechSynthesizerCreateStreamFromSsml`, `XSpeechSynthesizerGetStreamDataSize`, `XSpeechSynthesizerGetStreamData`, `XSpeechSynthesizerCloseStreamHandle` | SSML variant of `synthesize_text`. |
 | `synthesize_to_stream()` | (decodes the `synthesize_text` WAV bytes) | Parses the RIFF/WAV header and returns a ready-to-play `AudioStreamWAV`. |
 | service shutdown | `XSpeechSynthesizerCloseHandle` | Releases the cached synthesizer. |
+
+#### `GDK.events` service
+
+##### Methods
+
+```gdscript
+write_event(user: GDKUser, event_name: String, dimensions := {}, measurements := {}) -> GDKResult
+set_play_session_id(play_session_id: String)   # empty string regenerates a fresh GUID
+get_play_session_id() -> String
+```
+
+##### Behavior contract
+
+- `GDK.events` is the GDK-native in-game telemetry path, complementary to PlayFab analytics (`godot_playfab`). Titles may use either or both.
+- `write_event()` is synchronous and returns a `GDKResult`; the runtime batches and uploads events asynchronously.
+- `dimensions` hold fields with a finite set of values (map id, difficulty, mode, boolean settings); `measurements` hold scalar numeric metrics (score, time, counters, position). Both `Dictionary` payloads are serialized to JSON internally.
+- The SCID is pulled from the cached `GDKXboxServices` state; `play_session_id` is a per-session GUID auto-generated on runtime init and overridable via `set_play_session_id()`.
+- The event name and the names of all `dimensions`/`measurements` fields must match the title's Xbox Live service-configuration event manifest (case-insensitive); the service **silently drops** events whose names do not match.
+- Graceful degradation: returns `events_feature_unavailable` on `E_NOTIMPL` when the GRTS XGameEvent feature/runtime is not installed. Other validation failures return `invalid_event_name`, `invalid_user`, `not_initialized`, or `xbox_services_uninitialized`.
+
+##### Native API mapping
+
+| Wrapper/API | Native API(s) | Notes |
+| --- | --- | --- |
+| `write_event()` | `XGameEventWrite` (`XGameEvent.h`) | Primary GDK telemetry write path. Requires a signed-in `GDKUser` handle and the cached SCID; `dimensions`/`measurements` are JSON-serialized. |
+| `set_play_session_id()` / `get_play_session_id()` | (wrapper-managed GUID) | Session-scoped GUID forwarded as `playSessionId` to `XGameEventWrite`. |
+
+> The alternate Xbox Services write path `XblEventsWriteInGameEvent` (`events_c.h`) is intentionally **not** wrapped; `XGameEventWrite` is the primary GDK path. The `XblEventsSet*` configuration/tuning functions remain internal-gated.
 
 #### `GDK.users` service
 

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -27,9 +27,9 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Package metadata and DLC content access | Implemented | `GDK.package` wraps PC-supported `XPackage` enumeration, install progress, package mounts, and resource-pack loading |
 | Achievements | Implemented | Achievements Manager-backed |
 | Presence | Implemented | `GDK.presence` covers set/clear, single/multi-user queries, social-group query, tracking, non-deprecated change handlers, and cache access |
-| Social | Implemented | Social Manager graph/groups and reputation feedback are exposed; direct relationship paging remains intentionally excluded |
+| Social | Implemented | Social Manager graph/groups (create/update/destroy list-based groups), rich-presence polling toggle, and reputation feedback are exposed; direct relationship paging remains intentionally excluded |
 | Multiplayer activity | Implemented and capped | `GDK.multiplayer_activity` is the only multiplayer-related Xbox Services surface |
-| Stats | Implemented | `GDK.stats` wraps `title_managed_statistics_c.h` and `user_statistics_c.h` for reads, staged writes, tracking, and cache access |
+| Stats | Implemented | `GDK.stats` wraps `title_managed_statistics_c.h` and `user_statistics_c.h` for single/multiple-stat reads, staged merge writes plus replace-all/delete writes, tracking, and cache access |
 | Leaderboards | Implemented | `GDK.leaderboards` wraps read-only `leaderboard_c.h` queries and pagination |
 | Privacy | Implemented | `GDK.privacy` wraps `privacy_c.h` permission checks and avoid/mute list reads; list-change handlers are not exported by the public XSAPI thunk libraries used by the addon |
 | Profile | Implemented | `GDK.profile` wraps `profile_c.h` profile lookup APIs |
@@ -40,6 +40,8 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Game activation events | Implemented | `GDK.activation` wraps `XGameActivation.h` (modern replacement for the deprecated `XGameProtocol.h`) |
 | Text-to-speech | Implemented | `GDK.speech` wraps `XSpeechSynthesizer.h`: enumerate installed voices, select default/custom voice, and synthesize text/SSML to WAV/PCM bytes locally (no network) |
 | Events | Implemented | `GDK.events` wraps the per-title `XGameEvent.h` writer (`XGameEventWrite`) for GDK-native in-game telemetry. Complementary to PlayFab analytics. The `events_c.h` Xbox Services configuration/tuning APIs (`XblEventsSet*`) remain internal-gated and unwrapped |
+| Game Save (files) | Implemented | `GDK.game_save` wraps `XGameSaveFiles.h` (`XGameSaveFilesGetFolderWithUiAsync`, `XGameSaveFilesGetRemainingQuota`) for GDK-native file-style saves. Requires the title's `MicrosoftGame.config` connected-storage/SaveFolder config. The richer `XGameSave.h` connected-storage container API is intentionally left unwrapped (overlaps PlayFab Game Saves) |
+| Runtime feature probe | Implemented | `GDK.system.is_feature_available(name)` wraps `XGameRuntimeIsFeatureAvailable` (`XGameRuntimeFeature.h`) so titles can gate optional GDK features (e.g. Events, GameChat) at runtime |
 | Multiplayer/session/matchmaking | Excluded | Do not wrap matchmaking, MPSD, multiplayer sessions, lobby/session transport, or legacy invite APIs |
 | Store/commerce/licensing | Implemented (XStore-only) | Exposed via `GDK.store` using public XStore APIs; excluded from the Xbox Services coverage matrix below |
 
@@ -49,12 +51,12 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 
 | Public service | Native Xbox Services APIs | Notes |
 | --- | --- | --- |
-| `GDK.achievements` | Achievements Manager APIs | Query/update/cache are manager-backed. |
-| `GDK.stats` | `XblUserStatisticsGetSingleUserStatisticsAsync`, `XblUserStatisticsGetSingleUserStatisticsResultSize`, `XblUserStatisticsGetSingleUserStatisticsResult`, `XblUserStatisticsGetMultipleUserStatisticsAsync`, `XblUserStatisticsGetMultipleUserStatisticsResultSize`, `XblUserStatisticsGetMultipleUserStatisticsResult`, `XblUserStatisticsAddStatisticChangedHandler`, `XblUserStatisticsRemoveStatisticChangedHandler`, `XblUserStatisticsTrackStatistics`, `XblUserStatisticsStopTrackingStatistics`, `XblUserStatisticsStopTrackingUsers`, `XblTitleManagedStatsUpdateStatsAsync` | Query one or more users' stats, stage integer/number writes, flush staged stats, track changes, and read cached stats. |
+| `GDK.achievements` | Achievements Manager APIs including `XblAchievementsManagerGetAchievementsByState` | Query/update/cache are manager-backed; cached achievements can be filtered by progress state. |
+| `GDK.stats` | `XblUserStatisticsGetSingleUserStatisticAsync`, `XblUserStatisticsGetSingleUserStatisticResultSize`, `XblUserStatisticsGetSingleUserStatisticResult`, `XblUserStatisticsGetSingleUserStatisticsAsync`, `XblUserStatisticsGetSingleUserStatisticsResultSize`, `XblUserStatisticsGetSingleUserStatisticsResult`, `XblUserStatisticsGetMultipleUserStatisticsAsync`, `XblUserStatisticsGetMultipleUserStatisticsResultSize`, `XblUserStatisticsGetMultipleUserStatisticsResult`, `XblUserStatisticsAddStatisticChangedHandler`, `XblUserStatisticsRemoveStatisticChangedHandler`, `XblUserStatisticsTrackStatistics`, `XblUserStatisticsStopTrackingStatistics`, `XblUserStatisticsStopTrackingUsers`, `XblTitleManagedStatsUpdateStatsAsync`, `XblTitleManagedStatsWriteAsync`, `XblTitleManagedStatsDeleteStatsAsync` | Query a single named stat or one/more users' stats, stage merge writes, replace-all or delete title-managed stats, track changes, and read cached stats. |
 | `GDK.leaderboards` | `XblLeaderboardGetLeaderboardAsync`, `XblLeaderboardGetLeaderboardResultSize`, `XblLeaderboardGetLeaderboardResult`, `XblLeaderboardResultGetNextAsync`, `XblLeaderboardResultGetNextResultSize`, `XblLeaderboardResultGetNextResult` | Read-only global, around-user, social leaderboard queries plus next-page pagination. |
 | `GDK.privacy` | `XblPrivacyCheckPermissionAsync`, `XblPrivacyCheckPermissionResultSize`, `XblPrivacyCheckPermissionResult`, `XblPrivacyCheckPermissionForAnonymousUserAsync`, `XblPrivacyCheckPermissionForAnonymousUserResultSize`, `XblPrivacyCheckPermissionForAnonymousUserResult`, `XblPrivacyBatchCheckPermissionAsync`, `XblPrivacyBatchCheckPermissionResultSize`, `XblPrivacyBatchCheckPermissionResult`, `XblPrivacyGetAvoidListAsync`, `XblPrivacyGetAvoidListResultCount`, `XblPrivacyGetAvoidListResult`, `XblPrivacyGetMuteListAsync`, `XblPrivacyGetMuteListResultCount`, `XblPrivacyGetMuteListResult` | Permission checks against XUIDs or anonymous user types, batch permission checks, and avoid/mute list reads. |
 | `GDK.presence` | `XblPresenceSetPresenceAsync`, `XblPresenceGetPresenceAsync`, `XblPresenceGetPresenceResult`, `XblPresenceGetPresenceForMultipleUsersAsync`, `XblPresenceGetPresenceForMultipleUsersResultCount`, `XblPresenceGetPresenceForMultipleUsersResult`, `XblPresenceGetPresenceForSocialGroupAsync`, `XblPresenceGetPresenceForSocialGroupResultCount`, `XblPresenceGetPresenceForSocialGroupResult`, `XblPresenceAddDevicePresenceChangedHandler`, `XblPresenceRemoveDevicePresenceChangedHandler`, `XblPresenceAddTitlePresenceChangedHandler`, `XblPresenceRemoveTitlePresenceChangedHandler`, `XblPresenceTrackUsers`, `XblPresenceStopTrackingUsers`, `XblPresenceTrackAdditionalTitles`, `XblPresenceStopTrackingAdditionalTitles`, `XblPresenceRecordGetXuid`, `XblPresenceRecordGetUserState`, `XblPresenceRecordGetDeviceRecords`, `XblPresenceRecordCloseHandle` | Set/clear local presence, query presence records, track change notifications, and cache translated records. |
-| `GDK.social` | Social Manager APIs including `XblSocialManagerAddLocalUser`, `XblSocialManagerRemoveLocalUser`, `XblSocialManagerDoWork`, `XblSocialManagerCreateSocialUserGroupFromFilters`, `XblSocialManagerCreateSocialUserGroupFromList`, `XblSocialManagerDestroySocialUserGroup`, and `XblSocialManagerUserGroupGetUsers`; reputation APIs `XblSocialSubmitReputationFeedbackAsync` and `XblSocialSubmitBatchReputationFeedbackAsync` | Direct relationship REST-style wrappers are intentionally not exposed. |
+| `GDK.social` | Social Manager APIs including `XblSocialManagerAddLocalUser`, `XblSocialManagerRemoveLocalUser`, `XblSocialManagerDoWork`, `XblSocialManagerCreateSocialUserGroupFromFilters`, `XblSocialManagerCreateSocialUserGroupFromList`, `XblSocialManagerUpdateSocialUserGroup`, `XblSocialManagerDestroySocialUserGroup`, `XblSocialManagerUserGroupGetUsers`, and `XblSocialManagerSetRichPresencePollingStatus`; reputation APIs `XblSocialSubmitReputationFeedbackAsync` and `XblSocialSubmitBatchReputationFeedbackAsync` | Direct relationship REST-style wrappers are intentionally not exposed. |
 | `GDK.profile` | `XblProfileGetUserProfileAsync`, `XblProfileGetUserProfileResult`, `XblProfileGetUserProfilesAsync`, `XblProfileGetUserProfilesResultCount`, `XblProfileGetUserProfilesResult`, `XblProfileGetUserProfilesForSocialGroupAsync`, `XblProfileGetUserProfilesForSocialGroupResultCount`, `XblProfileGetUserProfilesForSocialGroupResult` | Query one profile, multiple profiles by XUID list, or profiles for a named social group. |
 | `GDK.string_verify` | `XblStringVerifyStringAsync`, `XblStringVerifyStringResultSize`, `XblStringVerifyStringResult`, `XblStringVerifyStringsAsync`, `XblStringVerifyStringsResultSize`, `XblStringVerifyStringsResult` | Verify one string or a batch of strings and return per-string result dictionaries. |
 | `GDK.title_storage` | `XblTitleStorageGetQuotaAsync`, `XblTitleStorageGetQuotaResult`, `XblTitleStorageGetBlobMetadataAsync`, `XblTitleStorageGetBlobMetadataResult`, `XblTitleStorageBlobMetadataResultGetItems`, `XblTitleStorageBlobMetadataResultHasNext`, `XblTitleStorageBlobMetadataResultGetNextAsync`, `XblTitleStorageBlobMetadataResultGetNextResult`, `XblTitleStorageBlobMetadataResultDuplicateHandle`, `XblTitleStorageBlobMetadataResultCloseHandle`, `XblTitleStorageDownloadBlobAsync`, `XblTitleStorageDownloadBlobResult`, `XblTitleStorageUploadBlobAsync`, `XblTitleStorageUploadBlobResult`, `XblTitleStorageDeleteBlobAsync` | Query quota, list paged metadata, download blobs via metadata discovery, upload bytes, and delete blobs. |
@@ -383,6 +385,9 @@ GDK.launcher: GDKLauncher
 GDK.capture: GDKCapture
 GDK.activation: GDKActivation
 GDK.multiplayer_activity: GDKMultiplayerActivity
+GDK.speech: GDKSpeechSynthesizer
+GDK.events: GDKEvents
+GDK.game_save: GDKGameSave
 ```
 
 #### Root signals
@@ -499,6 +504,32 @@ get_play_session_id() -> String
 | `set_play_session_id()` / `get_play_session_id()` | (wrapper-managed GUID) | Session-scoped GUID forwarded as `playSessionId` to `XGameEventWrite`. |
 
 > The alternate Xbox Services write path `XblEventsWriteInGameEvent` (`events_c.h`) is intentionally **not** wrapped; `XGameEventWrite` is the primary GDK path. The `XblEventsSet*` configuration/tuning functions remain internal-gated.
+
+#### `GDK.game_save` service
+
+##### Methods
+
+```gdscript
+get_folder_async(user: GDKUser) -> Signal      # GDKResult.data.path := absolute save-folder path
+get_remaining_quota(user: GDKUser) -> GDKResult # GDKResult.data.bytes := remaining quota in bytes
+```
+
+##### Behavior contract
+
+- `GDK.game_save` wraps the GDK-native file-style save API (`XGameSaveFiles.h`). It is distinct from PlayFab Game Saves (`godot_playfab`) and from Xbox Services Title Storage (`GDK.title_storage`).
+- The title must declare connected storage / a `SaveFolder` in its `MicrosoftGame.config`; without it the native calls fail and the wrapper returns the propagated `HRESULT` error.
+- `get_folder_async()` wraps `XGameSaveFilesGetFolderWithUiAsync`: it resolves (and may surface a system UI for) the user's save folder, returning the absolute path in `GDKResult.data.path`. Titles then read/write ordinary files under that folder.
+- `get_remaining_quota()` is synchronous and wraps `XGameSaveFilesGetRemainingQuota`, returning the remaining byte quota in `GDKResult.data.bytes`.
+- The service configuration id (SCID) is pulled from the cached `GDKXboxServices` state. Validation failures return `not_initialized`, `invalid_user`, or `xbox_services_uninitialized`.
+
+##### Native API mapping
+
+| Wrapper/API | Native API(s) | Notes |
+| --- | --- | --- |
+| `get_folder_async()` | `XGameSaveFilesGetFolderWithUiAsync`, `XGameSaveFilesGetFolderWithUiResult` | Returns the absolute save-folder path; may show a system UI. |
+| `get_remaining_quota()` | `XGameSaveFilesGetRemainingQuota` | Synchronous; returns remaining quota bytes. |
+
+> The richer `XGameSave.h` connected-storage container API (27 functions) is intentionally **not** wrapped: it is a more complex API than `XGameSaveFiles` and overlaps PlayFab Game Saves.
 
 #### `GDK.users` service
 
@@ -625,6 +656,7 @@ show_text_entry_async(title_text := "", description_text := "", default_text := 
 query_player_achievements_async(user: GDKUser) -> Signal
 update_achievement_async(user: GDKUser, achievement_id: String, percent_complete: int) -> Signal
 get_cached_achievements(user: GDKUser) -> Array
+get_achievements_by_state(user: GDKUser, progress_state: String) -> GDKResult  # data.achievements: Array[GDKAchievement]
 ```
 
 ##### Signals
@@ -651,6 +683,7 @@ runtime_error(result: GDKResult)  # unsolicited achievement-service errors
 | `query_player_achievements_async()` | `XblAchievementsManagerAddLocalUser`, `XblAchievementsManagerIsUserInitialized`, `XblAchievementsManagerDoWork`, `XblAchievementsManagerGetAchievements` | Treat this as a cache-warm operation: ensure the user is registered, wait until the manager reports the user initialized, then copy the cache into Godot objects before completing. |
 | `update_achievement_async()` | `XblAchievementsManagerUpdateAchievement`, `XblAchievementsManagerDoWork` | Resolve the returned completion signal only after the manager reports the updated achievement state on the dispatch thread. |
 | `get_cached_achievements()` | `XblAchievementsManagerGetAchievements` | Reads the current manager cache and translates it into Godot-facing achievement objects. |
+| `get_achievements_by_state()` | `XblAchievementsManagerGetAchievementsByState`, `XblAchievementsManagerResultGetAchievements`, `XblAchievementsManagerResultCloseHandle` | Filters the cached achievements by progress state (`Achieved`/`NotStarted`/`InProgress`/`Unknown`); returns `achievements_not_loaded` until the user's cache is warmed by `query_player_achievements_async()`. |
 | `achievement_unlocked` / `achievements_updated` | `XblAchievementsManagerDoWork` | These signals come from manager update events, not from a separate polling or REST-style query path. |
 
 The manager result handles should be copied into extension-owned data immediately on dispatch, because they are cache views rather than long-lived script-safe objects.
@@ -692,9 +725,12 @@ get_install_progress(package_identifier: String) -> GDKResult
 ```gdscript
 query_user_stats_async(user: GDKUser, stat_names := PackedStringArray()) -> Signal
 query_users_stats_async(user: GDKUser, xuids: PackedStringArray, stat_names := PackedStringArray()) -> Signal
+get_single_stat_async(user: GDKUser, stat_name: String) -> Signal
 set_stat_number(user: GDKUser, stat_name: String, value: float) -> GDKResult
 set_stat_integer(user: GDKUser, stat_name: String, value: int) -> GDKResult
 flush_stats_async(user: GDKUser) -> Signal
+write_stats_async(user: GDKUser, stats: Dictionary) -> Signal
+delete_stats_async(user: GDKUser, stat_names: PackedStringArray) -> Signal
 track_stats(user: GDKUser, stat_names: PackedStringArray) -> GDKResult
 stop_tracking_stats(user: GDKUser, stat_names := PackedStringArray()) -> GDKResult
 get_cached_stats(user: GDKUser) -> Dictionary
@@ -721,9 +757,12 @@ stats_flushed(user: GDKUser, result: GDKResult)
 | Wrapper/API | Native API(s) | Notes |
 | --- | --- | --- |
 | `query_user_stats_async()` | `XblUserStatisticsGetSingleUserStatisticsAsync`, `XblUserStatisticsGetSingleUserStatisticsResultSize`, `XblUserStatisticsGetSingleUserStatisticsResult` | Use explicit user-statistics reads for query-style fetches and cache refreshes. |
+| `get_single_stat_async()` | `XblUserStatisticsGetSingleUserStatisticAsync`, `XblUserStatisticsGetSingleUserStatisticResultSize`, `XblUserStatisticsGetSingleUserStatisticResult` | Reads one named stat for the signed-in user; returns the same result shape as the plural read with a single entry. |
 | `query_users_stats_async()` | `XblUserStatisticsGetMultipleUserStatisticsAsync`, `XblUserStatisticsGetMultipleUserStatisticsResultSize`, `XblUserStatisticsGetMultipleUserStatisticsResult` | Use one local user context to read the requested stats for a target XUID list. |
 | `set_stat_number()` / `set_stat_integer()` | extension-local staging only | Convert staged values into `XblTitleManagedStatistic` payloads. No native call is made until `flush_stats_async()`. |
-| `flush_stats_async()` | `XblTitleManagedStatsUpdateStatsAsync`, `XblTitleManagedStatistic`, `XblTitleManagedStatType` | Flushes staged values through the documented title-managed stats write API. If the wrapper later needs full-document replacement semantics, add a separate path that uses `XblTitleManagedStatsWriteAsync`. |
+| `flush_stats_async()` | `XblTitleManagedStatsUpdateStatsAsync`, `XblTitleManagedStatistic`, `XblTitleManagedStatType` | Flushes staged values through the documented title-managed stats write API (merge semantics). |
+| `write_stats_async()` | `XblTitleManagedStatsWriteAsync`, `XblTitleManagedStatistic`, `XblTitleManagedStatType` | Replace-all write: the supplied `stats` Dictionary becomes the complete title-managed stat document for the user. Live-write surface. |
+| `delete_stats_async()` | `XblTitleManagedStatsDeleteStatsAsync` | Deletes the named title-managed stats for the user. Live-write surface. |
 | `track_stats()` | `XblUserStatisticsAddStatisticChangedHandler`, `XblUserStatisticsTrackStatistics` | Register one change handler per local user context, then track the requested stats for that user's XUID. |
 | `stop_tracking_stats()` | `XblUserStatisticsStopTrackingStatistics`, `XblUserStatisticsStopTrackingUsers`, `XblUserStatisticsRemoveStatisticChangedHandler` | Stop specific stat tracking or all tracked stat updates for the local user. |
 | `get_cached_stats()` | service cache only | Cache ownership stays in the extension; it is hydrated by explicit reads and tracked-stat change callbacks. |
@@ -847,6 +886,8 @@ stop_social_graph(user: GDKUser) -> void
 get_friends_async(user: GDKUser) -> Signal
 create_social_group(user: GDKUser, filter: GDKSocialFilter = null) -> GDKResult  # data: GDKSocialGroup
 create_social_group_from_xuids(user: GDKUser, xuids: PackedStringArray) -> GDKResult  # data: GDKSocialGroup
+update_social_user_group(group: GDKSocialGroup, xuids: PackedStringArray) -> GDKResult  # data.count: int
+set_rich_presence_polling(user: GDKUser, enabled: bool) -> GDKResult  # data.enabled: bool
 destroy_social_group(group: GDKSocialGroup) -> void
 get_group_users(group: GDKSocialGroup) -> GDKResult  # data: Array[GDKSocialUser]
 submit_reputation_feedback_async(user: GDKUser, target_xuid: String, feedback_type: String, reason := "", evidence_id := "") -> Signal
@@ -878,8 +919,9 @@ runtime_error(result: GDKResult)  # unsolicited social-service errors
 | `get_friends_async()` | `XblSocialManagerCreateSocialUserGroupFromFilters`, `XblSocialManagerDoWork` | Treat this as a default friends-group bootstrap op that completes after the first group population event is observed. |
 | `create_social_group()` | `XblSocialManagerCreateSocialUserGroupFromFilters` | Filter-backed social groups map directly to native filtered groups. |
 | `create_social_group_from_xuids()` | `XblSocialManagerCreateSocialUserGroupFromList` | Fixed-list groups map directly to native list-backed groups. |
+| `update_social_user_group()` | `XblSocialManagerUpdateSocialUserGroup` | Replaces the tracked-user list of a list-based group with a new XUID set. Filter-based groups cannot be updated this way. |
+| `set_rich_presence_polling()` | `XblSocialManagerSetRichPresencePollingStatus`, `XblSocialManagerAddLocalUser` | Toggles Social Manager rich-presence polling for the user; starts the user's social graph first if needed. |
 | `destroy_social_group()` | `XblSocialManagerDestroySocialUserGroup` | Releases the native social-group handle. |
-| future mutable list groups | `XblSocialManagerUpdateSocialUserGroup` | Keep this internal until a public update-group API is justified. |
 | `get_group_users()` | `XblSocialManagerUserGroupGetUsers` | Reads the current user list from the native social group handle. |
 | `submit_reputation_feedback_async()` | `XblSocialSubmitReputationFeedbackAsync` | Submit one feedback item without exposing native MPSD session-reference structs. |
 | `submit_batch_reputation_feedback_async()` | `XblSocialSubmitBatchReputationFeedbackAsync`, `XblReputationFeedbackItem` | Batch items are Godot dictionaries with `target_xuid`, `feedback_type`, optional `reason`, and optional `evidence_id`. |

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -38,6 +38,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Capture | Implemented | `GDK.capture` wraps PC-supported `XAppCapture` metadata/state APIs; console-only paths excluded |
 | Display | Implemented | `GDK.display` wraps `XDisplay.h`: HDR mode probe/enable and idle display-timeout deferrals |
 | Game activation events | Implemented | `GDK.activation` wraps `XGameActivation.h` (modern replacement for the deprecated `XGameProtocol.h`) |
+| Text-to-speech | Implemented | `GDK.speech` wraps `XSpeechSynthesizer.h`: enumerate installed voices, select default/custom voice, and synthesize text/SSML to WAV/PCM bytes locally (no network) |
 | Events | Excluded | Do not wrap `events_c.h` Xbox Services telemetry/configuration APIs or the per-title `XGameEvent.h` writer; titles that need event telemetry should use PlayFab or a separate analytics integration |
 | Multiplayer/session/matchmaking | Excluded | Do not wrap matchmaking, MPSD, multiplayer sessions, lobby/session transport, or legacy invite APIs |
 | Store/commerce/licensing | Implemented (XStore-only) | Exposed via `GDK.store` using public XStore APIs; excluded from the Xbox Services coverage matrix below |
@@ -437,6 +438,39 @@ launch_uri(uri: String, user: GDKUser = null) -> GDKResult
 - Unsupported URI destinations reject with `unsupported_launcher_destination`.
 - Optional `user` must be a signed-in `GDKUser` when provided (`invalid_user`).
 
+#### `GDK.speech` service
+
+##### Methods
+
+```gdscript
+get_installed_voices() -> Array            # [{id, display_name, language, gender, description}, ...]
+set_default_voice() -> GDKResult
+set_custom_voice(voice_id: String) -> GDKResult
+synthesize_text(text: String) -> GDKResult        # data.audio_wav := PackedByteArray (RIFF/WAV), data.byte_count
+synthesize_ssml(ssml: String) -> GDKResult        # data.audio_wav := PackedByteArray (RIFF/WAV), data.byte_count
+synthesize_to_stream(text: String) -> AudioStreamWAV   # convenience; null on failure
+```
+
+##### Behavior contract
+
+- Synthesis runs locally on the device and produces WAV/PCM bytes with no network call, so it is headless-testable.
+- The service lazily creates a single native `XSpeechSynthesizer` the first time a voice is selected or speech is synthesized, and releases it on `GDK.shutdown`.
+- Voice selection (`set_default_voice` / `set_custom_voice`) applies to every subsequent `synthesize_*` call.
+- Empty input rejects with `invalid_input`; an empty voice id rejects with `invalid_voice_id`.
+- Calls before `GDK.initialize()` return a `not_initialized` error; a failure to create the synthesizer returns `speech_synthesizer_unavailable`.
+
+##### Native API mapping
+
+| Wrapper/API | Native API(s) | Notes |
+| --- | --- | --- |
+| `get_installed_voices()` | `XSpeechSynthesizerEnumerateInstalledVoices` | Collects `XSpeechSynthesizerVoiceInformation` rows into dictionaries. |
+| `set_default_voice()` | `XSpeechSynthesizerCreate`, `XSpeechSynthesizerSetDefaultVoice` | Creates the synthesizer lazily. |
+| `set_custom_voice()` | `XSpeechSynthesizerCreate`, `XSpeechSynthesizerSetCustomVoice` | Selects a voice by id. |
+| `synthesize_text()` | `XSpeechSynthesizerCreateStreamFromText`, `XSpeechSynthesizerGetStreamDataSize`, `XSpeechSynthesizerGetStreamData`, `XSpeechSynthesizerCloseStreamHandle` | Returns RIFF/WAV bytes in `GDKResult.data.audio_wav`. |
+| `synthesize_ssml()` | `XSpeechSynthesizerCreateStreamFromSsml`, `XSpeechSynthesizerGetStreamDataSize`, `XSpeechSynthesizerGetStreamData`, `XSpeechSynthesizerCloseStreamHandle` | SSML variant of `synthesize_text`. |
+| `synthesize_to_stream()` | (decodes the `synthesize_text` WAV bytes) | Parses the RIFF/WAV header and returns a ready-to-play `AudioStreamWAV`. |
+| service shutdown | `XSpeechSynthesizerCloseHandle` | Releases the cached synthesizer. |
+
 #### `GDK.users` service
 
 ##### Methods
@@ -525,6 +559,10 @@ set_notification_position_hint(position: String) -> GDKResult
 show_player_profile_card_async(requesting_user: GDKUser, target_xuid: String) -> Signal
 show_player_picker_async(requesting_user: GDKUser, prompt: String, selectable_xuids: PackedStringArray, preselected_xuids := PackedStringArray(), min_selection_count := 1, max_selection_count := 1) -> Signal
 resolve_privilege_with_ui_async(user: GDKUser, privilege: int) -> Signal
+show_achievements_async(requesting_user: GDKUser) -> Signal
+show_error_dialog_async(error_code: int, context := "") -> Signal
+show_send_game_invite_async(requesting_user: GDKUser, session_configuration_id: String, session_template_name: String, session_id: String, invitation_text := "", custom_activation_context := "") -> Signal
+show_text_entry_async(title_text := "", description_text := "", default_text := "", input_scope := "default", max_text_length := 0) -> Signal
 ```
 
 ##### Notes
@@ -543,6 +581,12 @@ resolve_privilege_with_ui_async(user: GDKUser, privilege: int) -> Signal
 | `show_player_profile_card_async()` | `XGameUiShowPlayerProfileCardAsync`, `XGameUiShowPlayerProfileCardResult` | Requires a signed-in `GDKUser` requesting handle and numeric target XUID. |
 | `show_player_picker_async()` | `XGameUiShowPlayerPickerAsync`, `XGameUiShowPlayerPickerResultCount`, `XGameUiShowPlayerPickerResult` | Validate XUID lists and selection ranges up front; return selected XUIDs in `GDKResult.data`. |
 | `resolve_privilege_with_ui_async()` | `XUserResolvePrivilegeWithUiAsync`, `XUserResolvePrivilegeWithUiResult` | Delegate to `GDK.users` privilege-remediation flow so existing users-service behavior remains authoritative. |
+| `show_achievements_async()` | `XGameUiShowAchievementsAsync`, `XGameUiShowAchievementsResult` | Title ID resolved via `XGameGetXboxTitleId`. Requires a signed-in `GDKUser`. |
+| `show_error_dialog_async()` | `XGameUiShowErrorDialogAsync`, `XGameUiShowErrorDialogResult` | Takes an HRESULT `error_code` plus optional `context` text. |
+| `show_send_game_invite_async()` | `XGameUiShowSendGameInviteAsync`, `XGameUiShowSendGameInviteResult` | Requires session configuration/template/id; optional invitation text and custom activation context. Title owns the MPSD session identifiers. |
+| `show_text_entry_async()` | `XGameUiShowTextEntryAsync`, `XGameUiShowTextEntryResultSize`, `XGameUiShowTextEntryResult` | Gamepad/virtual-keyboard text entry. `input_scope` maps to `XGameUiTextEntryInputScope`; returns the entered text in `GDKResult.data.text`. |
+
+> Excluded from `GDK.game_ui` (engine/host overlap): `XGameUiShowStateShareAsync` and `XGameUiShowWebAuthenticationAsync`/`WithOptions` — Godot already provides web-auth/state-share equivalents.
 
 #### `GDK.achievements` service
 

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -42,6 +42,7 @@ The core architectural rule is: **C++ is internal; GDScript is the primary publi
 | Events | Implemented | `GDK.events` wraps the per-title `XGameEvent.h` writer (`XGameEventWrite`) for GDK-native in-game telemetry. Complementary to PlayFab analytics. The `events_c.h` Xbox Services configuration/tuning APIs (`XblEventsSet*`) remain internal-gated and unwrapped |
 | Game Save (files) | Implemented | `GDK.game_save` wraps `XGameSaveFiles.h` (`XGameSaveFilesGetFolderWithUiAsync`, `XGameSaveFilesGetRemainingQuota`) for GDK-native file-style saves. Requires the title's `MicrosoftGame.config` connected-storage/SaveFolder config. The richer `XGameSave.h` connected-storage container API is intentionally left unwrapped (overlaps PlayFab Game Saves) |
 | Runtime feature probe | Implemented | `GDK.system.is_feature_available(name)` wraps `XGameRuntimeIsFeatureAvailable` (`XGameRuntimeFeature.h`) so titles can gate optional GDK features (e.g. Events, GameChat) at runtime |
+| Voice and text chat | Implemented | `GDK.game_chat` wraps the Game Chat 2 (`GameChat2.h`) `chat_manager` for GDK-native voice + text chat: user management, communication relationships, mute/volume controls, text, and text-to-speech. The wrapper exposes Game Chat's opaque data-frame surface (`outgoing_data_frame` signal + `process_incoming_data_frame`) and builds **no** network transport — titles ferry frames over their own transport (sample/tests use single-process loopback). This is the GDK-native alternative to PlayFab Party (`godot_playfab`) |
 | Multiplayer/session/matchmaking | Excluded | Do not wrap matchmaking, MPSD, multiplayer sessions, lobby/session transport, or legacy invite APIs |
 | Store/commerce/licensing | Implemented (XStore-only) | Exposed via `GDK.store` using public XStore APIs; excluded from the Xbox Services coverage matrix below |
 
@@ -388,6 +389,7 @@ GDK.multiplayer_activity: GDKMultiplayerActivity
 GDK.speech: GDKSpeechSynthesizer
 GDK.events: GDKEvents
 GDK.game_save: GDKGameSave
+GDK.game_chat: GDKGameChat
 ```
 
 #### Root signals
@@ -530,6 +532,67 @@ get_remaining_quota(user: GDKUser) -> GDKResult # GDKResult.data.bytes := remain
 | `get_remaining_quota()` | `XGameSaveFilesGetRemainingQuota` | Synchronous; returns remaining quota bytes. |
 
 > The richer `XGameSave.h` connected-storage container API (27 functions) is intentionally **not** wrapped: it is a more complex API than `XGameSaveFiles` and overlaps PlayFab Game Saves.
+
+#### `GDK.game_chat` service
+
+##### Methods
+
+```gdscript
+initialize(max_users := 16, default_relationship := GDKGameChat.RELATIONSHIP_SEND_AND_RECEIVE_ALL) -> GDKResult
+is_initialized() -> bool
+cleanup() -> void
+add_local_user(user: GDKUser) -> GDKResult                                  # GDKResult.data.xuid
+add_remote_user(xuid: String, endpoint_id: int) -> GDKResult               # GDKResult.data := {xuid, endpoint_id}
+remove_user(xuid: String) -> GDKResult
+set_communication_relationship(local_xuid, target_xuid, relationship: int) -> GDKResult
+set_microphone_muted(local_xuid: String, muted: bool) -> GDKResult
+set_remote_user_muted(local_xuid: String, target_xuid: String, muted: bool) -> GDKResult
+set_audio_render_volume(local_xuid: String, target_xuid: String, volume: float) -> GDKResult
+send_text(local_xuid: String, text: String) -> GDKResult
+synthesize_text_to_speech(local_xuid: String, text: String) -> GDKResult
+process_incoming_data_frame(source_endpoint_id: int, bytes: PackedByteArray) -> GDKResult
+get_chat_users() -> Array          # [{xuid, is_local, chat_indicator}]
+```
+
+##### Signals
+
+```gdscript
+outgoing_data_frame(target_endpoint_ids: PackedInt64Array, bytes: PackedByteArray, transport_requirement: int)
+text_chat_received(sender_xuid: String, message: String)
+transcribed_chat_received(speaker_xuid: String, message: String)
+```
+
+##### Behavior contract
+
+- `GDK.game_chat` wraps the Game Chat 2 (`GameChat2.h`) C++ `chat_manager` singleton. It is the GDK-native voice + text chat option; PlayFab Party (`godot_playfab`) is the batteries-included alternative that owns its own transport.
+- **No transport is built or selected.** Game Chat encodes its own opaque audio/text data frames; the wrapper exposes that surface only. During the per-frame pump (driven by `GDK.dispatch()`), each frame Game Chat wants to send is emitted on `outgoing_data_frame`; the title delivers those bytes over whatever transport it already has and calls `process_incoming_data_frame()` on each receiving instance. The sample and tests demonstrate this with single-process **loopback** (feeding each `outgoing_data_frame` straight back into `process_incoming_data_frame`).
+- `initialize()` requires the GDK runtime to be initialized; it then initializes the `chat_manager` for `max_users` combined local + remote users with `default_relationship` between new users. Re-initializing without `cleanup()` first returns `already_initialized`; `max_users <= 0` returns `invalid_max_users`.
+- `add_local_user()` requires a signed-in `GDKUser` (its decimal XUID); remote users are added by XUID + a title-assigned `endpoint_id` used to address outgoing frames and attribute incoming ones.
+- Independent voice and text control mirrors PlayFab Party: `set_communication_relationship()` takes a bitwise combination of `GDKGameChat.CommunicationRelationship` flags (separate send/receive bits for microphone, text-to-speech audio, and text), and `set_microphone_muted()` / `set_remote_user_muted()` / `set_audio_render_volume()` provide per-user mute and volume.
+- Inbound text and transcription surface on `text_chat_received` / `transcribed_chat_received` during the pump. `shutdown()` calls `cleanup()` automatically.
+- Real voice capture/render requires multi-machine audio hardware and cannot be validated headlessly (mirrors the Party "voice deferred" stance); headless coverage exercises the service surface, enum constants, lifecycle, and data-frame plumbing.
+
+##### Native API mapping
+
+| Wrapper/API | Native API(s) | Notes |
+| --- | --- | --- |
+| `initialize()` | `chat_manager::initialize` | Sets max users and the default local↔remote relationship. |
+| `cleanup()` / service shutdown | `chat_manager::cleanup` | Releases all Game Chat resources. |
+| `add_local_user()` | `chat_manager::add_local_user` | Adds a signed-in user's XUID as a local chat user. |
+| `add_remote_user()` | `chat_manager::add_remote_user` | Adds a remote XUID reachable on a title-assigned endpoint id. |
+| `remove_user()` | `chat_manager::get_chat_users`, `chat_manager::remove_user` | Locates the user by XUID, then removes it. |
+| `set_communication_relationship()` | `chat_user::chat_user_local::set_communication_relationship` | Bitwise `game_chat_communication_relationship_flags`. |
+| `set_microphone_muted()` | `chat_user::chat_user_local::set_microphone_muted` | Local microphone mute. |
+| `set_remote_user_muted()` | `chat_user::chat_user_local::set_remote_user_muted` | Per-remote-user mute for a local user. |
+| `set_audio_render_volume()` | `chat_user::chat_user_local::set_audio_render_volume` | Per-remote render volume. |
+| `send_text()` | `chat_user::chat_user_local::send_chat_text` | 1–1023 character chat text. |
+| `synthesize_text_to_speech()` | `chat_user::chat_user_local::synthesize_text_to_speech` | TTS-as-microphone for the local user. |
+| `process_incoming_data_frame()` | `chat_manager::process_incoming_data` | Hands a received frame to Game Chat by source endpoint id. |
+| `get_chat_users()` | `chat_manager::get_chat_users`, `chat_user::xbox_user_id`, `chat_user::local`, `chat_user::chat_indicator` | Snapshots current users into dictionaries. |
+| `outgoing_data_frame` (pump) | `chat_manager::start_processing_data_frames`, `chat_manager::finish_processing_data_frames` | Emits each frame's targets, bytes, and transport requirement. |
+| `text_chat_received` / `transcribed_chat_received` (pump) | `chat_manager::start_processing_state_changes`, `chat_manager::finish_processing_state_changes` | Drains text + transcription state changes. |
+
+> Game Chat 2 ships in its own `GameChat2.lib`/`GameChat2.dll`. The wrapper links `Xbox::GameChat2` and includes `GameChat2Impl.h` in exactly one translation unit (the class methods are defined out-of-line there). No network transport is part of this addon.
 
 #### `GDK.users` service
 

--- a/tests/godot/gdk/tests/test_achievements.gd
+++ b/tests/godot/gdk/tests/test_achievements.gd
@@ -22,7 +22,7 @@ func test_achievements_full_flow() -> void:
 	if achievements == null:
 		return
 
-	for method_name in ["query_player_achievements_async", "update_achievement_async", "get_cached_achievements"]:
+	for method_name in ["query_player_achievements_async", "update_achievement_async", "get_cached_achievements", "get_achievements_by_state"]:
 		assert_has_method_named(achievements, method_name)
 
 	for signal_name in ["achievement_unlocked", "achievements_updated"]:
@@ -83,3 +83,51 @@ func test_achievements_full_flow() -> void:
 			assert_true(query_result.code.length() > 0, "achievement query failure exposes an error code")
 			assert_true(query_result.message.length() > 0, "achievement query failure exposes an error message")
 			pending("Achievement cache assertions: %s" % query_result.message)
+
+
+func test_get_achievements_by_state_validation() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var achievements = gdk.get_achievements()
+	assert_not_null(achievements, "GDK.achievements returns service object")
+	if achievements == null:
+		return
+
+	# progress_state is validated before any runtime/user state, so an invalid
+	# state is rejected deterministically without a signed-in user.
+	var invalid_state = achievements.get_achievements_by_state(null, "not-a-state")
+	assert_result_error(invalid_state, "invalid_progress_state", "get_achievements_by_state() rejects unknown progress states")
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for achievements-by-state validation returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Achievements-by-state validation: %s" % init_result.message)
+		return
+
+	var sign_in = await ensure_primary_user()
+	var user = sign_in["user"]
+	var sign_in_result = sign_in["result"]
+	if user == null:
+		if sign_in_result != null and not sign_in_result.ok:
+			pending("Achievements-by-state signed-in validation: %s" % sign_in_result.message)
+		else:
+			pending("Achievements-by-state signed-in validation: No signed-in user is available on this machine.")
+		return
+
+	# A valid progress state with a freshly-registered user that has not been
+	# queried yet reports achievements_not_loaded.
+	var not_loaded = achievements.get_achievements_by_state(user, "Achieved")
+	assert_not_null(not_loaded, "get_achievements_by_state() returns GDKResult for a signed-in user")
+	if not_loaded == null:
+		return
+	if not_loaded.ok:
+		assert_dict_has_key(not_loaded.data, "achievements", "get_achievements_by_state() success data exposes achievements")
+		assert_dict_has_key(not_loaded.data, "progress_state", "get_achievements_by_state() success data exposes progress_state")
+		assert_true(not_loaded.data["achievements"] is Array, "get_achievements_by_state() achievements payload is an Array")
+	else:
+		assert_true(not_loaded.code.length() > 0, "get_achievements_by_state() failure exposes an error code")
+		assert_true(not_loaded.message.length() > 0, "get_achievements_by_state() failure exposes an error message")

--- a/tests/godot/gdk/tests/test_events.gd
+++ b/tests/godot/gdk/tests/test_events.gd
@@ -1,0 +1,70 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+
+func before_each() -> void:
+	reset_runtime()
+
+
+func after_each() -> void:
+	reset_runtime()
+
+
+func test_events_surface_and_validation_paths() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var events = gdk.get_events()
+	assert_not_null(events, "GDK.events returns service object")
+	if events == null:
+		return
+
+	for method_name in [
+		"write_event",
+		"set_play_session_id",
+		"get_play_session_id",
+	]:
+		assert_has_method_named(events, method_name)
+
+	var blank_user = instantiate_class("GDKUser")
+
+	var pre_init_result = events.write_event(blank_user, "LevelComplete")
+	assert_result_error(pre_init_result, "not_initialized", "write_event() rejects calls before GDK.initialize()")
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for events behavior returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Events runtime behavior: %s" % init_result.message)
+		return
+
+	assert_result_error(events.write_event(blank_user, "  "), "invalid_event_name", "write_event() rejects blank event names")
+	assert_result_error(events.write_event(null, "LevelComplete"), "invalid_user", "write_event() requires a signed-in user")
+
+
+func test_events_play_session_id_round_trips() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var init_result = initialize_runtime()
+	if init_result == null or not init_result.ok:
+		pending("Events runtime unavailable")
+		return
+
+	var gdk = get_gdk()
+	var events = gdk.get_events()
+	if events == null:
+		return
+
+	var generated = events.get_play_session_id()
+	assert_typeof(generated, TYPE_STRING, "get_play_session_id() returns a String")
+	assert_gt(generated.length(), 0, "play_session_id is auto-generated and non-empty")
+
+	events.set_play_session_id("custom-session-1234")
+	assert_eq(events.get_play_session_id(), "custom-session-1234", "set_play_session_id() stores the provided id")
+
+	events.set_play_session_id("")
+	var regenerated = events.get_play_session_id()
+	assert_gt(regenerated.length(), 0, "empty set_play_session_id() regenerates a fresh GUID")
+	assert_ne(regenerated, "custom-session-1234", "regenerated play_session_id differs from the custom id")

--- a/tests/godot/gdk/tests/test_game_chat.gd
+++ b/tests/godot/gdk/tests/test_game_chat.gd
@@ -206,7 +206,26 @@ func test_game_chat_text_loopback_when_user_available() -> void:
 	# Loopback: feed the captured frame back in as if it arrived from the peer.
 	var frame: Dictionary = captured_frames[0]
 	assert_true(frame["bytes"].size() > 0, "outgoing_data_frame carries a non-empty payload")
+
+	var received: Array = []
+	var on_text := func(sender_xuid, message):
+		received.append({ "sender": sender_xuid, "message": message })
+	game_chat.text_chat_received.connect(on_text)
+
 	var round_trip = game_chat.process_incoming_data_frame(REMOTE_ENDPOINT, frame["bytes"])
 	assert_result_ok(round_trip, "process_incoming_data_frame() accepts a looped-back frame")
+
+	# Pump a few frames so the state-change pump surfaces text_chat_received.
+	for _i in range(30):
+		await get_tree().process_frame
+		if not received.is_empty():
+			break
+
+	game_chat.text_chat_received.disconnect(on_text)
+
+	assert_false(received.is_empty(), "text_chat_received fires for the looped-back text frame")
+	if not received.is_empty():
+		assert_eq(received[0]["message"], "loopback hello", "text_chat_received delivers the original message text")
+		assert_false(String(received[0]["sender"]).is_empty(), "text_chat_received reports a non-empty sender XUID")
 
 	game_chat.cleanup()

--- a/tests/godot/gdk/tests/test_game_chat.gd
+++ b/tests/godot/gdk/tests/test_game_chat.gd
@@ -1,0 +1,212 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+# Game Chat 2 (GDK.game_chat) coverage. Game Chat encodes its own opaque data
+# frames and does not pick a transport; the wrapper exposes that surface via the
+# outgoing_data_frame signal + process_incoming_data_frame. Real voice/text
+# delivery needs signed-in users and multi-machine audio, so headless runs cover
+# the service surface, enum constants, lifecycle, and argument validation; the
+# signed-in loopback path degrades to pending on hosts without an Xbox user.
+
+const REMOTE_XUID := "2814639011419087"
+const REMOTE_ENDPOINT := 1001
+
+
+func before_each() -> void:
+	reset_runtime()
+
+
+func after_each() -> void:
+	var gdk = get_gdk()
+	if gdk != null:
+		var game_chat = gdk.get_game_chat()
+		if game_chat != null and game_chat.is_initialized():
+			game_chat.cleanup()
+	reset_runtime()
+
+
+func test_game_chat_surface_and_constants() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var game_chat = gdk.get_game_chat()
+	assert_not_null(game_chat, "GDK.game_chat returns service object")
+	if game_chat == null:
+		return
+
+	for method_name in [
+		"initialize",
+		"is_initialized",
+		"cleanup",
+		"add_local_user",
+		"add_remote_user",
+		"remove_user",
+		"set_communication_relationship",
+		"set_microphone_muted",
+		"set_remote_user_muted",
+		"set_audio_render_volume",
+		"send_text",
+		"synthesize_text_to_speech",
+		"process_incoming_data_frame",
+		"get_chat_users",
+	]:
+		assert_has_method_named(game_chat, method_name)
+
+	for signal_name in [
+		"outgoing_data_frame",
+		"text_chat_received",
+		"transcribed_chat_received",
+	]:
+		assert_has_signal_named(game_chat, signal_name)
+
+	# Communication-relationship flags compose as documented in GDKGameChat.xml.
+	assert_eq(get_class_constant("GDKGameChat", "RELATIONSHIP_NONE"), 0, "RELATIONSHIP_NONE == 0")
+	assert_eq(get_class_constant("GDKGameChat", "RELATIONSHIP_SEND_ALL"), 7, "RELATIONSHIP_SEND_ALL == 7")
+	assert_eq(get_class_constant("GDKGameChat", "RELATIONSHIP_RECEIVE_ALL"), 24, "RELATIONSHIP_RECEIVE_ALL == 24")
+	assert_eq(get_class_constant("GDKGameChat", "RELATIONSHIP_SEND_AND_RECEIVE_ALL"), 31, "RELATIONSHIP_SEND_AND_RECEIVE_ALL == 31")
+	assert_eq(get_class_constant("GDKGameChat", "TRANSPORT_GUARANTEED"), 0, "TRANSPORT_GUARANTEED == 0")
+	assert_eq(get_class_constant("GDKGameChat", "TRANSPORT_BEST_EFFORT"), 1, "TRANSPORT_BEST_EFFORT == 1")
+	assert_eq(get_class_constant("GDKGameChat", "CHAT_INDICATOR_SILENT"), 0, "CHAT_INDICATOR_SILENT == 0")
+	assert_eq(get_class_constant("GDKGameChat", "CHAT_INDICATOR_NO_MICROPHONE"), 7, "CHAT_INDICATOR_NO_MICROPHONE == 7")
+
+
+func test_game_chat_rejects_calls_before_initialize() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var game_chat = get_gdk().get_game_chat()
+	if game_chat == null:
+		return
+
+	assert_false(game_chat.is_initialized(), "is_initialized() is false before initialize()")
+	assert_eq(game_chat.get_chat_users().size(), 0, "get_chat_users() is empty before initialize()")
+
+	assert_result_error(game_chat.initialize(), "not_initialized", "initialize() requires GDK.initialize() first")
+	assert_result_error(game_chat.add_remote_user(REMOTE_XUID, REMOTE_ENDPOINT), "not_initialized", "add_remote_user() requires initialize()")
+	assert_result_error(game_chat.remove_user(REMOTE_XUID), "not_initialized", "remove_user() requires initialize()")
+	assert_result_error(game_chat.send_text(REMOTE_XUID, "hello"), "not_initialized", "send_text() requires initialize()")
+	assert_result_error(game_chat.process_incoming_data_frame(REMOTE_ENDPOINT, PackedByteArray([1, 2, 3])), "not_initialized", "process_incoming_data_frame() requires initialize()")
+
+
+func test_game_chat_lifecycle_and_validation_paths() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for game chat returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Game chat runtime behavior: %s" % init_result.message)
+		return
+
+	var game_chat = get_gdk().get_game_chat()
+	if game_chat == null:
+		return
+
+	# Lifecycle: initialize -> already_initialized -> cleanup -> invalid_max_users -> re-initialize.
+	assert_false(game_chat.is_initialized(), "is_initialized() is false until initialize() succeeds")
+	assert_result_ok(game_chat.initialize(), "initialize() succeeds once the runtime is ready")
+	assert_true(game_chat.is_initialized(), "is_initialized() is true after initialize()")
+	assert_result_error(game_chat.initialize(), "already_initialized", "initialize() is rejected while already initialized")
+
+	game_chat.cleanup()
+	assert_false(game_chat.is_initialized(), "is_initialized() is false after cleanup()")
+	assert_result_error(game_chat.initialize(0), "invalid_max_users", "initialize() rejects non-positive max_users")
+	assert_result_ok(game_chat.initialize(), "initialize() succeeds again after cleanup()")
+
+	# Remote users can be added without sign-in (they carry no local audio).
+	assert_result_error(game_chat.add_remote_user("", REMOTE_ENDPOINT), "invalid_xuid", "add_remote_user() rejects an empty xuid")
+	var add_remote = game_chat.add_remote_user(REMOTE_XUID, REMOTE_ENDPOINT)
+	assert_result_ok(add_remote, "add_remote_user() adds a remote chat user")
+	if add_remote.ok:
+		assert_dict_has_key(add_remote.data, "xuid", "add_remote_user() data exposes xuid")
+		assert_dict_has_key(add_remote.data, "endpoint_id", "add_remote_user() data exposes endpoint_id")
+
+	var users = game_chat.get_chat_users()
+	var found_remote := false
+	for entry in users:
+		if entry.get("xuid", "") == REMOTE_XUID:
+			found_remote = true
+			assert_false(entry.get("is_local", true), "remote chat user reports is_local == false")
+			assert_dict_has_key(entry, "chat_indicator", "chat user entry exposes chat_indicator")
+	assert_true(found_remote, "get_chat_users() lists the added remote user")
+
+	# Argument validation against an initialized manager.
+	var send_all := get_class_constant("GDKGameChat", "RELATIONSHIP_SEND_ALL")
+	assert_result_error(game_chat.set_communication_relationship("unknown-local", REMOTE_XUID, send_all), "user_not_found", "set_communication_relationship() rejects an unknown local user")
+	assert_result_error(game_chat.set_microphone_muted("unknown-local", true), "user_not_found", "set_microphone_muted() rejects an unknown local user")
+	assert_result_error(game_chat.set_microphone_muted(REMOTE_XUID, true), "not_local_user", "set_microphone_muted() rejects a remote user")
+	assert_result_error(game_chat.send_text(REMOTE_XUID, ""), "invalid_text", "send_text() rejects empty text")
+	assert_result_error(game_chat.send_text("unknown-local", "hello"), "user_not_found", "send_text() rejects an unknown local user")
+	assert_result_error(game_chat.process_incoming_data_frame(REMOTE_ENDPOINT, PackedByteArray()), "invalid_data", "process_incoming_data_frame() rejects an empty payload")
+
+	assert_result_error(game_chat.remove_user("unknown-user"), "user_not_found", "remove_user() rejects an unknown user")
+	assert_result_ok(game_chat.remove_user(REMOTE_XUID), "remove_user() removes the remote user")
+	assert_eq(game_chat.get_chat_users().size(), 0, "get_chat_users() is empty after removing the remote user")
+
+	game_chat.cleanup()
+
+
+func test_game_chat_text_loopback_when_user_available() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var init_result = initialize_runtime()
+	if init_result == null or not init_result.ok:
+		pending("Game chat runtime unavailable")
+		return
+
+	var game_chat = get_gdk().get_game_chat()
+	if game_chat == null:
+		return
+
+	var sign_in = await ensure_primary_user()
+	var user = sign_in["user"]
+	if user == null:
+		pending("Game chat loopback coverage: no signed-in Xbox user is available on this machine.")
+		return
+
+	assert_result_ok(game_chat.initialize(), "initialize() succeeds for loopback coverage")
+
+	var add_local = game_chat.add_local_user(user)
+	assert_result_ok(add_local, "add_local_user() adds the signed-in user")
+	if not add_local.ok:
+		game_chat.cleanup()
+		return
+	var local_xuid: String = add_local.data.get("xuid", "")
+
+	assert_result_ok(game_chat.add_remote_user(REMOTE_XUID, REMOTE_ENDPOINT), "add_remote_user() adds the loopback peer")
+
+	var captured_frames: Array = []
+	var on_frame := func(target_endpoint_ids, bytes, transport_requirement):
+		captured_frames.append({
+			"targets": target_endpoint_ids,
+			"bytes": bytes,
+			"transport": transport_requirement,
+		})
+	game_chat.outgoing_data_frame.connect(on_frame)
+
+	assert_result_ok(game_chat.send_text(local_xuid, "loopback hello"), "send_text() queues a chat text frame")
+
+	# The per-frame pump runs via GDK.dispatch() on the embedded frame callback;
+	# give it a few frames to surface the encoded outgoing data frame.
+	for _i in range(30):
+		await get_tree().process_frame
+		if not captured_frames.is_empty():
+			break
+
+	game_chat.outgoing_data_frame.disconnect(on_frame)
+
+	if captured_frames.is_empty():
+		pending("Game chat did not emit an outgoing data frame for the local user on this host.")
+		game_chat.cleanup()
+		return
+
+	# Loopback: feed the captured frame back in as if it arrived from the peer.
+	var frame: Dictionary = captured_frames[0]
+	assert_true(frame["bytes"].size() > 0, "outgoing_data_frame carries a non-empty payload")
+	var round_trip = game_chat.process_incoming_data_frame(REMOTE_ENDPOINT, frame["bytes"])
+	assert_result_ok(round_trip, "process_incoming_data_frame() accepts a looped-back frame")
+
+	game_chat.cleanup()

--- a/tests/godot/gdk/tests/test_game_save.gd
+++ b/tests/godot/gdk/tests/test_game_save.gd
@@ -1,0 +1,87 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+
+func before_each() -> void:
+	reset_runtime()
+
+
+func after_each() -> void:
+	reset_runtime()
+
+
+func test_game_save_surface_and_validation_paths() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var game_save = gdk.get_game_save()
+	assert_not_null(game_save, "GDK.game_save returns service object")
+	if game_save == null:
+		return
+
+	for method_name in [
+		"get_folder_async",
+		"get_remaining_quota",
+	]:
+		assert_has_method_named(game_save, method_name)
+
+	var pre_init_quota = game_save.get_remaining_quota(null)
+	assert_result_error(pre_init_quota, "not_initialized", "get_remaining_quota() rejects calls before GDK.initialize()")
+
+	var pre_init_folder = game_save.get_folder_async(null)
+	await assert_signal_result_error(pre_init_folder, "not_initialized", "get_folder_async() rejects calls before GDK.initialize()")
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for game save behavior returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Game save runtime behavior: %s" % init_result.message)
+		return
+
+	var invalid_quota = game_save.get_remaining_quota(null)
+	assert_result_error(invalid_quota, "invalid_user", "get_remaining_quota() rejects null users after initialize")
+
+	var invalid_folder = game_save.get_folder_async(null)
+	await assert_signal_result_error(invalid_folder, "invalid_user", "get_folder_async() rejects null users after initialize")
+
+
+func test_game_save_folder_and_quota_when_user_available() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var init_result = initialize_runtime()
+	if init_result == null or not init_result.ok:
+		pending("Game save runtime unavailable")
+		return
+
+	var gdk = get_gdk()
+	var game_save = gdk.get_game_save()
+	if game_save == null:
+		return
+
+	var sign_in = await ensure_primary_user()
+	var user = sign_in["user"]
+	if user == null:
+		pending("Game save folder/quota coverage: no signed-in Xbox user is available on this machine.")
+		return
+
+	var quota_result = game_save.get_remaining_quota(user)
+	assert_not_null(quota_result, "get_remaining_quota() returns GDKResult for a signed-in user")
+	if quota_result == null:
+		return
+	if quota_result.ok:
+		assert_dict_has_key(quota_result.data, "bytes", "get_remaining_quota() success data exposes bytes")
+	else:
+		assert_true(quota_result.code.length() > 0, "get_remaining_quota() failure exposes an error code")
+		assert_true(quota_result.message.length() > 0, "get_remaining_quota() failure exposes an error message")
+
+	var folder_result = await await_completion(game_save.get_folder_async(user))
+	assert_not_null(folder_result, "get_folder_async() completes with a GDKResult for a signed-in user")
+	if folder_result == null:
+		return
+	if folder_result.ok:
+		assert_dict_has_key(folder_result.data, "path", "get_folder_async() success data exposes path")
+	else:
+		assert_true(folder_result.code.length() > 0, "get_folder_async() failure exposes an error code")
+		assert_true(folder_result.message.length() > 0, "get_folder_async() failure exposes an error message")

--- a/tests/godot/gdk/tests/test_game_ui.gd
+++ b/tests/godot/gdk/tests/test_game_ui.gd
@@ -25,10 +25,26 @@ func test_game_ui_surface_and_validation() -> void:
 		"show_player_profile_card_async",
 		"show_player_picker_async",
 		"resolve_privilege_with_ui_async",
+		"show_achievements_async",
+		"show_error_dialog_async",
+		"show_send_game_invite_async",
+		"show_text_entry_async",
 	]:
 		assert_has_method_named(game_ui, method_name)
 
 	var blank_user = instantiate_class("GDKUser")
+
+	var not_initialized_achievements_signal = game_ui.show_achievements_async(blank_user)
+	await assert_signal_result_error(not_initialized_achievements_signal, "not_initialized", "show_achievements_async() requires initialized runtime")
+
+	var not_initialized_error_dialog_signal = game_ui.show_error_dialog_async(-2147467259)
+	await assert_signal_result_error(not_initialized_error_dialog_signal, "not_initialized", "show_error_dialog_async() requires initialized runtime")
+
+	var not_initialized_text_entry_signal = game_ui.show_text_entry_async("Title", "Description")
+	await assert_signal_result_error(not_initialized_text_entry_signal, "not_initialized", "show_text_entry_async() requires initialized runtime")
+
+	var invalid_session_invite_signal = game_ui.show_send_game_invite_async(blank_user, "", "", "")
+	await assert_signal_result_error(invalid_session_invite_signal, "invalid_session", "show_send_game_invite_async() rejects empty session identifiers")
 
 	var empty_title_signal = game_ui.show_message_dialog_async("", "Body")
 	await assert_signal_result_error(empty_title_signal, "invalid_title", "show_message_dialog_async() rejects empty title")
@@ -83,6 +99,12 @@ func test_game_ui_surface_and_validation() -> void:
 
 	var invalid_user_privilege_signal = game_ui.resolve_privilege_with_ui_async(blank_user, 254)
 	await assert_signal_result_error(invalid_user_privilege_signal, "invalid_user", "resolve_privilege_with_ui_async() rejects invalid users")
+
+	var invalid_user_achievements_signal = game_ui.show_achievements_async(blank_user)
+	await assert_signal_result_error(invalid_user_achievements_signal, "invalid_user", "show_achievements_async() rejects invalid users")
+
+	var invalid_user_invite_signal = game_ui.show_send_game_invite_async(blank_user, "scid", "MinGameSession", "session-1")
+	await assert_signal_result_error(invalid_user_invite_signal, "invalid_user", "show_send_game_invite_async() rejects invalid users")
 
 
 func test_game_ui_show_method_fails_after_shutdown() -> void:

--- a/tests/godot/gdk/tests/test_social.gd
+++ b/tests/godot/gdk/tests/test_social.gd
@@ -28,6 +28,8 @@ func test_social_full_flow() -> void:
 		"get_friends_async",
 		"create_social_group",
 		"create_social_group_from_xuids",
+		"update_social_user_group",
+		"set_rich_presence_polling",
 		"destroy_social_group",
 		"get_group_users",
 		"submit_reputation_feedback_async",
@@ -210,3 +212,61 @@ func test_social_full_flow() -> void:
 
 	disconnect_signal_handlers(gdk, ["runtime_error"])
 	disconnect_signal_handlers(social, ["runtime_error"])
+
+
+func test_social_group_update_and_rich_presence_validation() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var social = gdk.get_social()
+	assert_not_null(social, "GDK.social returns service object")
+	if social == null:
+		return
+
+	# update_social_user_group() validates the group handle before any runtime
+	# state, so a blank group is rejected deterministically.
+	var blank_group = instantiate_class("GDKSocialGroup")
+	var blank_update = social.update_social_user_group(blank_group, PackedStringArray(["1"]))
+	assert_result_error(blank_update, "invalid_social_group", "update_social_user_group() rejects an unloaded social group")
+	var null_update = social.update_social_user_group(null, PackedStringArray(["1"]))
+	assert_result_error(null_update, "invalid_social_group", "update_social_user_group(null) is rejected")
+
+	# set_rich_presence_polling() requires the runtime to be initialized first.
+	var pre_init_polling = social.set_rich_presence_polling(null, true)
+	assert_result_error(pre_init_polling, "not_initialized", "set_rich_presence_polling() rejects calls before GDK.initialize()")
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for social group/polling validation returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Social group/polling validation: %s" % init_result.message)
+		return
+
+	var invalid_polling = social.set_rich_presence_polling(null, true)
+	assert_result_error(invalid_polling, "invalid_user", "set_rich_presence_polling() rejects null users after initialize")
+
+	var sign_in = await ensure_primary_user()
+	var user = sign_in["user"]
+	var sign_in_result = sign_in["result"]
+	if user == null:
+		if sign_in_result != null and not sign_in_result.ok:
+			pending("Social rich-presence signed-in validation: %s" % sign_in_result.message)
+		else:
+			pending("Social rich-presence signed-in validation: No signed-in user is available on this machine.")
+		return
+
+	var polling_result = social.set_rich_presence_polling(user, true)
+	assert_not_null(polling_result, "set_rich_presence_polling() returns GDKResult for a signed-in user")
+	if polling_result == null:
+		return
+	if polling_result.ok:
+		assert_dict_has_key(polling_result.data, "enabled", "set_rich_presence_polling() success data exposes enabled")
+		assert_eq(polling_result.data["enabled"], true, "set_rich_presence_polling() echoes the requested state")
+		social.set_rich_presence_polling(user, false)
+		social.stop_social_graph(user)
+	else:
+		assert_true(polling_result.code.length() > 0, "set_rich_presence_polling() failure exposes an error code")
+		assert_true(polling_result.message.length() > 0, "set_rich_presence_polling() failure exposes an error message")
+		pending("Social rich-presence behavior: %s" % polling_result.message)

--- a/tests/godot/gdk/tests/test_speech.gd
+++ b/tests/godot/gdk/tests/test_speech.gd
@@ -1,0 +1,81 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+
+
+func before_each() -> void:
+	reset_runtime()
+
+
+func after_each() -> void:
+	reset_runtime()
+
+
+func test_speech_surface_and_validation_paths() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var speech = gdk.get_speech()
+	assert_not_null(speech, "GDK.speech returns service object")
+	if speech == null:
+		return
+
+	for method_name in [
+		"get_installed_voices",
+		"set_default_voice",
+		"set_custom_voice",
+		"synthesize_text",
+		"synthesize_ssml",
+		"synthesize_to_stream",
+	]:
+		assert_has_method_named(speech, method_name)
+
+	var pre_init_result = speech.synthesize_text("hello")
+	assert_result_error(pre_init_result, "not_initialized", "synthesize_text() rejects calls before GDK.initialize()")
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for speech behavior returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Speech runtime behavior: %s" % init_result.message)
+		return
+
+	assert_result_error(speech.synthesize_text(""), "invalid_input", "synthesize_text('') rejects blank text")
+	assert_result_error(speech.synthesize_ssml("   "), "invalid_input", "synthesize_ssml() rejects whitespace input")
+	assert_result_error(speech.set_custom_voice(""), "invalid_voice_id", "set_custom_voice('') rejects blank voice id")
+
+	var voices = speech.get_installed_voices()
+	assert_typeof(voices, TYPE_ARRAY, "get_installed_voices() returns an Array")
+
+
+func test_speech_synthesis_produces_audio_when_available() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var init_result = initialize_runtime()
+	if init_result == null or not init_result.ok:
+		pending("Speech runtime unavailable")
+		return
+
+	var gdk = get_gdk()
+	var speech = gdk.get_speech()
+	if speech == null:
+		return
+
+	speech.set_default_voice()
+	var result = speech.synthesize_text("GDK speech synthesis test.")
+	assert_not_null(result, "synthesize_text() returns GDKResult")
+	if result == null:
+		return
+	if not result.ok:
+		pending("Speech synthesis unavailable on this host: %s" % result.message)
+		return
+
+	assert_dict_has_key(result.data, "audio_wav", "synthesize_text() result exposes audio_wav")
+	assert_dict_has_key(result.data, "byte_count", "synthesize_text() result exposes byte_count")
+	var audio: PackedByteArray = result.data["audio_wav"]
+	assert_gt(audio.size(), 0, "synthesize_text() produces non-empty audio bytes")
+	assert_eq(int(result.data["byte_count"]), audio.size(), "byte_count matches audio_wav length")
+
+	var stream = speech.synthesize_to_stream("GDK speech stream test.")
+	assert_not_null(stream, "synthesize_to_stream() returns an AudioStreamWAV when synthesis succeeds")

--- a/tests/godot/gdk/tests/test_stats.gd
+++ b/tests/godot/gdk/tests/test_stats.gd
@@ -22,9 +22,12 @@ func test_stats_surface_and_validation() -> void:
 	for method_name in [
 		"query_user_stats_async",
 		"query_users_stats_async",
+		"get_single_stat_async",
 		"set_stat_integer",
 		"set_stat_number",
 		"flush_stats_async",
+		"write_stats_async",
+		"delete_stats_async",
 		"track_stats",
 		"stop_tracking_stats",
 		"get_cached_stats",
@@ -234,3 +237,63 @@ func test_stats_live_write_tracked_callback_context() -> void:
 	assert_result_ok(stop_result, "stop_tracking_stats() unregisters after live write callback exercise")
 	gdk.shutdown()
 	assert_eq(gdk.is_initialized(), false, "GDK.shutdown() after live write callback exercise does not crash")
+
+
+func test_stats_single_write_delete_validation() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var stats = gdk.get_stats()
+	assert_not_null(stats, "GDK.stats returns service object")
+	if stats == null:
+		return
+
+	var pre_init_single = stats.get_single_stat_async(null, "score")
+	await assert_signal_result_error(pre_init_single, "runtime_unavailable", "get_single_stat_async() reports unavailable runtime before initialize")
+
+	var pre_init_write = stats.write_stats_async(null, {"score": 1})
+	await assert_signal_result_error(pre_init_write, "runtime_unavailable", "write_stats_async() reports unavailable runtime before initialize")
+
+	var pre_init_delete = stats.delete_stats_async(null, PackedStringArray(["score"]))
+	await assert_signal_result_error(pre_init_delete, "runtime_unavailable", "delete_stats_async() reports unavailable runtime before initialize")
+
+	var init_result = initialize_runtime()
+	assert_not_null(init_result, "GDK.initialize() for stats write/delete validation returns GDKResult")
+	if init_result == null:
+		return
+	if not init_result.ok:
+		pending("Stats write/delete validation: %s" % init_result.message)
+		return
+
+	var invalid_single = stats.get_single_stat_async(null, "score")
+	await assert_signal_result_error(invalid_single, "invalid_user", "get_single_stat_async() rejects null users after initialize")
+
+	var invalid_write = stats.write_stats_async(null, {"score": 1})
+	await assert_signal_result_error(invalid_write, "invalid_user", "write_stats_async() rejects null users after initialize")
+
+	var invalid_delete = stats.delete_stats_async(null, PackedStringArray(["score"]))
+	await assert_signal_result_error(invalid_delete, "invalid_user", "delete_stats_async() rejects null users after initialize")
+
+	var sign_in = await ensure_primary_user()
+	var user = sign_in["user"]
+	var sign_in_result = sign_in["result"]
+	if user == null:
+		if sign_in_result != null and not sign_in_result.ok:
+			pending("Stats write/delete signed-in validation: %s" % sign_in_result.message)
+		else:
+			pending("Stats write/delete signed-in validation: No signed-in user is available on this machine.")
+		return
+
+	var blank_single = stats.get_single_stat_async(user, "   ")
+	await assert_signal_result_error(blank_single, "invalid_stat_name", "get_single_stat_async() rejects blank statistic names")
+
+	var empty_write = stats.write_stats_async(user, {})
+	await assert_signal_result_error(empty_write, "no_stats", "write_stats_async() rejects empty stat dictionaries")
+
+	var bad_value_write = stats.write_stats_async(user, {"score": "not-a-number"})
+	await assert_signal_result_error(bad_value_write, "invalid_stat_value", "write_stats_async() rejects non-numeric stat values")
+
+	var empty_delete = stats.delete_stats_async(user, PackedStringArray())
+	await assert_signal_result_error(empty_delete, "no_stat_names", "delete_stats_async() rejects empty stat-name lists")
+

--- a/tests/godot/gdk/tests/test_store.gd
+++ b/tests/godot/gdk/tests/test_store.gd
@@ -23,6 +23,11 @@ func test_store_surface_and_validation_paths() -> void:
 		"query_license_status_async",
 		"refresh_entitlements_async",
 		"show_purchase_ui_async",
+		"show_product_page_ui_async",
+		"show_associated_products_ui_async",
+		"show_rate_and_review_ui_async",
+		"show_redeem_token_ui_async",
+		"show_gifting_ui_async",
 		"get_cached_license_status",
 		"check_cached_license_status",
 	]:
@@ -48,6 +53,21 @@ func test_store_surface_and_validation_paths() -> void:
 	var pre_init_purchase = store.show_purchase_ui_async(blank_user, "9NBLGGH4R315")
 	await assert_signal_result_error(pre_init_purchase, "not_initialized", "show_purchase_ui_async() rejects requests before initialize()")
 
+	var pre_init_product_page = store.show_product_page_ui_async(blank_user, "9NBLGGH4R315")
+	await assert_signal_result_error(pre_init_product_page, "not_initialized", "show_product_page_ui_async() rejects requests before initialize()")
+
+	var pre_init_associated = store.show_associated_products_ui_async(blank_user, "9NBLGGH4R315", "game")
+	await assert_signal_result_error(pre_init_associated, "not_initialized", "show_associated_products_ui_async() rejects requests before initialize()")
+
+	var pre_init_rate = store.show_rate_and_review_ui_async(blank_user)
+	await assert_signal_result_error(pre_init_rate, "not_initialized", "show_rate_and_review_ui_async() rejects requests before initialize()")
+
+	var pre_init_redeem = store.show_redeem_token_ui_async(blank_user, "TOKEN-12345")
+	await assert_signal_result_error(pre_init_redeem, "not_initialized", "show_redeem_token_ui_async() rejects requests before initialize()")
+
+	var pre_init_gifting = store.show_gifting_ui_async(blank_user, "9NBLGGH4R315")
+	await assert_signal_result_error(pre_init_gifting, "not_initialized", "show_gifting_ui_async() rejects requests before initialize()")
+
 	var invalid_cached_check = store.check_cached_license_status("")
 	assert_not_null(invalid_cached_check, "check_cached_license_status('') returns GDKResult")
 	if invalid_cached_check != null:
@@ -72,6 +92,24 @@ func test_store_surface_and_validation_paths() -> void:
 
 	var invalid_store_id_purchase = store.show_purchase_ui_async(blank_user, " ")
 	await assert_signal_result_error(invalid_store_id_purchase, "invalid_product_id", "show_purchase_ui_async() rejects blank Store product IDs")
+
+	var invalid_store_id_product_page = store.show_product_page_ui_async(blank_user, " ")
+	await assert_signal_result_error(invalid_store_id_product_page, "invalid_product_id", "show_product_page_ui_async() rejects blank Store product IDs")
+
+	var invalid_store_id_associated = store.show_associated_products_ui_async(blank_user, "", "game")
+	await assert_signal_result_error(invalid_store_id_associated, "invalid_product_id", "show_associated_products_ui_async() rejects blank Store product IDs")
+
+	var invalid_store_id_gifting = store.show_gifting_ui_async(blank_user, " ")
+	await assert_signal_result_error(invalid_store_id_gifting, "invalid_product_id", "show_gifting_ui_async() rejects blank Store product IDs")
+
+	var invalid_token_redeem = store.show_redeem_token_ui_async(blank_user, "  ")
+	await assert_signal_result_error(invalid_token_redeem, "invalid_token", "show_redeem_token_ui_async() rejects blank tokens")
+
+	var missing_user_product_page = store.show_product_page_ui_async(null, "9NBLGGH4R315")
+	await assert_signal_result_error(missing_user_product_page, "invalid_user", "show_product_page_ui_async() requires a signed-in user")
+
+	var missing_user_rate = store.show_rate_and_review_ui_async(null)
+	await assert_signal_result_error(missing_user_rate, "invalid_user", "show_rate_and_review_ui_async() requires a signed-in user")
 
 	var missing_user_query = store.query_license_status_async(null, "9NBLGGH4R315")
 	await assert_signal_result_error(missing_user_query, "invalid_user", "query_license_status_async() requires a signed-in user")

--- a/tests/godot/gdk/tests/test_system.gd
+++ b/tests/godot/gdk/tests/test_system.gd
@@ -25,6 +25,7 @@ func test_system_surface_and_validation_paths() -> void:
 		"get_sandbox_id",
 		"get_service_configuration_id",
 		"is_xbox_services_initialized",
+		"is_feature_available",
 	]:
 		assert_has_method_named(system, method_name)
 
@@ -81,3 +82,24 @@ func test_system_surface_and_validation_paths() -> void:
 	else:
 		assert_true(post_init_scid.code.length() > 0, "get_service_configuration_id() failure exposes an error code")
 		assert_true(post_init_scid.message.length() > 0, "get_service_configuration_id() failure exposes an error message")
+
+
+func test_is_feature_available() -> void:
+	if pending_unless_runtime_available():
+		return
+
+	var gdk = get_gdk()
+	var system = gdk.get_system()
+	assert_not_null(system, "GDK.system returns service object")
+	if system == null:
+		return
+
+	# Known feature names resolve to a bool regardless of runtime availability.
+	for feature_name in ["XAccessibility", "xgameui", "XGameSave", "XGameStreaming"]:
+		var available = system.is_feature_available(feature_name)
+		assert_typeof(available, TYPE_BOOL, "is_feature_available('%s') returns a bool" % feature_name)
+
+	# Unknown feature names push a warning and return false.
+	assert_eq(system.is_feature_available("NotARealFeature"), false, "is_feature_available() returns false for unknown feature names")
+	assert_eq(system.is_feature_available(""), false, "is_feature_available('') returns false")
+


### PR DESCRIPTION
## Issue #94 — 100% GDK API reference coverage in the sample

Closes #94. The issue named three gaps — **XSpeechSynthesizer (TTS)**, **XLauncher surfaces beyond `XLaunchUri`**, and **GameChat2** — and asked for comprehensive examples in the sample. To resolve them faithfully I first evaluated **every GDK header** the build sees (`build/vcpkg_installed/x64-windows/include` + `xsapi-c/`). That audit confirmed TTS and GameChat2 as real gaps, found that **`XLauncher` is already complete** (`XLaunchUri` is its only function and it is wrapped — there is no launch-destination gap), and surfaced several adjacent coverage fills the user asked to include.

### What's new

All new behavior attaches as service namespaces under the single `GDK` singleton (no new global singletons), with matching `doc_classes` XML, `spec/gdext-gdk.md`, `docs/gdk/api-reference.md`, and tests kept in lockstep.

| Area | Surface | Native API |
| --- | --- | --- |
| **Text-to-speech** | `GDK.speech` | `XSpeechSynthesizer.h` |
| **Store Show-UIs** | `GDK.store.show_product_page_async` + 4 more | `XStoreShow*UIAsync` |
| **Game UI Show surfaces** | `GDK.game_ui.show_achievements_async` + 3 more | `XGameUiShow*Async` |
| **Events / telemetry** | `GDK.events` | `XGameEventWrite` (`XGameEvent.h`) |
| **Runtime feature probe** | `GDK.system.is_feature_available` | `XGameRuntimeIsFeatureAvailable` |
| **Game Save (files)** | `GDK.game_save` | `XGameSaveFiles.h` |
| **Within-family XSAPI fills** | `GDK.stats` (single/write/delete), `GDK.social` (group update, RP polling), `GDK.achievements` (by-state) | `xsapi-c` |
| **Voice + text chat** | `GDK.game_chat` | `GameChat2.h` (separate `GameChat2.lib`) |

Explicitly **left off** per the issue discussion: `XGameSave.h` connected-storage (more complex than `XGameSaveFiles`, overlaps PlayFab Game Saves), and infra (`XAsync*`, `XTaskQueue`, `XThread`, `XCurl`).

### Usage snippets for each new public surface

**`GDK.speech` (TTS)** — local, no network/user required:
```gdscript
for v in GDK.speech.get_installed_voices():
    print(v.display_name, v.language)
GDK.speech.set_default_voice()
var stream: AudioStreamWAV = GDK.speech.synthesize_to_stream("Hello from the GDK")
$AudioStreamPlayer.stream = stream
$AudioStreamPlayer.play()
var ssml := GDK.speech.synthesize_ssml("<speak version='1.0' xml:lang='en-US'>Hi</speak>")
```

**`GDK.store` Show-UIs**:
```gdscript
await GDK.store.show_product_page_async("9NBLGGH4R315")
await GDK.store.show_rate_and_review_async()
await GDK.store.show_gifting_async("9NBLGGH4R315")
```

**`GDK.game_ui` Show surfaces**:
```gdscript
await GDK.game_ui.show_achievements_async(GDK.users.get_primary_user())
await GDK.game_ui.show_error_dialog_async("Title", "Something went wrong", "OK")
var entry = await GDK.game_ui.show_text_entry_async("Save name", "Name your save", "", 0, 32)
```

**`GDK.events` (telemetry)**:
```gdscript
GDK.events.set_play_session_id("")  # regenerate, or pass your own GUID
var r: GDKResult = GDK.events.write_event(
    GDK.users.get_primary_user(), "LevelComplete",
    {"level": "1-3"}, {"score": 1450, "seconds": 88.5})
```

**`GDK.system.is_feature_available`**:
```gdscript
if GDK.system.is_feature_available("XGameEvent"):
    GDK.events.write_event(user, "Booted")
```

**`GDK.game_save` (files)**:
```gdscript
var folder := await GDK.game_save.get_folder_async(user)
if folder.ok:
    FileAccess.open(folder.data.path.path_join("save1.dat"), FileAccess.WRITE)
var quota := GDK.game_save.get_remaining_quota(user)  # quota.data.bytes
```

**`GDK.stats` / `GDK.social` / `GDK.achievements` fills**:
```gdscript
await GDK.stats.get_single_stat_async(user, "HighScore")
await GDK.stats.write_stats_async(user, {"HighScore": 9001})          # replace-all
await GDK.stats.delete_stats_async(user, PackedStringArray(["HighScore"]))
GDK.social.set_rich_presence_polling(true)
await GDK.achievements.get_achievements_by_state(user, "achieved")
```

**`GDK.game_chat` (GameChat2)** — encodes opaque data frames and builds **no** transport; the title ferries frames over whatever it already has (sample/tests use single-process loopback):
```gdscript
GDK.game_chat.initialize()
var me := GDK.game_chat.add_local_user(GDK.users.get_primary_user())
GDK.game_chat.add_remote_user("2814639011419087", 1001)

# Ferry Game Chat's encoded frames over your transport (here: loopback).
GDK.game_chat.outgoing_data_frame.connect(
    func(target_endpoint_ids, bytes, transport_requirement):
        for ep in target_endpoint_ids:
            GDK.game_chat.process_incoming_data_frame(1001, bytes))
GDK.game_chat.text_chat_received.connect(
    func(sender_xuid, message): print("%s: %s" % [sender_xuid, message]))

GDK.game_chat.send_text(me.data.xuid, "hello over game chat")
GDK.game_chat.set_microphone_muted(me.data.xuid, true)  # voice/text are independent
```

### Sample demonstrations

- **`tutorial_gdk` → G5 "Text-to-Speech"**: lists voices, synthesizes text to an `AudioStreamWAV` and plays it, and synthesizes SSML. Local-only, so it runs without sign-in.
- **`tutorial_integrated` → Game Chat tab** (next to the PlayFab Party panel): demonstrates `GDK.game_chat` with single-process loopback and an independent mic-mute toggle, positioned as the GDK-native alternative to Party's batteries-included transport.

The remaining new surfaces (Store/Game UI Show-UIs, events, feature probe, game_save) are documented with the usage snippets above, in `docs/gdk/api-reference.md`, and in their `doc_classes` XML.

### GameChat2 linkage note

GameChat2 ships in its own `GameChat2.lib`/`GameChat2.dll`. Its C++ `chat_manager`/`chat_user` methods are defined **out-of-line** in `GameChat2Impl.h` (which forwards to the C API in `GameChat2.lib`); linking the `.lib` alone yields unresolved externals. The fix is to `#include <GameChat2Impl.h>` in exactly one TU (`gdk_game_chat.cpp`). CMake links `Xbox::GameChat2` and copies the DLL into each host.

### Validation

- Parse gate (`tools/check_gd_scripts_headless.ps1`): **pass**.
- Full orchestrator (`tools/run_all_tests.ps1`, non-live): **overall pass** — GDK host 259 tests / 2489 asserts / 0 failed (incl. new `test_speech.gd`, `test_store.gd`/`test_game_ui.gd`, `test_events.gd`, `test_system.gd`/`test_game_save.gd`/stat+social+achievement fills, and `test_game_chat.gd` at 106 asserts), PlayFab + GameInput hosts green, C++ doctest + bootstrap runners green.
- **Live coverage:** skipped (default). Stats write/delete + social group updates are live-write surfaces; validate against a sandbox PlayFab/title with `tools/run_all_tests.ps1 -Live -AllowLiveWrites` before relying on them online. Real GameChat2 voice and configured event delivery require multi-machine audio / a service-config manifest and are not CI-verifiable (mirrors the Party "voice deferred" stance).
