### PR TITLE
Add token-based PlayFab sign-in methods (Steam, OpenID Connect, Battle.net) (#95)

### DIFF
--- a/addons/godot_playfab/doc_classes/PlayFabUsers.xml
+++ b/addons/godot_playfab/doc_classes/PlayFabUsers.xml
@@ -4,7 +4,7 @@
 		Manual PlayFab sign-in and cached user lookup service.
 	</brief_description>
 	<description>
-		Accessed through [code]PlayFab.users[/code]. Use this service to manually sign a local Xbox user or title-defined custom id into PlayFab and inspect cached [PlayFabUser] sessions. For Xbox-backed sign-in, reuse [code]GDK.users.get_primary_user()[/code] when available or await [code]GDK.users.add_user_with_ui_async()[/code] to acquire a signed-in [code]GDKUser[/code], then pass that object to [method sign_in_with_xuser_async]. Never pass a raw local Xbox user id.
+		Accessed through [code]PlayFab.users[/code]. Use this service to manually sign a player into PlayFab and inspect cached [PlayFabUser] sessions. Sign-in supports a local Xbox user ([method sign_in_with_xuser_async]), a title-defined custom id ([method sign_in_with_custom_id_async]), and external identity providers that the title authenticates first: Steam ([method sign_in_with_steam_async]), OpenID Connect ([method sign_in_with_open_id_connect_async]), and Battle.net ([method sign_in_with_battle_net_async]). The token-based providers require the title to obtain a platform token through that platform's SDK or OAuth flow; this addon only forwards the token to PlayFab. For Xbox-backed sign-in, reuse [code]GDK.users.get_primary_user()[/code] when available or await [code]GDK.users.add_user_with_ui_async()[/code] to acquire a signed-in [code]GDKUser[/code], then pass that object to [method sign_in_with_xuser_async]. Never pass a raw local Xbox user id.
 	</description>
 	<tutorials></tutorials>
 	<methods>
@@ -22,6 +22,32 @@
 			<param index="1" name="create_account" type="bool" default="true" />
 			<description>
 				Starts PlayFab sign-in using a title-defined custom id. Await the returned completion [Signal] directly; the emitted [PlayFabResult] data contains a [PlayFabUser] with [member PlayFabUser.custom_id] populated and no local Xbox user handle. Failure codes include [code]invalid_custom_id[/code] and [code]not_initialized[/code].
+			</description>
+		</method>
+		<method name="sign_in_with_steam_async">
+			<return type="Signal" />
+			<param index="0" name="steam_ticket" type="String" />
+			<param index="1" name="create_account" type="bool" default="true" />
+			<param index="2" name="ticket_is_service_specific" type="bool" default="false" />
+			<description>
+				Starts PlayFab sign-in using a Steam session ticket. [param steam_ticket] is the authentication token returned by Steam (for example from [code]ISteamUser::GetAuthSessionTicket()[/code] or [code]GetAuthTicketForWebAPI()[/code]), converted to a hexadecimal string. Set [param ticket_is_service_specific] to [code]true[/code] when the ticket was generated with [code]GetAuthTicketForWebAPI()[/code] using the [code]AzurePlayFab[/code] identity string. The title must mint the ticket through the Steamworks SDK; this addon does not bundle Steam. Await the returned completion [Signal] directly; on success the emitted [PlayFabResult] data contains a [PlayFabUser] keyed by its PlayFab entity id (with [member PlayFabUser.local_id] of [code]0[/code], an empty [member PlayFabUser.custom_id], and no local Xbox user handle). The title must be configured with the Steam add-on in PlayFab Game Manager. Failure codes include [code]invalid_steam_ticket[/code], [code]not_initialized[/code], and [code]platform_unsupported[/code]; an invalid or placeholder ticket surfaces a [code]playfab_steam_sign_in_failed[/code] result.
+			</description>
+		</method>
+		<method name="sign_in_with_open_id_connect_async">
+			<return type="Signal" />
+			<param index="0" name="connection_id" type="String" />
+			<param index="1" name="id_token" type="String" />
+			<param index="2" name="create_account" type="bool" default="true" />
+			<description>
+				Starts PlayFab sign-in using an OpenID Connect identity provider. [param connection_id] names the OpenID Connect connection configured for the title in PlayFab Game Manager, and [param id_token] is the JSON Web Token (JWT) returned by that provider after the user authenticates. The title obtains the [param id_token] from its identity provider; this addon does not perform the OpenID Connect flow. Await the returned completion [Signal] directly; on success the emitted [PlayFabResult] data contains a [PlayFabUser] keyed by its PlayFab entity id. Failure codes include [code]invalid_connection_id[/code], [code]invalid_id_token[/code], [code]not_initialized[/code], and [code]platform_unsupported[/code]; an invalid or placeholder token surfaces a [code]playfab_open_id_connect_sign_in_failed[/code] result.
+			</description>
+		</method>
+		<method name="sign_in_with_battle_net_async">
+			<return type="Signal" />
+			<param index="0" name="identity_token" type="String" />
+			<param index="1" name="create_account" type="bool" default="true" />
+			<description>
+				Starts PlayFab sign-in using a Battle.net account. [param identity_token] is the JSON Web Token (JWT) returned by Battle.net after the user authenticates. The title obtains the [param identity_token] from the Battle.net OAuth flow; this addon does not perform that flow. Await the returned completion [Signal] directly; on success the emitted [PlayFabResult] data contains a [PlayFabUser] keyed by its PlayFab entity id. The title must enable Battle.net in PlayFab Game Manager. Failure codes include [code]invalid_identity_token[/code], [code]not_initialized[/code], and [code]platform_unsupported[/code]; an invalid or placeholder token surfaces a [code]playfab_battle_net_sign_in_failed[/code] result.
 			</description>
 		</method>
 		<method name="get_user_by_local_id" qualifiers="const">

--- a/addons/godot_playfab/src/playfab_user.cpp
+++ b/addons/godot_playfab/src/playfab_user.cpp
@@ -32,6 +32,10 @@ String PlayFabUser::get_custom_id() const {
     return m_custom_id;
 }
 
+String PlayFabUser::get_entity_id() const {
+    return m_entity_id;
+}
+
 Dictionary PlayFabUser::get_entity_key() const {
     Dictionary key;
     key["id"] = m_entity_id;
@@ -132,12 +136,34 @@ HRESULT PlayFabUser::adopt_custom_id_session(const String &p_custom_id, PFEntity
     return S_OK;
 }
 
+HRESULT PlayFabUser::adopt_entity_session(PFEntityHandle p_entity_handle) {
+    clear();
+
+    if (p_entity_handle == nullptr) {
+        return E_INVALIDARG;
+    }
+
+    m_entity_handle = p_entity_handle;
+
+    HRESULT hr = populate_from_entity_handle(m_entity_handle);
+    if (FAILED(hr)) {
+        clear();
+        return hr;
+    }
+
+    return S_OK;
+}
+
 bool PlayFabUser::matches_local_id(XUserLocalId p_local_id) const {
     return m_local_id.value != 0 && m_local_id.value == p_local_id.value;
 }
 
 bool PlayFabUser::matches_custom_id(const String &p_custom_id) const {
     return !m_custom_id.is_empty() && m_custom_id == p_custom_id.strip_edges();
+}
+
+bool PlayFabUser::matches_entity_id(const String &p_entity_id) const {
+    return !m_entity_id.is_empty() && m_entity_id == p_entity_id;
 }
 
 PFEntityHandle PlayFabUser::get_entity_handle() const {

--- a/addons/godot_playfab/src/playfab_user.h
+++ b/addons/godot_playfab/src/playfab_user.h
@@ -43,13 +43,16 @@ public:
 
     uint64_t get_local_id() const;
     String get_custom_id() const;
+    String get_entity_id() const;
     Dictionary get_entity_key() const;
     bool has_local_user_handle() const;
 
     HRESULT adopt_session(XUserHandle p_user_handle, PFEntityHandle p_entity_handle, PFServiceConfigHandle p_service_config_handle);
     HRESULT adopt_custom_id_session(const String &p_custom_id, PFEntityHandle p_entity_handle);
+    HRESULT adopt_entity_session(PFEntityHandle p_entity_handle);
     bool matches_local_id(XUserLocalId p_local_id) const;
     bool matches_custom_id(const String &p_custom_id) const;
+    bool matches_entity_id(const String &p_entity_id) const;
     PFEntityHandle get_entity_handle() const;
     HRESULT duplicate_local_user_handle(PFLocalUserHandle *r_local_user_handle) const;
     void clear();

--- a/addons/godot_playfab/src/playfab_users.cpp
+++ b/addons/godot_playfab/src/playfab_users.cpp
@@ -1,5 +1,6 @@
 #include "playfab_users.h"
 
+#include <list>
 #include <string>
 #include <vector>
 
@@ -200,11 +201,120 @@ protected:
     }
 };
 
+// Shared completion handler for token-based PlayFab logins (Steam, OpenID
+// Connect, Battle.net). Each of these flows yields only a PFEntityHandle, so
+// the resulting PlayFabUser is keyed by its PlayFab entity id rather than a
+// local Xbox user id or a title-defined custom id. The PlayFab result
+// accessors share an identical signature, so the per-method size/result
+// functions are injected as function pointers.
+class SignInEntityAsyncContext final : public PlayFabSignalXAsyncContext {
+public:
+    using GetResultSizeFn = HRESULT (*)(XAsyncBlock *, size_t *);
+    using GetResultFn = HRESULT (*)(XAsyncBlock *, PFEntityHandle *, size_t, void *, PFAuthenticationLoginResult const **, size_t *);
+
+private:
+    PlayFabUsers *m_users = nullptr;
+    String m_method_label;
+    String m_error_prefix;
+    GetResultSizeFn m_get_result_size_fn = nullptr;
+    GetResultFn m_get_result_fn = nullptr;
+    std::list<std::string> m_interned_strings;
+    std::list<bool> m_interned_bools;
+
+public:
+    SignInEntityAsyncContext(
+            PlayFabUsers *p_users,
+            PlayFabRuntime *p_runtime,
+            const Ref<PlayFabPendingSignal> &p_pending_signal,
+            const String &p_method_label,
+            const String &p_error_prefix,
+            GetResultSizeFn p_get_result_size_fn,
+            GetResultFn p_get_result_fn) :
+            PlayFabSignalXAsyncContext(p_runtime, p_pending_signal),
+            m_users(p_users),
+            m_method_label(p_method_label),
+            m_error_prefix(p_error_prefix),
+            m_get_result_size_fn(p_get_result_size_fn),
+            m_get_result_fn(p_get_result_fn) {}
+
+    // Copies the supplied value into storage owned by this context so the C
+    // string remains valid for the lifetime of the async request. std::list
+    // never relocates its elements, so previously returned pointers stay valid
+    // as additional values are interned.
+    const char *intern_string(const String &p_value) {
+        m_interned_strings.push_back(std::string(p_value.utf8().get_data()));
+        return m_interned_strings.back().c_str();
+    }
+
+    const bool *intern_bool(bool p_value) {
+        m_interned_bools.push_back(p_value);
+        return &m_interned_bools.back();
+    }
+
+protected:
+    void finalize(XAsyncBlock *p_async_block) override {
+        const String cancel_message = "PlayFab " + m_method_label + " sign-in cancelled.";
+
+        if (get_runtime()->is_shutting_down() || get_pending_signal()->was_cancel_requested()) {
+            get_pending_signal()->complete(PlayFabResult::cancelled(cancel_message));
+            return;
+        }
+
+        HRESULT status_hr = XAsyncGetStatus(p_async_block, false);
+        if (status_hr == E_ABORT) {
+            get_pending_signal()->complete(PlayFabResult::cancelled(cancel_message));
+            return;
+        }
+        if (FAILED(status_hr)) {
+            get_pending_signal()->complete(PlayFabResult::hresult_error(status_hr, "Failed to sign in to PlayFab with " + m_method_label + ".", m_error_prefix + "_sign_in_failed"));
+            return;
+        }
+
+        size_t buffer_size = 0;
+        HRESULT size_hr = m_get_result_size_fn(p_async_block, &buffer_size);
+        if (FAILED(size_hr)) {
+            get_pending_signal()->complete(PlayFabResult::hresult_error(size_hr, "Failed to get the PlayFab " + m_method_label + " login result size.", m_error_prefix + "_sign_in_result_size_failed"));
+            return;
+        }
+
+        std::vector<char> buffer(buffer_size);
+        PFAuthenticationLoginResult const *login_result = nullptr;
+        PFEntityHandle entity_handle = nullptr;
+        HRESULT result_hr = m_get_result_fn(
+                p_async_block,
+                &entity_handle,
+                buffer.size(),
+                buffer.data(),
+                &login_result,
+                nullptr);
+        if (FAILED(result_hr)) {
+            get_pending_signal()->complete(PlayFabResult::hresult_error(result_hr, "Failed to retrieve the PlayFab " + m_method_label + " login result.", m_error_prefix + "_sign_in_result_failed"));
+            return;
+        }
+
+        Ref<PlayFabUser> user;
+        user.instantiate();
+
+        HRESULT user_hr = user->adopt_entity_session(entity_handle);
+        if (FAILED(user_hr)) {
+            get_pending_signal()->complete(PlayFabResult::hresult_error(user_hr, "Failed to translate the PlayFab " + m_method_label + " login result into a Godot user wrapper.", m_error_prefix + "_user_wrapper_create_failed"));
+            return;
+        }
+
+        m_users->add_or_update_user_session(user);
+
+        get_pending_signal()->complete(PlayFabResult::ok_result(user));
+    }
+};
+
 } // namespace
 
 void PlayFabUsers::_bind_methods() {
     ClassDB::bind_method(D_METHOD("sign_in_with_xuser_async", "user", "create_account"), &PlayFabUsers::sign_in_with_xuser_async, DEFVAL(true));
     ClassDB::bind_method(D_METHOD("sign_in_with_custom_id_async", "custom_id", "create_account"), &PlayFabUsers::sign_in_with_custom_id_async, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("sign_in_with_steam_async", "steam_ticket", "create_account", "ticket_is_service_specific"), &PlayFabUsers::sign_in_with_steam_async, DEFVAL(true), DEFVAL(false));
+    ClassDB::bind_method(D_METHOD("sign_in_with_open_id_connect_async", "connection_id", "id_token", "create_account"), &PlayFabUsers::sign_in_with_open_id_connect_async, DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("sign_in_with_battle_net_async", "identity_token", "create_account"), &PlayFabUsers::sign_in_with_battle_net_async, DEFVAL(true));
     ClassDB::bind_method(D_METHOD("get_user_by_local_id", "local_id"), &PlayFabUsers::get_user_by_local_id);
     ClassDB::bind_method(D_METHOD("get_user_by_custom_id", "custom_id"), &PlayFabUsers::get_user_by_custom_id);
     ClassDB::bind_method(D_METHOD("get_user", "user_or_local_id"), &PlayFabUsers::get_user);
@@ -306,6 +416,150 @@ Signal PlayFabUsers::sign_in_with_custom_id_async(const String &p_custom_id, boo
         delete context;
 
         Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to start the PlayFab custom-ID login request.", "playfab_custom_id_sign_in_start_failed");
+        pending_signal->complete_deferred(result);
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal PlayFabUsers::sign_in_with_steam_async(const String &p_steam_ticket, bool p_create_account, bool p_ticket_is_service_specific) {
+    PlayFabRuntime *runtime = _get_runtime();
+    const String steam_ticket = p_steam_ticket.strip_edges();
+    if (steam_ticket.is_empty()) {
+        return make_users_error_signal(runtime, E_INVALIDARG, "invalid_steam_ticket", "PlayFab Steam sign-in requires a non-empty steam_ticket.");
+    }
+
+    if (runtime == nullptr || !runtime->is_initialized()) {
+        return make_users_error_signal(runtime, E_FAIL, "not_initialized", "PlayFab is not initialized. Call PlayFab.initialize() first.");
+    }
+
+    if (!PLAYFAB_GDK_PLATFORM) {
+        return make_users_error_signal(runtime, E_FAIL, "platform_unsupported", "PlayFab sign-in is only supported on GDK platforms right now.");
+    }
+
+    Ref<PlayFabPendingSignal> pending_signal = runtime->make_pending_signal();
+
+    auto *context = new SignInEntityAsyncContext(
+            this,
+            runtime,
+            pending_signal,
+            "Steam",
+            "playfab_steam",
+            &PFAuthenticationLoginWithSteamGetResultSize,
+            &PFAuthenticationLoginWithSteamGetResult);
+    context->bind_cancel_handler();
+
+    PFAuthenticationLoginWithSteamRequest request = {};
+    request.createAccount = p_create_account;
+    request.steamTicket = context->intern_string(steam_ticket);
+    request.ticketIsServiceSpecific = context->intern_bool(p_ticket_is_service_specific);
+
+    HRESULT hr = PFAuthenticationLoginWithSteamAsync(
+            runtime->get_service_config_handle(),
+            &request,
+            context->get_async_block());
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+
+        Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to start the PlayFab Steam login request.", "playfab_steam_sign_in_start_failed");
+        pending_signal->complete_deferred(result);
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal PlayFabUsers::sign_in_with_open_id_connect_async(const String &p_connection_id, const String &p_id_token, bool p_create_account) {
+    PlayFabRuntime *runtime = _get_runtime();
+    const String connection_id = p_connection_id.strip_edges();
+    const String id_token = p_id_token.strip_edges();
+    if (connection_id.is_empty()) {
+        return make_users_error_signal(runtime, E_INVALIDARG, "invalid_connection_id", "PlayFab OpenID Connect sign-in requires a non-empty connection_id.");
+    }
+    if (id_token.is_empty()) {
+        return make_users_error_signal(runtime, E_INVALIDARG, "invalid_id_token", "PlayFab OpenID Connect sign-in requires a non-empty id_token.");
+    }
+
+    if (runtime == nullptr || !runtime->is_initialized()) {
+        return make_users_error_signal(runtime, E_FAIL, "not_initialized", "PlayFab is not initialized. Call PlayFab.initialize() first.");
+    }
+
+    if (!PLAYFAB_GDK_PLATFORM) {
+        return make_users_error_signal(runtime, E_FAIL, "platform_unsupported", "PlayFab sign-in is only supported on GDK platforms right now.");
+    }
+
+    Ref<PlayFabPendingSignal> pending_signal = runtime->make_pending_signal();
+
+    auto *context = new SignInEntityAsyncContext(
+            this,
+            runtime,
+            pending_signal,
+            "OpenID Connect",
+            "playfab_open_id_connect",
+            &PFAuthenticationLoginWithOpenIdConnectGetResultSize,
+            &PFAuthenticationLoginWithOpenIdConnectGetResult);
+    context->bind_cancel_handler();
+
+    PFAuthenticationLoginWithOpenIdConnectRequest request = {};
+    request.connectionId = context->intern_string(connection_id);
+    request.createAccount = p_create_account;
+    request.idToken = context->intern_string(id_token);
+
+    HRESULT hr = PFAuthenticationLoginWithOpenIdConnectAsync(
+            runtime->get_service_config_handle(),
+            &request,
+            context->get_async_block());
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+
+        Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to start the PlayFab OpenID Connect login request.", "playfab_open_id_connect_sign_in_start_failed");
+        pending_signal->complete_deferred(result);
+    }
+
+    return pending_signal->get_completed_signal();
+}
+
+Signal PlayFabUsers::sign_in_with_battle_net_async(const String &p_identity_token, bool p_create_account) {
+    PlayFabRuntime *runtime = _get_runtime();
+    const String identity_token = p_identity_token.strip_edges();
+    if (identity_token.is_empty()) {
+        return make_users_error_signal(runtime, E_INVALIDARG, "invalid_identity_token", "PlayFab Battle.net sign-in requires a non-empty identity_token.");
+    }
+
+    if (runtime == nullptr || !runtime->is_initialized()) {
+        return make_users_error_signal(runtime, E_FAIL, "not_initialized", "PlayFab is not initialized. Call PlayFab.initialize() first.");
+    }
+
+    if (!PLAYFAB_GDK_PLATFORM) {
+        return make_users_error_signal(runtime, E_FAIL, "platform_unsupported", "PlayFab sign-in is only supported on GDK platforms right now.");
+    }
+
+    Ref<PlayFabPendingSignal> pending_signal = runtime->make_pending_signal();
+
+    auto *context = new SignInEntityAsyncContext(
+            this,
+            runtime,
+            pending_signal,
+            "Battle.net",
+            "playfab_battle_net",
+            &PFAuthenticationLoginWithBattleNetGetResultSize,
+            &PFAuthenticationLoginWithBattleNetGetResult);
+    context->bind_cancel_handler();
+
+    PFAuthenticationLoginWithBattleNetRequest request = {};
+    request.createAccount = p_create_account;
+    request.identityToken = context->intern_string(identity_token);
+
+    HRESULT hr = PFAuthenticationLoginWithBattleNetAsync(
+            runtime->get_service_config_handle(),
+            &request,
+            context->get_async_block());
+    if (FAILED(hr)) {
+        pending_signal->clear_cancel_handler();
+        delete context;
+
+        Ref<PlayFabResult> result = PlayFabResult::hresult_error(hr, "Failed to start the PlayFab Battle.net login request.", "playfab_battle_net_sign_in_start_failed");
         pending_signal->complete_deferred(result);
     }
 
@@ -469,7 +723,8 @@ bool PlayFabUsers::_add_or_update_user(const Ref<PlayFabUser> &p_user) {
 
     const uint64_t local_id = p_user->get_local_id();
     const String custom_id = p_user->get_custom_id();
-    if (local_id == 0 && custom_id.is_empty()) {
+    const String entity_id = p_user->get_entity_id();
+    if (local_id == 0 && custom_id.is_empty() && entity_id.is_empty()) {
         return false;
     }
     XUserLocalId user_local_id = {};
@@ -484,6 +739,17 @@ bool PlayFabUsers::_add_or_update_user(const Ref<PlayFabUser> &p_user) {
             return false;
         }
         if (!custom_id.is_empty() && existing->matches_custom_id(custom_id)) {
+            existing = p_user;
+            return false;
+        }
+        // Token-only sessions (Steam/OpenID/Battle.net) carry no local id or
+        // custom id, so they are deduplicated by PlayFab entity id. Only match
+        // against another entity-only session: XUser and custom-id wrappers
+        // also populate entity_id, and replacing one of those richer sessions
+        // with a leaner token wrapper would drop its local-user handle.
+        if (local_id == 0 && custom_id.is_empty() && !entity_id.is_empty()
+                && existing->get_local_id() == 0 && existing->get_custom_id().is_empty()
+                && existing->matches_entity_id(entity_id)) {
             existing = p_user;
             return false;
         }

--- a/addons/godot_playfab/src/playfab_users.h
+++ b/addons/godot_playfab/src/playfab_users.h
@@ -48,6 +48,9 @@ public:
 
     Signal sign_in_with_xuser_async(Object *p_user, bool p_create_account = true);
     Signal sign_in_with_custom_id_async(const String &p_custom_id, bool p_create_account = true);
+    Signal sign_in_with_steam_async(const String &p_steam_ticket, bool p_create_account = true, bool p_ticket_is_service_specific = false);
+    Signal sign_in_with_open_id_connect_async(const String &p_connection_id, const String &p_id_token, bool p_create_account = true);
+    Signal sign_in_with_battle_net_async(const String &p_identity_token, bool p_create_account = true);
     Ref<PlayFabUser> get_user_by_local_id(int64_t p_local_id) const;
     Ref<PlayFabUser> get_user_by_custom_id(const String &p_custom_id) const;
     Ref<PlayFabUser> get_user(const Variant &p_user_or_local_id) const;

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -15,7 +15,8 @@ This is the landing page for the `godot_playfab` docs set.
 - project-settings-backed PlayFab config through `playfab/runtime/title_id` and `playfab/runtime/endpoint`
 - manual XBOX-backed PlayFab sign-in through `PlayFab.users.sign_in_with_xuser_async(...)`
 - custom-ID PlayFab sign-in through `PlayFab.users.sign_in_with_custom_id_async(...)`
-- cached `PlayFabUser` wrappers keyed by local XBOX user id or custom id
+- token-based identity-provider sign-in through `PlayFab.users.sign_in_with_steam_async(...)`, `PlayFab.users.sign_in_with_open_id_connect_async(...)`, and `PlayFab.users.sign_in_with_battle_net_async(...)` (the title authenticates with the platform first and forwards the resulting token)
+- cached `PlayFabUser` wrappers keyed by local XBOX user id, custom id, or PlayFab entity id
 - Game Saves add/sync, upload, folder/quota queries, cloud connectivity queries, save description updates, and cloud reset through `PlayFab.game_saves`
 - leaderboard submit, global query, around-user query, and friends/social leaderboard query
 - client-safe PlayFab service wrappers under `PlayFab.accounts`, `PlayFab.catalog`, `PlayFab.cloud_script`, `PlayFab.entity_data`, `PlayFab.experimentation`, `PlayFab.friends`, `PlayFab.groups`, `PlayFab.inventory`, `PlayFab.localization`, `PlayFab.player_data`, `PlayFab.statistics`, and `PlayFab.title_data`
@@ -29,6 +30,7 @@ This is the landing page for the `godot_playfab` docs set.
 
 - custom non-Windows Game Saves UI callback/response wrappers are not yet exposed as a public Godot surface
 - server/admin/title-secret PlayFab APIs are intentionally excluded from the client wrapper set
+- PlayFab-native credential sign-in (email + password, PlayFab username + password, register a PlayFab user) is **not wrappable** in this addon: those entry points are compiled out (`#if 0`) of the GDK flavor of the PlayFab Core C SDK. Other platform logins (Google, Apple, Facebook, PSN, Nintendo, Game Center, Twitch) are gated to non-GDK `HC_PLATFORM` targets and are likewise unavailable here. See the sign-in coverage matrix in `spec\gdext-playfab.md` for the full picture.
 
 ## Runtime configuration
 
@@ -140,6 +142,31 @@ if not stats_result.ok:
 ```
 
 Game Saves still requires an XBOX-backed PlayFab session because the PlayFab Game Saves C API needs a local user handle. Acquire a real `GDKUser` object and pass it to `PlayFab.users.sign_in_with_xuser_async(...)`; custom-ID users return `xbox_user_required` from Game Saves methods.
+
+## Sign-in methods
+
+Besides the Xbox (`sign_in_with_xuser_async`) and custom-id (`sign_in_with_custom_id_async`) flows, `PlayFab.users` exposes three token-based identity providers. Each one requires the title to authenticate the player with that platform first and forward the resulting token; the addon does not bundle any third-party SDK. The returned `PlayFabUser` is keyed by its PlayFab entity id (`local_id == 0`, empty `custom_id`).
+
+```gdscript
+# Steam — steam_ticket is a hex-encoded Steamworks session ticket.
+# Pass ticket_is_service_specific = true when minted via GetAuthTicketForWebAPI("AzurePlayFab").
+var steam_result = await PlayFab.users.sign_in_with_steam_async(steam_ticket, true, false)
+if steam_result.ok:
+    print(steam_result.data.entity_key)
+
+# OpenID Connect — connection_id names the OIDC connection in PlayFab Game Manager;
+# id_token is the JWT returned by the identity provider.
+var oidc_result = await PlayFab.users.sign_in_with_open_id_connect_async("my-oidc-connection", id_token)
+if not oidc_result.ok:
+    push_warning(oidc_result.message)
+
+# Battle.net — identity_token is the JWT returned by the Battle.net OAuth flow.
+var battle_net_result = await PlayFab.users.sign_in_with_battle_net_async(identity_token)
+if not battle_net_result.ok:
+    push_warning(battle_net_result.message)
+```
+
+Validation failures resolve immediately with an error code (`invalid_steam_ticket`, `invalid_connection_id`, `invalid_id_token`, `invalid_identity_token`, or `not_initialized`). A well-formed but invalid/placeholder token still runs the full async request and surfaces a service error (`playfab_steam_sign_in_failed`, `playfab_open_id_connect_sign_in_failed`, or `playfab_battle_net_sign_in_failed`). PlayFab-native credential sign-in (email/username/register) is not available in the GDK SDK build; see the sign-in coverage matrix in `spec\gdext-playfab.md`.
 
 ## Leaderboard write path
 

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -22,8 +22,8 @@ Lobby/matchmaking and Party design work are tracked separately in `spec\gdext-pl
 | Domain | Included | Notes |
 | --- | --- | --- |
 | Runtime init/shutdown | Yes | Process-lifetime Microsoft GDK runtime reference (`XGameRuntimeInitializeWithOptions` with `File` source when `res://MicrosoftGame.config` is on disk, otherwise `XGameRuntimeInitialize`), re-armable PlayFab init/shutdown, shared queue |
-| Manual sign-in | Yes | `GDKUser` object and custom-ID entry points |
-| Cached user sessions | Yes | `PlayFabUser` keyed by local Xbox user id or custom id |
+| Manual sign-in | Yes | `GDKUser` object, custom-ID, and token-based identity providers (Steam, OpenID Connect, Battle.net) |
+| Cached user sessions | Yes | `PlayFabUser` keyed by local Xbox user id, custom id, or PlayFab entity id |
 | Game Saves | Yes | add/sync, upload, folder/quota/cloud-state queries |
 | Leaderboards | Yes | submit, global, around-user, friends/social |
 | Client services | Yes | accounts, catalog, CloudScript, entity data, experimentation, friends, groups, inventory, localization, player data, statistics, title data |
@@ -89,7 +89,7 @@ The addon uses one shared task queue owned by the PlayFab runtime. Native comple
 
 Rules:
 
-1. `PlayFab.users.sign_in_with_xuser_async()`, `PlayFab.users.sign_in_with_custom_id_async()`, Game Saves calls, leaderboard calls, Party calls, Multiplayer calls, and PlayFab service calls all return completion signals awaited directly.
+1. `PlayFab.users.sign_in_with_xuser_async()`, `PlayFab.users.sign_in_with_custom_id_async()`, `PlayFab.users.sign_in_with_steam_async()`, `PlayFab.users.sign_in_with_open_id_connect_async()`, `PlayFab.users.sign_in_with_battle_net_async()`, Game Saves calls, leaderboard calls, Party calls, Multiplayer calls, and PlayFab service calls all return completion signals awaited directly.
 2. Each completion signal is one-shot: it resolves at most once, always with a `PlayFabResult`.
 3. `PlayFabResult.data` uses Godot-native types (`Dictionary`, `Array`, `String`, `int`, etc.).
 4. Completions are main-thread work. SDK callbacks are drained by the manual completion queue when `PlayFab.dispatch()` runs; immediate and synchronous completion paths use Godot `call_deferred` before emitting.
@@ -102,7 +102,7 @@ For Multiplayer lobbies, successful local `PlayFabLobby.set_member_properties_as
 
 ## User/session model
 
-`PlayFabUser` represents one signed-in PlayFab session associated with either a local Xbox user id or a title-defined custom id.
+`PlayFabUser` represents one signed-in PlayFab session associated with a local Xbox user id, a title-defined custom id, or a token-based identity provider (Steam, OpenID Connect, Battle.net).
 
 Publicly exposed data is intentionally narrow:
 
@@ -111,9 +111,30 @@ Publicly exposed data is intentionally narrow:
 - `entity_key` (`Dictionary` with `id` / `type`)
 - `has_local_user_handle`
 
-Xbox-facing identity details do not belong on the PlayFab user wrapper. The wrapper only exposes what higher-level PlayFab systems need. Custom-ID users have `local_id == 0`, a populated `custom_id`, and no local user handle.
+Xbox-facing identity details do not belong on the PlayFab user wrapper. The wrapper only exposes what higher-level PlayFab systems need. Custom-ID users have `local_id == 0`, a populated `custom_id`, and no local user handle. Token-based identity-provider users (Steam, OpenID Connect, Battle.net) have `local_id == 0`, an empty `custom_id`, and no local user handle; they are identified and de-duplicated in the session cache by their PlayFab `entity_key.id`.
 
 `PlayFab.users` is intentionally cache/result-driven and does not expose user lifecycle signals. Titles should use explicit sign-in results plus cache lookups (`get_user_by_local_id()`, `get_user_by_custom_id()`, and `get_users()`) instead.
+
+### Sign-in method coverage
+
+PlayFab's authentication SDK exposes many login methods, but the GDK flavor of the PlayFab Core C SDK vendored by this addon compiles only a subset of them in. The table below records which sign-in flows the addon wraps, which are intentionally available, and which the GDK SDK build makes impossible to wrap natively.
+
+| Sign-in method | `PlayFab.users` entry point | Token source | Status |
+| --- | --- | --- | --- |
+| Local Xbox user | `sign_in_with_xuser_async(user)` | `GDKUser` object (GDK) | Wrapped |
+| Custom id | `sign_in_with_custom_id_async(custom_id)` | Title-defined string | Wrapped |
+| Steam | `sign_in_with_steam_async(steam_ticket, …)` | Steamworks SDK session ticket | Wrapped (title mints the ticket) |
+| OpenID Connect | `sign_in_with_open_id_connect_async(connection_id, id_token)` | Identity-provider JWT (`id_token`) | Wrapped (title runs the OIDC flow) |
+| Battle.net | `sign_in_with_battle_net_async(identity_token)` | Battle.net OAuth JWT | Wrapped (title runs the OAuth flow) |
+| Email + password | — | PlayFab credentials | Not available — `#if 0` in the GDK SDK headers |
+| PlayFab username + password | — | PlayFab credentials | Not available — `#if 0` in the GDK SDK headers |
+| Register PlayFab user | — | PlayFab credentials | Not available — `#if 0` in the GDK SDK headers |
+| Google / Apple / Facebook / PSN / Nintendo / Game Center / Twitch | — | Platform SDK token | Not available on GDK — gated to other `HC_PLATFORM` targets |
+
+Notes:
+
+- The three wrapped token-based methods (Steam, OpenID Connect, Battle.net) require the title to obtain a platform token through that platform's own SDK or OAuth flow; the addon only forwards the token to PlayFab and does not bundle any third-party SDK. With a placeholder or invalid token the call still completes through the normal async path and surfaces a service error (`playfab_<method>_sign_in_failed`).
+- Steam and Battle.net are gated to `HC_PLATFORM == HC_PLATFORM_GDK` in the SDK headers; OpenID Connect is ungated. The credential-based methods (email/username/register) are hard-disabled (`#if 0`) in the GDK SDK build and cannot be re-enabled from this addon. The PlayFab-native account flows therefore remain represented only by the custom-id and Xbox entry points.
 
 ## Game Saves
 
@@ -209,5 +230,6 @@ Use `sample\tutorial_playfab\` / `sample\tutorial_integrated\` and `tests\godot\
 
 ## Progress
 
+- Additional sign-in examples (#95): ✅ shipped — `PlayFab.users` gained `sign_in_with_steam_async()`, `sign_in_with_open_id_connect_async()`, and `sign_in_with_battle_net_async()` (token-based identity providers that the title authenticates first). Token logins yield an entity-keyed `PlayFabUser` (`local_id == 0`, empty `custom_id`), de-duplicated in the session cache by `entity_key.id`. The credential-based PlayFab flows (email/username/register) and other platform logins (Google, etc.) are unavailable in the GDK SDK build (`#if 0` / non-GDK `HC_PLATFORM` gates) and are documented in the sign-in coverage matrix rather than wrapped. No sample scene was added — the token-based flows cannot complete without a real platform token.
 - MP-test-automation: ✅ complete in the `feat/mpta-c5-c6-finalize` line. The C1 P0/P1 matrix is represented as one `mp_orchestrator` scenario file per scenario, P2/P3 remain deferred, and `tools\run_all_tests.ps1` is wired to run the P0/P1 set under `-Live` with live writes gated by `-AllowLiveWrites`.
 - Legacy PlayFab Multiplayer live harness: ✅ retired. `tools\run_playfab_multiplayer_live.ps1` and `tests\godot\playfab_multiplayer_worker\` have been removed; `tools\run_mp_orchestrator.ps1` is the canonical direct entry point.

--- a/tests/godot/playfab/tests/test_users.gd
+++ b/tests/godot/playfab/tests/test_users.gd
@@ -16,7 +16,7 @@ func test_users_api() -> void:
 	if users == null:
 		return
 
-	for method_name in ["sign_in_with_xuser_async", "sign_in_with_custom_id_async", "get_user_by_local_id", "get_user_by_custom_id", "get_user", "get_users"]:
+	for method_name in ["sign_in_with_xuser_async", "sign_in_with_custom_id_async", "sign_in_with_steam_async", "sign_in_with_open_id_connect_async", "sign_in_with_battle_net_async", "get_user_by_local_id", "get_user_by_custom_id", "get_user", "get_users"]:
 		assert_has_method_named(users, method_name)
 
 	var blank_user_for_cache = instantiate_class("PlayFabUser")
@@ -78,6 +78,58 @@ func test_custom_id_sign_in_validation() -> void:
 	var users_signal = playfab.get_users().sign_in_with_custom_id_async("gdkfleet-test-custom-id")
 	await _assert_playfab_signal_result_error(
 		users_signal, "not_initialized", "PlayFab.users.sign_in_with_custom_id_async() before initialize()")
+
+
+func test_steam_sign_in_validation() -> void:
+	if pending_unless_playfab_available():
+		return
+	var playfab = get_playfab()
+
+	reset_playfab_runtime()
+
+	var empty_signal = playfab.get_users().sign_in_with_steam_async("  ")
+	await _assert_playfab_signal_result_error(
+		empty_signal, "invalid_steam_ticket", "PlayFab.users.sign_in_with_steam_async() rejects blank steam_ticket")
+
+	var not_init_signal = playfab.get_users().sign_in_with_steam_async("DEADBEEF")
+	await _assert_playfab_signal_result_error(
+		not_init_signal, "not_initialized", "PlayFab.users.sign_in_with_steam_async() before initialize()")
+
+
+func test_open_id_connect_sign_in_validation() -> void:
+	if pending_unless_playfab_available():
+		return
+	var playfab = get_playfab()
+
+	reset_playfab_runtime()
+
+	var empty_connection_signal = playfab.get_users().sign_in_with_open_id_connect_async("  ", "id-token")
+	await _assert_playfab_signal_result_error(
+		empty_connection_signal, "invalid_connection_id", "PlayFab.users.sign_in_with_open_id_connect_async() rejects blank connection_id")
+
+	var empty_token_signal = playfab.get_users().sign_in_with_open_id_connect_async("connection", "  ")
+	await _assert_playfab_signal_result_error(
+		empty_token_signal, "invalid_id_token", "PlayFab.users.sign_in_with_open_id_connect_async() rejects blank id_token")
+
+	var not_init_signal = playfab.get_users().sign_in_with_open_id_connect_async("connection", "id-token")
+	await _assert_playfab_signal_result_error(
+		not_init_signal, "not_initialized", "PlayFab.users.sign_in_with_open_id_connect_async() before initialize()")
+
+
+func test_battle_net_sign_in_validation() -> void:
+	if pending_unless_playfab_available():
+		return
+	var playfab = get_playfab()
+
+	reset_playfab_runtime()
+
+	var empty_signal = playfab.get_users().sign_in_with_battle_net_async("  ")
+	await _assert_playfab_signal_result_error(
+		empty_signal, "invalid_identity_token", "PlayFab.users.sign_in_with_battle_net_async() rejects blank identity_token")
+
+	var not_init_signal = playfab.get_users().sign_in_with_battle_net_async("battle-net-jwt")
+	await _assert_playfab_signal_result_error(
+		not_init_signal, "not_initialized", "PlayFab.users.sign_in_with_battle_net_async() before initialize()")
 
 
 # Mirror of the previous `assert_signal_result_error` but routes through the


### PR DESCRIPTION
## Summary

Closes #95.

Adds three **token-based** PlayFab sign-in entry points to the native `godot_playfab` addon, alongside the existing XUser and custom-id flows:

| Provider | Method |
| --- | --- |
| Steam | `PlayFab.users.sign_in_with_steam_async(steam_ticket, create_account := true, ticket_is_service_specific := false)` |
| OpenID Connect | `PlayFab.users.sign_in_with_open_id_connect_async(connection_id, id_token, create_account := true)` |
| Battle.net | `PlayFab.users.sign_in_with_battle_net_async(identity_token, create_account := true)` |

These are the credential providers that actually compile on the **GDK flavor** of the PlayFab Core C SDK. The PlayFab-native credential flows (email + password, PlayFab username + password, register a PlayFab user) are compiled out (`#if 0`) of that SDK, and the other platform logins (Google, Apple, Facebook, PSN, Nintendo, Game Center, Twitch) are gated to non-GDK `HC_PLATFORM` targets — both are documented in the sign-in coverage matrix in `spec/gdext-playfab.md` rather than wrapped. No sample scene was added: these flows cannot complete without a real platform token minted by the title.

## Design notes

- Each provider returns only a `PFEntityHandle`, so the resulting `PlayFabUser` is keyed by its PlayFab **entity id** (`local_id == 0`, empty `custom_id`, no local-user handle).
- A single new `SignInEntityAsyncContext` serves all three flows via injected `GetResultSize`/`GetResult` function pointers (the three SDK signatures are identical). Request string/bool pointers are interned in `std::list` storage owned by the context so they outlive the async dispatch.
- `PlayFabUser::adopt_entity_session()` takes ownership of the entity handle and closes it on populate failure (no leak / no double-close).
- The user cache deduplicates token-only sessions by entity id, but **only against other entity-only sessions**, so a token re-login can never evict a richer XUser/custom-id session (which would drop the `PFLocalUserHandle` that Game Saves needs).

## Usage

```gdscript
# Steam — steam_ticket is a hex-encoded Steamworks session ticket.
# Pass ticket_is_service_specific = true when minted via GetAuthTicketForWebAPI("AzurePlayFab").
var steam_result = await PlayFab.users.sign_in_with_steam_async(steam_ticket, true, false)
if steam_result.ok:
    print(steam_result.data.entity_key)

# OpenID Connect — connection_id names the OIDC connection in PlayFab Game Manager;
# id_token is the JWT returned by the identity provider.
var oidc_result = await PlayFab.users.sign_in_with_open_id_connect_async("my-oidc-connection", id_token)
if not oidc_result.ok:
    push_warning(oidc_result.message)

# Battle.net — identity_token is the JWT returned by the Battle.net OAuth flow.
var battle_net_result = await PlayFab.users.sign_in_with_battle_net_async(identity_token)
if not battle_net_result.ok:
    push_warning(battle_net_result.message)
```

Validation failures resolve immediately (`invalid_steam_ticket`, `invalid_connection_id`, `invalid_id_token`, `invalid_identity_token`, `not_initialized`). A well-formed-but-invalid token runs the full async path and surfaces a service error (`playfab_steam_sign_in_failed` / `playfab_open_id_connect_sign_in_failed` / `playfab_battle_net_sign_in_failed`).

## Vertical coverage

- Native: `playfab_users.{h,cpp}`, `playfab_user.{h,cpp}`
- doc_classes: `PlayFabUsers.xml` (class description + 3 method docs)
- Spec: `spec/gdext-playfab.md` — scope rows, async rule, user/session model, new **sign-in method coverage matrix**, and a `## Progress` entry
- Docs: `docs/playfab/plugin.md` — implemented-now list, "not implemented yet" rationale, and a Sign-in methods section with usage
- Tests: `tests/godot/playfab/tests/test_users.gd` — method exposure + invalid-arg + `not_initialized` validation (non-live)

## Validation

- **Parse gate** (`tools/check_gd_scripts_headless.ps1`): clean.
- **Build** (`cmake --build build --config Debug --target godot_playfab`): compiles/links clean; DLL synced to coverage hosts.
- **PlayFab GUT host**: 73 tests, 0 failures (20 pending = live-gated). The 3 new sign-in tests pass (`test_users.gd`: 7/7, 76 asserts).
- **Live coverage**: **non-live** (default). Real provider tokens cannot be minted in CI; only the validation and `not_initialized` paths are exercised.

## Adversarial review

Ran the two-family review loop (Claude + GPT) on the diff. One consensus issue was fixed: the entity-id cache dedup could **downgrade/evict a richer XUser/custom-id session** (those also populate `entity_id`) when a token-only login matched the same entity. Fixed by only entity-deduping against other entity-only sessions; rebuilt and re-ran tests (still green); both families re-reviewed and confirmed the fix is correct with no new issues. One disputed, non-blocking suggestion remains (compare the full `PFEntityKey {type,id}` instead of `id` alone) — GPT itself rated it low-value hardening since PlayFab title-player entity ids are globally unique.

## Follow-up (separate PR, after this merges)

- `LoginWithXboxAsync` (raw XSTS-token sign-in) is the one remaining GDK-available login not wrapped here; the SDK recommends the already-wrapped `LoginWithXUserAsync` for automatic token refresh.
- C# facade parity on the `experimental/dotnet` branch.
