### PR TITLE
Make guest sign-in opt-in for GDK add_user_with_ui_async (#115)

### DIFF
--- a/addons/godot_gdk/doc_classes/GDKUsers.xml
+++ b/addons/godot_gdk/doc_classes/GDKUsers.xml
@@ -16,8 +16,9 @@
 		</method>
 		<method name="add_user_with_ui_async">
 			<return type="Signal" />
+			<param index="0" name="allow_guests" type="bool" default="false" />
 			<description>
-				Opens the system UI to add a user interactively, allowing guest selection when the platform offers it. This can add another local user, but it does not replace the session primary user once one has already been established. Await the returned completion [Signal] directly; the emitted [GDKResult] data contains the signed-in [GDKUser].
+				Adds a user interactively, surfacing the system sign-in UI. [b]Requires the advanced user model.[/b] Under the simplified (PC-default) user model the native call rejects every interactive add option with [code]E_INVALIDARG[/code]; PC titles should sign in with the silent [method add_default_user_async] instead. By default ([param allow_guests] is [code]false[/code]) it resolves the launching default user with the system sign-in UI. Pass [code]true[/code] to open the full account picker so the player can choose any account, including guests. This can add another local user, but it does not replace the session primary user once one has already been established. Await the returned completion [Signal] directly; the emitted [GDKResult] data contains the signed-in [GDKUser]. Whether dismissing the system UI completes the request is GDK platform behavior; when the platform reports cancellation the completion [Signal] resolves with a failed [GDKResult] whose [code]code[/code] is [code]cancelled[/code].
 			</description>
 		</method>
 		<method name="get_primary_user" qualifiers="const">

--- a/addons/godot_gdk/src/gdk_user.cpp
+++ b/addons/godot_gdk/src/gdk_user.cpp
@@ -734,7 +734,7 @@ void GDKUser::clear() {
 
 void GDKUsers::_bind_methods() {
     ClassDB::bind_method(D_METHOD("add_default_user_async"), &GDKUsers::add_default_user_async);
-    ClassDB::bind_method(D_METHOD("add_user_with_ui_async"), &GDKUsers::add_user_with_ui_async);
+    ClassDB::bind_method(D_METHOD("add_user_with_ui_async", "allow_guests"), &GDKUsers::add_user_with_ui_async, DEFVAL(false));
     ClassDB::bind_method(D_METHOD("get_primary_user"), &GDKUsers::get_primary_user);
     ClassDB::bind_method(D_METHOD("get_users"), &GDKUsers::get_users);
     ClassDB::bind_method(D_METHOD("check_privilege_async", "user", "privilege"), &GDKUsers::check_privilege_async);
@@ -807,10 +807,29 @@ Signal GDKUsers::add_default_user_async() {
     return _start_add_user_async(XUserAddOptions::AddDefaultUserSilently, "Failed to add the default user.");
 }
 
-Signal GDKUsers::add_user_with_ui_async() {
-    return _start_add_user_async(
-            XUserAddOptions::AddDefaultUserAllowingUI | XUserAddOptions::AllowGuests,
-            "Failed to add a user with UI.");
+Signal GDKUsers::add_user_with_ui_async(bool p_allow_guests) {
+    // Interactive add-with-UI is an advanced-user-model feature. Under the
+    // simplified (PC-default) user model, XUserAddAsync rejects every UI/guest
+    // option (None, AllowGuests, AddDefaultUserAllowingUI) with E_INVALIDARG --
+    // only the silent add_default_user_async() path works there. Titles that
+    // call this method must be running the advanced user model.
+    //
+    // p_allow_guests selects the interactive flow:
+    //   false (default) -> AddDefaultUserAllowingUI: resolve the launching
+    //                      default user, surfacing the system sign-in UI.
+    //   true            -> AllowGuests: open the full account picker (without the
+    //                      default/silent flags) so the player can choose any
+    //                      account, including guests.
+    //
+    // When the GDK reports the player cancelled (E_ABORT), finalize() normalizes
+    // it to a cancelled GDKResult. Whether dismissing the system UI fires the
+    // completion callback at all is GDK platform behavior outside the addon's
+    // control (see issue #115); the addon faithfully surfaces whatever the GDK
+    // reports.
+    const XUserAddOptions options = p_allow_guests
+            ? XUserAddOptions::AllowGuests
+            : XUserAddOptions::AddDefaultUserAllowingUI;
+    return _start_add_user_async(options, "Failed to add a user with UI.");
 }
 
 Ref<GDKUser> GDKUsers::get_primary_user() const {

--- a/addons/godot_gdk/src/gdk_user.h
+++ b/addons/godot_gdk/src/gdk_user.h
@@ -110,7 +110,7 @@ public:
     void shutdown();
 
     Signal add_default_user_async();
-    Signal add_user_with_ui_async();
+    Signal add_user_with_ui_async(bool p_allow_guests = false);
     Ref<GDKUser> get_primary_user() const;
     Array get_users() const;
     Signal check_privilege_async(const Ref<GDKUser> &p_user, int64_t p_privilege);

--- a/docs/addon-getting-started.md
+++ b/docs/addon-getting-started.md
@@ -233,8 +233,9 @@ The recommended pattern is:
    the user already signed into the XBOX app on the PC without
    surfacing any UI.
 3. **If silent fails, fall back to UI.** `add_user_with_ui_async()`
-   shows the system account picker so the user can pick or add an
-   account interactively.
+   shows the system sign-in UI so the user can sign in or add an
+   account interactively. Pass `add_user_with_ui_async(true)` for the
+   guest-capable account picker (requires the advanced user model).
 
 ```gdscript
 extends Node

--- a/docs/addon-getting-started.md
+++ b/docs/addon-getting-started.md
@@ -271,7 +271,7 @@ func _ensure_xbox_user() -> GDKUser:
 
     print("[GDK] Silent sign-in failed (%s) — falling back to UI." % silent.message)
 
-    # 3. Fall back to the system account picker.
+    # 3. Fall back to the system sign-in UI for the default user.
     var ui: GDKResult = await GDK.users.add_user_with_ui_async()
     if ui.ok and ui.data != null and ui.data.signed_in:
         return ui.data
@@ -350,7 +350,7 @@ snippets above tells you which step failed.
 |--|--|--|
 | `GDExtension dynamic library not found` | The `bin/` folder didn't make it into the project copy. | Copy `addons/<addon>/` recursively, including `bin/`. |
 | `GDK singleton not registered` | Native DLL failed to load (wrong arch, missing Microsoft GDK install, missing `libHttpClient.dll`). | Install the Microsoft GDK on the machine that runs the game. |
-| Silent sign-in returns `no_default_user` | No test account signed into the XBOX app on the PC, or PC sandbox doesn't match Partner Center. | Sign in a test account via the XBOX app after switching to the right sandbox (step 4). The fallback `add_user_with_ui_async()` will surface the picker. |
+| Silent sign-in returns `no_default_user` | No test account signed into the XBOX app on the PC, or PC sandbox doesn't match Partner Center. | Sign in a test account via the XBOX app after switching to the right sandbox (step 4). The fallback `add_user_with_ui_async()` will surface the sign-in UI. |
 | XBOX Live calls fail with a registration error | `MicrosoftGame.config` is missing, malformed, or has placeholder Title Id / SCID. | Re-run **Microsoft GDK — Edit MicrosoftGame.config** and fill in real Partner Center values. |
 | `PlayFab.initialize()` fails immediately | `playfab/runtime/title_id` is empty. | Set it in Project Settings (step 2). |
 | `sign_in_with_xuser_async` returns `invalid_xuser` | Passing a null or signed-out Microsoft GDK user. | Confirm `xbox_user != null and xbox_user.signed_in` first. |

--- a/docs/gdk/api-reference.md
+++ b/docs/gdk/api-reference.md
@@ -139,7 +139,7 @@ if sandbox_result.ok:
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `add_default_user_async()` | `Signal` | Silent XBOX sign-in for a non-guest user |
-| `add_user_with_ui_async()` | `Signal` | XBOX sign-in with UI prompt for another local user or guest-capable picker flow; it does not replace the session primary user |
+| `add_user_with_ui_async(allow_guests := false)` | `Signal` | Interactive XBOX sign-in. **Requires the advanced user model**; under the simplified (PC-default) user model the native call returns a failed `GDKResult` (`E_INVALIDARG`), so PC titles should use the silent `add_default_user_async()`. By default resolves the launching default user with the system sign-in UI; pass `allow_guests = true` to open the guest-capable account picker. It does not replace the session primary user. When the platform reports cancellation, the result resolves with a failed `GDKResult` whose `code` is `cancelled`. |
 | `get_primary_user()` | `GDKUser` | Current primary user (or `null`) |
 | `get_users()` | `Array` | All local users |
 | `check_privilege_async(user, privilege)` | `Signal` | Check user privilege |

--- a/docs/gdk/async-system.md
+++ b/docs/gdk/async-system.md
@@ -71,7 +71,7 @@ Current public signals:
 Current public methods:
 
 - `add_default_user_async() -> Signal`
-- `add_user_with_ui_async() -> Signal`
+- `add_user_with_ui_async(allow_guests := false) -> Signal`
 - `get_primary_user() -> GDKUser`
 - `get_users() -> Array`
 - `check_privilege_async(user, privilege) -> Signal`

--- a/docs/gdk/native-runtime.md
+++ b/docs/gdk/native-runtime.md
@@ -130,7 +130,7 @@ It currently owns:
 It currently exposes:
 
 - `add_default_user_async()` (returns a completion `Signal`)
-- `add_user_with_ui_async()` (returns a completion `Signal`)
+- `add_user_with_ui_async(allow_guests := false)` (returns a completion `Signal`)
 - `get_primary_user()`
 - `get_users()`
 - `check_privilege_async()` (returns a completion `Signal`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -407,7 +407,7 @@ func _exit_tree() -> void:
 `add_default_user_async()` is the XBOX **silent** sign-in. If no user is
 already signed into the XBOX app on the PC, it returns a non-ok result
 (commonly `no_default_user`). Use `add_user_with_ui_async()` to put the
-system account picker on screen instead.
+system sign-in UI on screen instead.
 
 For the full method/signal table see
 [Microsoft GDK API reference → `GDK.users`](gdk/api-reference.md#users-service-gdkusers).

--- a/docs/platform/xbox-sandbox-and-test-accounts.md
+++ b/docs/platform/xbox-sandbox-and-test-accounts.md
@@ -92,10 +92,10 @@ title screen HUD shows **Microsoft GDK READY · SIGNED IN** with the test accoun
 gamertag and avatar. **If silent sign-in fails** — common when running
 unpackaged from the editor or right after a sandbox switch — the bootstrap
 automatically falls back to `GDK.users.add_user_with_ui_async()`, which
-pops the system identity picker. Pick the test account once and the HUD
+pops the system sign-in UI. Sign in the test account once and the HUD
 flips to signed-in for the rest of the session. (The fallback requires
 [Windows Developer Mode to be enabled](#enabling-windows-developer-mode);
-without it the picker silently no-ops.)
+without it the sign-in UI silently no-ops.)
 
 ### Option B — via `XblDevAccount.exe` (scripted / CI-friendly)
 

--- a/docs/tutorials/gdk/01-signin.md
+++ b/docs/tutorials/gdk/01-signin.md
@@ -2,7 +2,7 @@
 
 ## What you'll build
 
-Build the `GdkAuth` autoload used by the GDK track. It initializes `GDK`, checks for an already-signed-in primary user, tries silent sign-in, falls back to the system account picker, and exposes a read-only `xbox_user` once the state reaches `SIGNED_IN`. The scene `g01_signin` renders that state and lets the player retry.
+Build the `GdkAuth` autoload used by the GDK track. It initializes `GDK`, checks for an already-signed-in primary user, tries silent sign-in, falls back to the system sign-in UI, and exposes a read-only `xbox_user` once the state reaches `SIGNED_IN`. The scene `g01_signin` renders that state and lets the player retry.
 
 ## Prerequisites
 
@@ -164,8 +164,10 @@ func _ensure_xbox_user():
 
 	print("[GdkAuth] Silent sign-in failed (%s) — falling back to UI." % silent.message)
 
-	# 3. UI fallback. Shows the system account picker.
-	var ui = await AddonApi.singleton("GDK").users.add_user_with_ui_async()
+	# 3. UI fallback. Shows the system sign-in UI for the default user.
+	#    Pass add_user_with_ui_async(true) for the guest-capable account
+	#    picker, which requires the advanced user model.
+	var ui = await AddonApi.singleton("GDK").users.add_user_with_ui_async()
 	if ui.ok and ui.data != null and ui.data.signed_in:
 		return ui.data
 
@@ -276,8 +278,8 @@ Run `sample/tutorial_gdk`, open `g01_signin`, and press **Sign in**. You should 
 |---|---|---|
 | `GdkAuth autoload missing` | The autoload is not registered or has the wrong name. | Register `autoload/gdk_auth.gd` as `GdkAuth`. |
 | `gdk.missing` | The GDK extension did not load. | Build the addons and confirm the mirrored `addons/godot_gdk/bin` files exist. |
-| `no_default_user` before UI | No Xbox app default user is available. | This is handled; choose a test account in the UI picker. |
-| `gdk.add_user_with_ui` failure | Picker canceled, wrong sandbox, or test account issue. | Retry, verify sandbox, and confirm the account has access to the title. |
+| `no_default_user` before UI | No Xbox app default user is available. | This is handled; choose a test account in the sign-in UI. |
+| `gdk.add_user_with_ui` failure | Sign-in UI dismissed without choosing an account (`cancelled`), wrong sandbox, or test account issue. | Dismissing now resolves with a `cancelled` result so the game can continue offline; otherwise retry, verify sandbox, and confirm the account has access to the title. |
 
 ## Reference implementation
 

--- a/docs/tutorials/gdk/01-signin.md
+++ b/docs/tutorials/gdk/01-signin.md
@@ -279,7 +279,7 @@ Run `sample/tutorial_gdk`, open `g01_signin`, and press **Sign in**. You should 
 | `GdkAuth autoload missing` | The autoload is not registered or has the wrong name. | Register `autoload/gdk_auth.gd` as `GdkAuth`. |
 | `gdk.missing` | The GDK extension did not load. | Build the addons and confirm the mirrored `addons/godot_gdk/bin` files exist. |
 | `no_default_user` before UI | No Xbox app default user is available. | This is handled; choose a test account in the sign-in UI. |
-| `gdk.add_user_with_ui` failure | Sign-in UI dismissed without choosing an account (`cancelled`), wrong sandbox, or test account issue. | Dismissing now resolves with a `cancelled` result so the game can continue offline; otherwise retry, verify sandbox, and confirm the account has access to the title. |
+| `gdk.add_user_with_ui` failure | Sign-in UI dismissed, wrong sandbox, or test account issue. | When the platform reports the dismissal (`E_ABORT`), the result is `cancelled` so the game can continue offline. Whether dismissing the UI completes the request is GDK platform behavior and is not guaranteed (see issue #115). Otherwise retry, verify sandbox, and confirm the account has access to the title. |
 
 ## Reference implementation
 

--- a/docs/tutorials/integrated/01-signin.md
+++ b/docs/tutorials/integrated/01-signin.md
@@ -143,7 +143,7 @@ func _ensure_xbox_user() -> GDKUser:
 
     print("[Auth] Silent sign-in failed (%s) — falling back to UI." % silent.message)
 
-    # 3. UI fallback. Shows the system account picker.
+    # 3. UI fallback. Shows the system sign-in UI for the default user.
     var ui: GDKResult = await GDK.users.add_user_with_ui_async()
     if ui.ok and ui.data != null and ui.data.signed_in:
         return ui.data

--- a/sample/tutorial_gdk/autoload/gdk_auth.gd
+++ b/sample/tutorial_gdk/autoload/gdk_auth.gd
@@ -137,7 +137,9 @@ func _ensure_xbox_user():
 
 	print("[GdkAuth] Silent sign-in failed (%s) — falling back to UI." % silent.message)
 
-	# 3. UI fallback. Shows the system account picker.
+	# 3. UI fallback. Shows the system sign-in UI for the default user.
+	#    Pass add_user_with_ui_async(true) for the guest-capable account
+	#    picker, which requires the advanced user model.
 	var ui = await AddonApi.singleton("GDK").users.add_user_with_ui_async()
 	if ui.ok and ui.data != null and ui.data.signed_in:
 		return ui.data

--- a/sample/tutorial_integrated/autoload/auth.gd
+++ b/sample/tutorial_integrated/autoload/auth.gd
@@ -159,7 +159,7 @@ func _ensure_xbox_user():
 
 	print("[Auth] Silent sign-in failed (%s) — falling back to UI." % silent.message)
 
-	# 3. UI fallback. Shows the system account picker.
+	# 3. UI fallback. Shows the system sign-in UI for the default user.
 	var ui = await AddonApi.singleton("GDK").users.add_user_with_ui_async()
 	if ui.ok and ui.data != null and ui.data.signed_in:
 		return ui.data

--- a/spec/gdext-gdk.md
+++ b/spec/gdext-gdk.md
@@ -600,7 +600,7 @@ transcribed_chat_received(speaker_xuid: String, message: String)
 
 ```gdscript
 add_default_user_async() -> Signal
-add_user_with_ui_async() -> Signal
+add_user_with_ui_async(allow_guests := false) -> Signal
 get_primary_user() -> GDKUser
 get_users() -> Array[GDKUser]
 check_privilege_async(user: GDKUser, privilege: int) -> Signal
@@ -636,7 +636,7 @@ is_store_user() -> bool
 | Wrapper/API | Native API(s) | Notes |
 | --- | --- | --- |
 | `add_default_user_async()` | `XUserAddAsync`, `XUserAddResult` | Uses the silent default-user path without guest support; on success, populate `GDKUser`, create `XblContextHandle`, and ensure change notifications are registered. |
-| `add_user_with_ui_async()` | `XUserAddAsync`, `XUserAddResult` | Uses the UI-driven add path with guest selection enabled; post-processing is the same as the default-user path except that later adds do not replace the session primary user once one already exists. |
+| `add_user_with_ui_async(allow_guests := false)` | `XUserAddAsync`, `XUserAddResult` | Interactive add path. **Requires the advanced user model** — under the simplified (PC-default) user model `XUserAddAsync` rejects every interactive option (`None`, `AddDefaultUserAllowingUI`, `AllowGuests`) with `E_INVALIDARG`; only the silent `add_default_user_async()` works there. By default (`allow_guests = false`) uses `AddDefaultUserAllowingUI` to resolve the launching default user with the system sign-in UI. Pass `allow_guests = true` to open the full account picker (`AllowGuests`, without the default/silent options) so the player can choose any account, including guests. Whether dismissing the system UI completes the request is GDK platform behavior; when the platform reports cancellation (`E_ABORT`) the wrapper normalizes it to a cancelled `GDKResult`. Post-processing matches the default-user path except that later adds do not replace the session primary user once one already exists. |
 | `check_privilege_async()` | `XUserCheckPrivilege` | There is no documented async privilege-check API in `XUser`; this wrapper should convert the synchronous result into a deferred completion `Signal`. Successful results carry a `Dictionary` in `GDKResult.data` with `privilege`, `has_privilege`, `deny_reason`, and `deny_reason_value`. If the check returns `E_GAMEUSER_RESOLVE_USER_ISSUE_REQUIRED`, the request should fail and direct callers to `resolve_issue_with_ui_async()`. |
 | `resolve_privilege_with_ui_async()` | `XUserResolvePrivilegeWithUiAsync`, `XUserResolvePrivilegeWithUiResult` | Use the native UI remediation path when `check_privilege_async()` reports that a privilege is denied and the title wants to let the player resolve it immediately. Successful results can carry a small `Dictionary` payload that echoes the resolved privilege id. |
 | `resolve_issue_with_ui_async()` | `XUserResolveIssueWithUiAsync`, `XUserResolveIssueWithUiResult` | This is the remediation path for `E_GAMEUSER_RESOLVE_USER_ISSUE_REQUIRED` from `XUser` getters such as age-group lookups and from privilege checks. Treat an empty `url` as the Xbox services/default flow and pass a URL only when the underlying issue is request-specific. |

--- a/tests/godot/gdk/tests/test_users.gd
+++ b/tests/godot/gdk/tests/test_users.gd
@@ -73,6 +73,9 @@ func test_users_full_flow() -> void:
 	var pre_init_add_with_ui_signal = users.add_user_with_ui_async()
 	await assert_signal_result_error(pre_init_add_with_ui_signal, "not_initialized", "add_user_with_ui_async() rejects before initialize")
 
+	var pre_init_add_guest_signal = users.add_user_with_ui_async(true)
+	await assert_signal_result_error(pre_init_add_guest_signal, "not_initialized", "add_user_with_ui_async(true) rejects before initialize")
+
 	var init_result = initialize_runtime()
 	assert_not_null(init_result, "GDK.initialize() for users behavior returns GDKResult")
 	if init_result == null:


### PR DESCRIPTION
## Summary

Relates to #115. `GDK.users.add_user_with_ui_async()` previously **always** forced guest support (`AddDefaultUserAllowingUI | AllowGuests`). Guests are inappropriate for most PC titles, so guest support is now **opt-in** via a new `allow_guests` parameter (default `false`).

## Usage

```gdscript
# Default: resolve the launching default user via the system sign-in UI (no guests)
var result = await GDK.users.add_user_with_ui_async()

# Opt in to the full account picker, including guest accounts (advanced user model)
var result = await GDK.users.add_user_with_ui_async(true)
```

## Behavior

- `allow_guests = false` (default) -> `AddDefaultUserAllowingUI`: surfaces the system sign-in UI for the launching default user.
- `allow_guests = true` -> `AllowGuests`: opens the full account picker so the player can choose any account, including guests.

## On #115 (the dismiss hang)

Interactive add-with-UI is an **advanced-user-model** feature. Under the simplified (PC-default) user model, `XUserAddAsync` rejects every interactive add option (`None`, `AddDefaultUserAllowingUI`, `AllowGuests`) with `E_INVALIDARG` — only the silent `add_default_user_async()` works there (confirmed against a standalone GDK sample app).

The genuine "dismissing the sign-in UI never completes the await" hang reported in #115 is **GDK platform behavior** — the completion callback may not fire on dismiss — and is **not addon-fixable**. When the platform *does* report cancellation (`E_ABORT`), the addon's `finalize()` already normalizes it to a cancelled `GDKResult`. This PR therefore does not auto-close #115; it makes the addon API correct (guests opt-in) and documents the platform constraint so titles use the right sign-in path.

## Validation

- `tools/run_all_tests.ps1` — green (parse gate, debug build, C++ doctest, GUT for gdk/playfab/gameinput hosts, bootstrap runners). Live tests skipped (default).
- Added pre-init test coverage for `add_user_with_ui_async(true)`.

## Docs/spec sync

`doc_classes/GDKUsers.xml`, `spec/gdext-gdk.md`, and the GDK docs/tutorials were updated to document the new parameter and the advanced-user-model requirement, and to correct earlier text that wrongly implied an interactive option works under the simplified user model.
