### PR TITLE
fuzz: libFuzzer infrastructure + PlayFab Party / GDK request-parsing seams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,10 +158,12 @@ godot_addon_mirror_test_support(
         ${GODOT_GUT_HOST_DIRS}
 )
 
-# ── C++ unit tests (doctest) ─────────────────────────────────────
-# Wired up by the parallel `infra-doctest-target` work; this option default
-# stays ON so once that branch lands, builds pick up the production exe.
-option(GDK_BUILD_TESTS "Build C++ unit tests (doctest)" ON)
-if(GDK_BUILD_TESTS)
+# ── C++ unit tests (doctest) + libFuzzer targets ─────────────────
+# GDK_BUILD_TESTS: builds gdk_unit_tests (doctest; no GDK SDK needed).
+# GDK_BUILD_FUZZ_TARGETS: builds libFuzzer targets (requires clang-cl; use
+#   the 'fuzz' preset). Either flag opens tests/cpp.
+option(GDK_BUILD_TESTS        "Build C++ unit tests (doctest)"                                      ON)
+option(GDK_BUILD_FUZZ_TARGETS "Build libFuzzer fuzz targets (requires clang-cl; use 'fuzz' preset)" OFF)
+if(GDK_BUILD_TESTS OR GDK_BUILD_FUZZ_TARGETS)
     add_subdirectory(tests/cpp)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -88,6 +88,43 @@
                 "GDK_DEPENDENCY_SOURCE": "installed",
                 "GAMEINPUT_SOURCE": "nuget"
             }
+        },
+        {
+            "name": "debug-asan",
+            "displayName": "Debug + AddressSanitizer (MSVC)",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build/asan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "/fsanitize=address",
+                "BUILD_GODOT_GDK": "OFF",
+                "BUILD_GODOT_GAMEINPUT": "OFF",
+                "BUILD_GODOT_PLAYFAB": "OFF",
+                "GDK_BUILD_TESTS": "ON"
+            }
+        },
+        {
+            "name": "_fuzz-base",
+            "hidden": true,
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "toolset": "ClangCL",
+            "binaryDir": "${sourceDir}/build/fuzz",
+            "cacheVariables": {
+                "CMAKE_CXX_STANDARD": "17",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded",
+                "CMAKE_CXX_FLAGS": "-fsanitize=address",
+                "CMAKE_TRY_COMPILE_TARGET_TYPE": "STATIC_LIBRARY",
+                "BUILD_GODOT_GDK": "OFF",
+                "BUILD_GODOT_GAMEINPUT": "OFF",
+                "BUILD_GODOT_PLAYFAB": "OFF",
+                "GDK_BUILD_TESTS": "OFF",
+                "GDK_BUILD_FUZZ_TARGETS": "ON"
+            }
+        },
+        {
+            "name": "fuzz",
+            "displayName": "LibFuzzer (clang-cl)",
+            "inherits": "_fuzz-base"
         }
     ],
     "buildPresets": [
@@ -190,6 +227,21 @@
             "displayName": "Release (installed GDK)",
             "configurePreset": "installed-gdk",
             "configuration": "Release"
+        },
+        {
+            "name": "debug-asan",
+            "displayName": "Debug + ASan (gdk_unit_tests)",
+            "configurePreset": "debug-asan",
+            "configuration": "Debug",
+            "targets": [
+                "gdk_unit_tests"
+            ]
+        },
+        {
+            "name": "debug-fuzz",
+            "displayName": "Debug fuzz targets (clang-cl)",
+            "configurePreset": "fuzz",
+            "configuration": "Debug"
         }
     ]
 }

--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(godot_gdk SHARED
     src/gdk_runtime.cpp
     src/gdk_result.cpp
     src/gdk_result_codes_internal.cpp
+    src/gdk_request_parsing.cpp
     src/gdk_pending_signal.cpp
     src/gdk_signal_xasync_context.cpp
     src/gdk_user.cpp

--- a/addons/godot_gdk/src/gdk_game_ui.cpp
+++ b/addons/godot_gdk/src/gdk_game_ui.cpp
@@ -11,6 +11,7 @@
 
 #include "gdk.h"
 #include "gdk_pending_signal.h"
+#include "gdk_request_parsing.h"
 #include "gdk_result.h"
 #include "gdk_runtime.h"
 #include "gdk_signal_xasync_context.h"
@@ -21,29 +22,7 @@ namespace godot {
 namespace {
 
 bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
-    if (r_xuid == nullptr) {
-        return false;
-    }
-
-    const String trimmed = p_xuid.strip_edges();
-    if (trimmed.is_empty()) {
-        return false;
-    }
-
-    const CharString utf8 = trimmed.utf8();
-    if (utf8.get_data() == nullptr || utf8.get_data()[0] == '\0') {
-        return false;
-    }
-
-    char *end = nullptr;
-    errno = 0;
-    const uint64_t parsed = std::strtoull(utf8.get_data(), &end, 10);
-    if (errno != 0 || end == nullptr || *end != '\0' || parsed == 0) {
-        return false;
-    }
-
-    *r_xuid = parsed;
-    return true;
+    return gdk_request_parsing::try_parse_xuid(p_xuid, r_xuid, /*p_reject_zero=*/true);
 }
 
 Ref<GDKResult> _parse_xuid_list(

--- a/addons/godot_gdk/src/gdk_profile.cpp
+++ b/addons/godot_gdk/src/gdk_profile.cpp
@@ -7,6 +7,7 @@
 
 #include "gdk.h"
 #include "gdk_pending_signal.h"
+#include "gdk_request_parsing.h"
 #include "gdk_result.h"
 #include "gdk_runtime.h"
 #include "gdk_signal_xasync_context.h"
@@ -25,25 +26,7 @@ String _utf8_or_empty(const char *p_value) {
 }
 
 bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
-    if (r_xuid == nullptr) {
-        return false;
-    }
-
-    const String normalized = p_xuid.strip_edges();
-    if (normalized.is_empty()) {
-        return false;
-    }
-
-    const CharString utf8 = normalized.utf8();
-    char *end_ptr = nullptr;
-    errno = 0;
-    const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
-    if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
-        return false;
-    }
-
-    *r_xuid = static_cast<uint64_t>(parsed);
-    return true;
+    return gdk_request_parsing::try_parse_xuid(p_xuid, r_xuid, /*p_reject_zero=*/false);
 }
 
 Ref<GDKUserProfile> _make_user_profile(const XblUserProfile &p_profile) {

--- a/addons/godot_gdk/src/gdk_request_parsing.cpp
+++ b/addons/godot_gdk/src/gdk_request_parsing.cpp
@@ -1,0 +1,99 @@
+// gdk_request_parsing.cpp — Implementation of the GDK request-input parsing
+// seam.  See gdk_request_parsing.h for the contract.  This translation unit
+// depends only on godot-cpp built-in types and GDKResult (no Xbox GDK service
+// headers) so it can be compiled into both the production addon and the
+// standalone fuzz harness.
+
+#include "gdk_request_parsing.h"
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+namespace godot {
+namespace gdk_request_parsing {
+
+bool try_parse_xuid(const String &p_xuid, uint64_t *r_xuid, bool p_reject_zero) {
+    if (r_xuid == nullptr) {
+        return false;
+    }
+
+    const String trimmed = p_xuid.strip_edges();
+    if (trimmed.is_empty()) {
+        return false;
+    }
+
+    // Defensive: a null buffer can never parse to a valid XUID. The original
+    // per-call-site helpers passed get_data() straight to strtoull; guarding
+    // here avoids UB without changing observable behavior for any non-empty
+    // trimmed string. We deliberately do NOT reject an empty-content buffer
+    // (first byte '\0') here: for a U+0000-prefixed value strtoull yields 0,
+    // which game-UI (p_reject_zero) rejects below and which title-storage /
+    // profile historically accepted as XUID 0 — matching each original helper.
+    const CharString utf8 = trimmed.utf8();
+    if (utf8.get_data() == nullptr) {
+        return false;
+    }
+
+    char *end = nullptr;
+    errno = 0;
+    const unsigned long long parsed = std::strtoull(utf8.get_data(), &end, 10);
+    if (errno != 0 || end == nullptr || *end != '\0') {
+        return false;
+    }
+    if (p_reject_zero && parsed == 0) {
+        return false;
+    }
+
+    *r_xuid = static_cast<uint64_t>(parsed);
+    return true;
+}
+
+Ref<GDKResult> parse_uint32(const String &p_name, int64_t p_value, uint32_t *r_value) {
+    if (r_value == nullptr) {
+        return GDKResult::error_result(E_POINTER, "invalid_output", "Output storage is unavailable.");
+    }
+    if (p_value < 0 || p_value > static_cast<int64_t>(UINT32_MAX)) {
+        return GDKResult::error_result(E_INVALIDARG, String("invalid_") + p_name, p_name + String(" must fit in a non-negative 32-bit unsigned integer."));
+    }
+
+    *r_value = static_cast<uint32_t>(p_value);
+    return GDKResult::ok_result();
+}
+
+Ref<GDKResult> copy_utf8_to_buffer(const String &p_value, char *p_buffer, size_t p_buffer_size, const String &p_field_name) {
+    if (p_buffer == nullptr || p_buffer_size == 0) {
+        return GDKResult::error_result(E_POINTER, "invalid_output", "String output storage is unavailable.");
+    }
+
+    const CharString utf8 = p_value.utf8();
+    const size_t length = std::strlen(utf8.get_data());
+    if (length >= p_buffer_size) {
+        return GDKResult::error_result(E_INVALIDARG, String("invalid_") + p_field_name, p_field_name + String(" is too long."));
+    }
+
+    std::memset(p_buffer, 0, p_buffer_size);
+    std::memcpy(p_buffer, utf8.get_data(), length);
+    return GDKResult::ok_result();
+}
+
+PackedByteArray to_packed_byte_array(const std::vector<uint8_t> &p_data) {
+    PackedByteArray result;
+    result.resize(static_cast<int64_t>(p_data.size()));
+    for (int64_t i = 0; i < result.size(); ++i) {
+        result.set(i, p_data[static_cast<size_t>(i)]);
+    }
+    return result;
+}
+
+std::vector<uint8_t> to_byte_vector(const PackedByteArray &p_data) {
+    std::vector<uint8_t> result;
+    result.reserve(static_cast<size_t>(p_data.size()));
+    for (int64_t i = 0; i < p_data.size(); ++i) {
+        result.push_back(static_cast<uint8_t>(p_data[i]));
+    }
+    return result;
+}
+
+} // namespace gdk_request_parsing
+} // namespace godot

--- a/addons/godot_gdk/src/gdk_request_parsing.h
+++ b/addons/godot_gdk/src/gdk_request_parsing.h
@@ -1,0 +1,61 @@
+// gdk_request_parsing.h — Engine-free seam for GDK request-input parsing.
+//
+// Several GDK service wrappers (title storage, profile, game UI) share the same
+// input-validation helpers: parse a decimal XUID, bounds-check a uint32 field,
+// copy a UTF-8 string into a fixed native buffer, and convert between
+// PackedByteArray and std::vector<uint8_t>. These operate on caller-supplied
+// (ultimately script-supplied) values and touch raw memory (strtoull, memcpy
+// into fixed buffers, byte-buffer round-trips), so they are the addon's
+// memory-relevant request surface.
+//
+// The helpers use only godot-cpp built-in types plus GDKResult (which is itself
+// SDK-free), with no dependency on the Xbox GDK service headers, so they can be
+// compiled into both the production addon and the standalone fuzz harness (see
+// tests/cpp/fuzz/fuzz_gdk_request_parsing.cpp).
+#ifndef GDK_REQUEST_PARSING_H
+#define GDK_REQUEST_PARSING_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// gdk_result.h must precede the godot-cpp variant headers below: it includes
+// <windows.h> (for HRESULT) which defines a CONNECT_DEFERRED macro, and the
+// godot-cpp include chain it pulls in runs godot_cpp/core/defs.hpp's
+// `#undef CONNECT_DEFERRED` *after* that macro is defined. Including a plain
+// godot header (string.hpp / packed_byte_array.hpp) first would mark defs.hpp's
+// include guard early, so its undef would be skipped and Object's
+// CONNECT_DEFERRED enum would fail to parse.
+#include "gdk_result.h"
+
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+namespace gdk_request_parsing {
+
+// Parse a decimal XUID string. Returns false on empty/whitespace input, a
+// non-numeric or partially-numeric value, or strtoull range error. When
+// p_reject_zero is true a parsed value of 0 is also rejected (the game-UI call
+// path treats 0 as invalid; the title-storage and profile paths accept it).
+bool try_parse_xuid(const String &p_xuid, uint64_t *r_xuid, bool p_reject_zero);
+
+// Validate that p_value fits in a non-negative 32-bit unsigned integer and
+// write it to *r_value. Returns a GDKResult describing success or the failure.
+Ref<GDKResult> parse_uint32(const String &p_name, int64_t p_value, uint32_t *r_value);
+
+// Copy the UTF-8 encoding of p_value (including a trailing NUL) into the fixed
+// buffer p_buffer of capacity p_buffer_size. Returns a GDKResult describing
+// success, a null/zero-size buffer, or an over-length value.
+Ref<GDKResult> copy_utf8_to_buffer(const String &p_value, char *p_buffer, size_t p_buffer_size, const String &p_field_name);
+
+// Convert a byte vector to a PackedByteArray.
+PackedByteArray to_packed_byte_array(const std::vector<uint8_t> &p_data);
+
+// Convert a PackedByteArray to a byte vector.
+std::vector<uint8_t> to_byte_vector(const PackedByteArray &p_data);
+
+} // namespace gdk_request_parsing
+} // namespace godot
+
+#endif // GDK_REQUEST_PARSING_H

--- a/addons/godot_gdk/src/gdk_title_storage.cpp
+++ b/addons/godot_gdk/src/gdk_title_storage.cpp
@@ -8,6 +8,7 @@
 
 #include "gdk.h"
 #include "gdk_pending_signal.h"
+#include "gdk_request_parsing.h"
 #include "gdk_result.h"
 #include "gdk_runtime.h"
 #include "gdk_signal_xasync_context.h"
@@ -27,25 +28,7 @@ String _normalize_token(const String &p_value) {
 }
 
 bool _try_parse_xuid(const String &p_xuid, uint64_t *r_xuid) {
-    if (r_xuid == nullptr) {
-        return false;
-    }
-
-    const String normalized = p_xuid.strip_edges();
-    if (normalized.is_empty()) {
-        return false;
-    }
-
-    const CharString utf8 = normalized.utf8();
-    char *end_ptr = nullptr;
-    errno = 0;
-    const unsigned long long parsed = std::strtoull(utf8.get_data(), &end_ptr, 10);
-    if (errno != 0 || end_ptr == nullptr || *end_ptr != '\0') {
-        return false;
-    }
-
-    *r_xuid = static_cast<uint64_t>(parsed);
-    return true;
+    return gdk_request_parsing::try_parse_xuid(p_xuid, r_xuid, /*p_reject_zero=*/false);
 }
 
 bool _try_parse_storage_type(const String &p_storage_type, XblTitleStorageType *r_storage_type) {
@@ -114,31 +97,11 @@ bool _try_parse_match_condition(const String &p_match_condition, XblTitleStorage
 }
 
 Ref<GDKResult> _parse_uint32(const String &p_name, int64_t p_value, uint32_t *r_value) {
-    if (r_value == nullptr) {
-        return GDKResult::error_result(E_POINTER, "invalid_output", "Output storage is unavailable.");
-    }
-    if (p_value < 0 || p_value > static_cast<int64_t>(UINT32_MAX)) {
-        return GDKResult::error_result(E_INVALIDARG, String("invalid_") + p_name, p_name + String(" must fit in a non-negative 32-bit unsigned integer."));
-    }
-
-    *r_value = static_cast<uint32_t>(p_value);
-    return GDKResult::ok_result();
+    return gdk_request_parsing::parse_uint32(p_name, p_value, r_value);
 }
 
 Ref<GDKResult> _copy_utf8_to_buffer(const String &p_value, char *p_buffer, size_t p_buffer_size, const String &p_field_name) {
-    if (p_buffer == nullptr || p_buffer_size == 0) {
-        return GDKResult::error_result(E_POINTER, "invalid_output", "String output storage is unavailable.");
-    }
-
-    const CharString utf8 = p_value.utf8();
-    const size_t length = std::strlen(utf8.get_data());
-    if (length >= p_buffer_size) {
-        return GDKResult::error_result(E_INVALIDARG, String("invalid_") + p_field_name, p_field_name + String(" is too long."));
-    }
-
-    std::memset(p_buffer, 0, p_buffer_size);
-    std::memcpy(p_buffer, utf8.get_data(), length);
-    return GDKResult::ok_result();
+    return gdk_request_parsing::copy_utf8_to_buffer(p_value, p_buffer, p_buffer_size, p_field_name);
 }
 
 Ref<GDKResult> _make_blob_metadata(
@@ -195,21 +158,11 @@ Ref<GDKTitleStorageBlobMetadata> _make_metadata_ref(const XblTitleStorageBlobMet
 }
 
 PackedByteArray _make_packed_byte_array(const std::vector<uint8_t> &p_data) {
-    PackedByteArray result;
-    result.resize(static_cast<int64_t>(p_data.size()));
-    for (int64_t i = 0; i < result.size(); ++i) {
-        result.set(i, p_data[static_cast<size_t>(i)]);
-    }
-    return result;
+    return gdk_request_parsing::to_packed_byte_array(p_data);
 }
 
 std::vector<uint8_t> _make_byte_vector(const PackedByteArray &p_data) {
-    std::vector<uint8_t> result;
-    result.reserve(static_cast<size_t>(p_data.size()));
-    for (int64_t i = 0; i < p_data.size(); ++i) {
-        result.push_back(static_cast<uint8_t>(p_data[i]));
-    }
-    return result;
+    return gdk_request_parsing::to_byte_vector(p_data);
 }
 
 const XblTitleStorageBlobMetadata *_find_exact_metadata(const XblTitleStorageBlobMetadata *p_items, size_t p_count, const String &p_blob_path) {

--- a/addons/godot_playfab/CMakeLists.txt
+++ b/addons/godot_playfab/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(godot_playfab SHARED
     src/api/playfab_api_models.cpp
     src/api/playfab_api_services.cpp
     src/playfab_multiplayer.cpp
+    src/playfab_party_codec.cpp
     src/playfab_party.cpp
 )
 

--- a/addons/godot_playfab/CMakeLists.txt
+++ b/addons/godot_playfab/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(godot_playfab SHARED
     src/playfab_result_codes_internal.cpp
     src/playfab_pending_signal.cpp
     src/playfab_api_helpers.cpp
+    src/playfab_request_value.cpp
     src/playfab_signal_xasync_context.cpp
     src/playfab_user.cpp
     src/playfab_users.cpp

--- a/addons/godot_playfab/src/playfab_api_helpers.cpp
+++ b/addons/godot_playfab/src/playfab_api_helpers.cpp
@@ -2,6 +2,8 @@
 
 #include <godot_cpp/classes/json.hpp>
 
+#include "playfab_request_key.h"
+
 namespace godot {
 namespace playfab_api {
 
@@ -26,6 +28,12 @@ bool get_request_value(const Dictionary &p_request, const char *p_field_name, co
         return false;
     }
 
+    // Priority: snake_case name first, PascalCase fallback. The pure equivalent
+    // of this selection logic is playfab_internal::match_request_key, which
+    // is fuzz-tested in tests/cpp/fuzz/fuzz_playfab_key_lookup.cpp and
+    // doctest-covered in tests/cpp/request_key/test_playfab_request_key.cpp.
+    // Production code uses O(1) hash lookups via StringName to avoid the linear
+    // scan in match_request_key.
     const StringName snake_name(p_snake_name);
     if (p_request.has(snake_name)) {
         *r_value = p_request[snake_name];
@@ -47,3 +55,4 @@ String variant_to_json_string(const Variant &p_value) {
 
 } // namespace playfab_api
 } // namespace godot
+

--- a/addons/godot_playfab/src/playfab_api_helpers.cpp
+++ b/addons/godot_playfab/src/playfab_api_helpers.cpp
@@ -3,6 +3,7 @@
 #include <godot_cpp/classes/json.hpp>
 
 #include "playfab_request_key.h"
+#include "playfab_request_value.h"
 
 namespace godot {
 namespace playfab_api {
@@ -21,32 +22,6 @@ Signal make_error_signal(
     pending_signal.instantiate();
     pending_signal->complete_deferred(PlayFabResult::error_result(p_hresult, p_code, p_message, p_data));
     return pending_signal->get_completed_signal();
-}
-
-bool get_request_value(const Dictionary &p_request, const char *p_field_name, const char *p_snake_name, Variant *r_value) {
-    if (r_value == nullptr) {
-        return false;
-    }
-
-    // Priority: snake_case name first, PascalCase fallback. The pure equivalent
-    // of this selection logic is playfab_internal::match_request_key, which
-    // is fuzz-tested in tests/cpp/fuzz/fuzz_playfab_key_lookup.cpp and
-    // doctest-covered in tests/cpp/request_key/test_playfab_request_key.cpp.
-    // Production code uses O(1) hash lookups via StringName to avoid the linear
-    // scan in match_request_key.
-    const StringName snake_name(p_snake_name);
-    if (p_request.has(snake_name)) {
-        *r_value = p_request[snake_name];
-        return true;
-    }
-
-    const StringName field_name(p_field_name);
-    if (p_request.has(field_name)) {
-        *r_value = p_request[field_name];
-        return true;
-    }
-
-    return false;
 }
 
 String variant_to_json_string(const Variant &p_value) {

--- a/addons/godot_playfab/src/playfab_api_helpers.h
+++ b/addons/godot_playfab/src/playfab_api_helpers.h
@@ -16,6 +16,7 @@
 #include <godot_cpp/variant/variant.hpp>
 
 #include "playfab_pending_signal.h"
+#include "playfab_request_value.h"
 #include "playfab_result.h"
 #include "playfab_runtime.h"
 #include "playfab_signal_xasync_context.h"
@@ -34,7 +35,6 @@ namespace playfab_api {
 using VariantEncoder = Variant (*)(const void *);
 
 Signal make_error_signal(PlayFabRuntime *p_runtime, HRESULT p_hresult, const String &p_code, const String &p_message, const Variant &p_data = Variant());
-bool get_request_value(const Dictionary &p_request, const char *p_field_name, const char *p_snake_name, Variant *r_value);
 String variant_to_json_string(const Variant &p_value);
 
 template <typename RequestOwner, typename RequestT, HRESULT (*StartFn)(PFEntityHandle, const RequestT *, XAsyncBlock *)>

--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -12,6 +12,7 @@
 #include <godot_cpp/classes/project_settings.hpp>
 
 #include "playfab.h"
+#include "playfab_party_codec.h"
 #include "playfab_pending_signal.h"
 #include "playfab_result.h"
 #include "playfab_runtime.h"
@@ -37,12 +38,19 @@ constexpr const char *PARTY_CHAT_CONTROL_CREATE_FAILED = "party_chat_control_cre
 constexpr const char *PARTY_CHAT_PERMISSION_FAILED = "party_chat_permission_failed";
 constexpr const char *PARTY_STATE_FINISH_FAILED = "party_state_finish_failed";
 
-// Reserved transport-control packet protocol marker. The first byte of every
-// envelope identifies the packet kind; gameplay packets are forwarded to
-// _get_packet(), control packets are consumed internally.
-constexpr uint8_t PACKET_KIND_GAMEPLAY = 0x00;
-constexpr uint8_t PACKET_KIND_HANDSHAKE_REQUEST = 0x01;
-constexpr uint8_t PACKET_KIND_HANDSHAKE_REPLY = 0x02;
+// The wire packet kind markers and the transport codec (build/parse handshake,
+// wrap/unwrap gameplay) live in the engine-free playfab_party_codec seam so
+// they can be fuzzed standalone (tests/cpp/fuzz/fuzz_playfab_party_codec.cpp).
+// They are re-exposed unqualified here so the call sites below stay unchanged.
+using pf_party_codec::PACKET_KIND_GAMEPLAY;
+using pf_party_codec::PACKET_KIND_HANDSHAKE_REQUEST;
+using pf_party_codec::PACKET_KIND_HANDSHAKE_REPLY;
+using pf_party_codec::build_handshake_request;
+using pf_party_codec::build_handshake_reply;
+using pf_party_codec::parse_handshake_request;
+using pf_party_codec::parse_handshake_reply;
+using pf_party_codec::wrap_gameplay_payload;
+using pf_party_codec::unwrap_gameplay_payload;
 
 constexpr int32_t HOST_PEER_ID = 1;
 
@@ -136,141 +144,6 @@ uint32_t random_handshake_nonce() {
     static thread_local std::mt19937 generator{std::random_device{}()};
     std::uniform_int_distribution<uint32_t> distribution(1, UINT32_MAX);
     return distribution(generator);
-}
-
-PackedByteArray build_handshake_request(uint32_t p_nonce, const String &p_entity_id, const String &p_entity_type) {
-    const CharString id_utf8 = p_entity_id.utf8();
-    const CharString type_utf8 = p_entity_type.utf8();
-    const uint16_t id_len = static_cast<uint16_t>(id_utf8.length());
-    const uint16_t type_len = static_cast<uint16_t>(type_utf8.length());
-
-    PackedByteArray packet;
-    packet.resize(1 + sizeof(uint32_t) + sizeof(uint16_t) + id_len + sizeof(uint16_t) + type_len);
-    int32_t offset = 0;
-    packet[offset++] = static_cast<uint8_t>(PACKET_KIND_HANDSHAKE_REQUEST);
-    std::memcpy(packet.ptrw() + offset, &p_nonce, sizeof(uint32_t));
-    offset += sizeof(uint32_t);
-    std::memcpy(packet.ptrw() + offset, &id_len, sizeof(uint16_t));
-    offset += sizeof(uint16_t);
-    if (id_len > 0) {
-        std::memcpy(packet.ptrw() + offset, id_utf8.get_data(), id_len);
-        offset += id_len;
-    }
-    std::memcpy(packet.ptrw() + offset, &type_len, sizeof(uint16_t));
-    offset += sizeof(uint16_t);
-    if (type_len > 0) {
-        std::memcpy(packet.ptrw() + offset, type_utf8.get_data(), type_len);
-    }
-    return packet;
-}
-
-PackedByteArray build_handshake_reply(uint32_t p_nonce, int32_t p_assigned_peer_id) {
-    PackedByteArray packet;
-    packet.resize(1 + sizeof(uint32_t) + sizeof(int32_t));
-    packet[0] = static_cast<uint8_t>(PACKET_KIND_HANDSHAKE_REPLY);
-    std::memcpy(packet.ptrw() + 1, &p_nonce, sizeof(uint32_t));
-    std::memcpy(packet.ptrw() + 1 + sizeof(uint32_t), &p_assigned_peer_id, sizeof(int32_t));
-    return packet;
-}
-
-bool parse_handshake_request(const uint8_t *p_buffer, uint32_t p_size, uint32_t *r_nonce, String *r_entity_id, String *r_entity_type) {
-    if (p_buffer == nullptr || p_size < 1 + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t)) {
-        return false;
-    }
-    if (p_buffer[0] != PACKET_KIND_HANDSHAKE_REQUEST) {
-        return false;
-    }
-    uint32_t offset = 1;
-    if (r_nonce != nullptr) {
-        std::memcpy(r_nonce, p_buffer + offset, sizeof(uint32_t));
-    }
-    offset += sizeof(uint32_t);
-    uint16_t id_len = 0;
-    std::memcpy(&id_len, p_buffer + offset, sizeof(uint16_t));
-    offset += sizeof(uint16_t);
-    if (offset + id_len > p_size) {
-        return false;
-    }
-    if (r_entity_id != nullptr && id_len > 0) {
-        *r_entity_id = String::utf8(reinterpret_cast<const char *>(p_buffer + offset), id_len);
-    }
-    offset += id_len;
-    if (offset + sizeof(uint16_t) > p_size) {
-        return false;
-    }
-    uint16_t type_len = 0;
-    std::memcpy(&type_len, p_buffer + offset, sizeof(uint16_t));
-    offset += sizeof(uint16_t);
-    if (offset + type_len > p_size) {
-        return false;
-    }
-    if (r_entity_type != nullptr && type_len > 0) {
-        *r_entity_type = String::utf8(reinterpret_cast<const char *>(p_buffer + offset), type_len);
-    }
-    return true;
-}
-
-bool parse_handshake_reply(const uint8_t *p_buffer, uint32_t p_size, uint32_t *r_nonce, int32_t *r_assigned_peer_id) {
-    if (p_buffer == nullptr || p_size < 1 + sizeof(uint32_t) + sizeof(int32_t)) {
-        return false;
-    }
-    if (p_buffer[0] != PACKET_KIND_HANDSHAKE_REPLY) {
-        return false;
-    }
-    if (r_nonce != nullptr) {
-        std::memcpy(r_nonce, p_buffer + 1, sizeof(uint32_t));
-    }
-    if (r_assigned_peer_id != nullptr) {
-        std::memcpy(r_assigned_peer_id, p_buffer + 1 + sizeof(uint32_t), sizeof(int32_t));
-    }
-    return true;
-}
-
-PackedByteArray wrap_gameplay_payload(int32_t p_source_peer, int32_t p_channel, MultiplayerPeer::TransferMode p_mode, const uint8_t *p_buffer, uint32_t p_size) {
-    PackedByteArray envelope;
-    envelope.resize(1 + sizeof(int32_t) + sizeof(int32_t) + 1 + p_size);
-    int32_t offset = 0;
-    envelope[offset++] = static_cast<uint8_t>(PACKET_KIND_GAMEPLAY);
-    std::memcpy(envelope.ptrw() + offset, &p_source_peer, sizeof(int32_t));
-    offset += sizeof(int32_t);
-    std::memcpy(envelope.ptrw() + offset, &p_channel, sizeof(int32_t));
-    offset += sizeof(int32_t);
-    envelope[offset++] = static_cast<uint8_t>(p_mode);
-    if (p_size > 0) {
-        std::memcpy(envelope.ptrw() + offset, p_buffer, p_size);
-    }
-    return envelope;
-}
-
-bool unwrap_gameplay_payload(const uint8_t *p_buffer, uint32_t p_size, int32_t *r_source_peer, int32_t *r_channel, MultiplayerPeer::TransferMode *r_mode, PackedByteArray *r_payload) {
-    if (p_buffer == nullptr || p_size < 1 + sizeof(int32_t) + sizeof(int32_t) + 1) {
-        return false;
-    }
-    if (p_buffer[0] != PACKET_KIND_GAMEPLAY) {
-        return false;
-    }
-    int32_t source_peer = 0;
-    int32_t channel = 0;
-    std::memcpy(&source_peer, p_buffer + 1, sizeof(int32_t));
-    std::memcpy(&channel, p_buffer + 1 + sizeof(int32_t), sizeof(int32_t));
-    const uint8_t mode_value = p_buffer[1 + sizeof(int32_t) * 2];
-    const uint32_t payload_size = p_size - (1 + sizeof(int32_t) * 2 + 1);
-    if (r_source_peer != nullptr) {
-        *r_source_peer = source_peer;
-    }
-    if (r_channel != nullptr) {
-        *r_channel = channel;
-    }
-    if (r_mode != nullptr) {
-        *r_mode = static_cast<MultiplayerPeer::TransferMode>(mode_value);
-    }
-    if (r_payload != nullptr) {
-        r_payload->resize(payload_size);
-        if (payload_size > 0) {
-            std::memcpy(r_payload->ptrw(), p_buffer + (1 + sizeof(int32_t) * 2 + 1), payload_size);
-        }
-    }
-    return true;
 }
 
 bool dictionary_entity_key_equals(const Dictionary &a, const Dictionary &b) {

--- a/addons/godot_playfab/src/playfab_party_codec.cpp
+++ b/addons/godot_playfab/src/playfab_party_codec.cpp
@@ -1,0 +1,151 @@
+// playfab_party_codec.cpp — Implementation of the PlayFab Party wire codec.
+//
+// See playfab_party_codec.h for the contract. This translation unit depends
+// only on godot-cpp built-in types and the C++ standard library (no PlayFab
+// Party SDK headers) so it can be compiled into both the production addon and
+// the standalone fuzz harness.
+
+#include "playfab_party_codec.h"
+
+#include <cstring>
+
+namespace godot {
+namespace pf_party_codec {
+
+PackedByteArray build_handshake_request(uint32_t p_nonce, const String &p_entity_id, const String &p_entity_type) {
+    const CharString id_utf8 = p_entity_id.utf8();
+    const CharString type_utf8 = p_entity_type.utf8();
+    const uint16_t id_len = static_cast<uint16_t>(id_utf8.length());
+    const uint16_t type_len = static_cast<uint16_t>(type_utf8.length());
+
+    PackedByteArray packet;
+    packet.resize(1 + sizeof(uint32_t) + sizeof(uint16_t) + id_len + sizeof(uint16_t) + type_len);
+    int32_t offset = 0;
+    packet[offset++] = static_cast<uint8_t>(PACKET_KIND_HANDSHAKE_REQUEST);
+    std::memcpy(packet.ptrw() + offset, &p_nonce, sizeof(uint32_t));
+    offset += sizeof(uint32_t);
+    std::memcpy(packet.ptrw() + offset, &id_len, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+    if (id_len > 0) {
+        std::memcpy(packet.ptrw() + offset, id_utf8.get_data(), id_len);
+        offset += id_len;
+    }
+    std::memcpy(packet.ptrw() + offset, &type_len, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+    if (type_len > 0) {
+        std::memcpy(packet.ptrw() + offset, type_utf8.get_data(), type_len);
+    }
+    return packet;
+}
+
+PackedByteArray build_handshake_reply(uint32_t p_nonce, int32_t p_assigned_peer_id) {
+    PackedByteArray packet;
+    packet.resize(1 + sizeof(uint32_t) + sizeof(int32_t));
+    packet[0] = static_cast<uint8_t>(PACKET_KIND_HANDSHAKE_REPLY);
+    std::memcpy(packet.ptrw() + 1, &p_nonce, sizeof(uint32_t));
+    std::memcpy(packet.ptrw() + 1 + sizeof(uint32_t), &p_assigned_peer_id, sizeof(int32_t));
+    return packet;
+}
+
+bool parse_handshake_request(const uint8_t *p_buffer, uint32_t p_size, uint32_t *r_nonce, String *r_entity_id, String *r_entity_type) {
+    if (p_buffer == nullptr || p_size < 1 + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint16_t)) {
+        return false;
+    }
+    if (p_buffer[0] != PACKET_KIND_HANDSHAKE_REQUEST) {
+        return false;
+    }
+    uint32_t offset = 1;
+    if (r_nonce != nullptr) {
+        std::memcpy(r_nonce, p_buffer + offset, sizeof(uint32_t));
+    }
+    offset += sizeof(uint32_t);
+    uint16_t id_len = 0;
+    std::memcpy(&id_len, p_buffer + offset, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+    if (offset + id_len > p_size) {
+        return false;
+    }
+    if (r_entity_id != nullptr && id_len > 0) {
+        *r_entity_id = String::utf8(reinterpret_cast<const char *>(p_buffer + offset), id_len);
+    }
+    offset += id_len;
+    if (offset + sizeof(uint16_t) > p_size) {
+        return false;
+    }
+    uint16_t type_len = 0;
+    std::memcpy(&type_len, p_buffer + offset, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+    if (offset + type_len > p_size) {
+        return false;
+    }
+    if (r_entity_type != nullptr && type_len > 0) {
+        *r_entity_type = String::utf8(reinterpret_cast<const char *>(p_buffer + offset), type_len);
+    }
+    return true;
+}
+
+bool parse_handshake_reply(const uint8_t *p_buffer, uint32_t p_size, uint32_t *r_nonce, int32_t *r_assigned_peer_id) {
+    if (p_buffer == nullptr || p_size < 1 + sizeof(uint32_t) + sizeof(int32_t)) {
+        return false;
+    }
+    if (p_buffer[0] != PACKET_KIND_HANDSHAKE_REPLY) {
+        return false;
+    }
+    if (r_nonce != nullptr) {
+        std::memcpy(r_nonce, p_buffer + 1, sizeof(uint32_t));
+    }
+    if (r_assigned_peer_id != nullptr) {
+        std::memcpy(r_assigned_peer_id, p_buffer + 1 + sizeof(uint32_t), sizeof(int32_t));
+    }
+    return true;
+}
+
+PackedByteArray wrap_gameplay_payload(int32_t p_source_peer, int32_t p_channel, MultiplayerPeer::TransferMode p_mode, const uint8_t *p_buffer, uint32_t p_size) {
+    PackedByteArray envelope;
+    envelope.resize(1 + sizeof(int32_t) + sizeof(int32_t) + 1 + p_size);
+    int32_t offset = 0;
+    envelope[offset++] = static_cast<uint8_t>(PACKET_KIND_GAMEPLAY);
+    std::memcpy(envelope.ptrw() + offset, &p_source_peer, sizeof(int32_t));
+    offset += sizeof(int32_t);
+    std::memcpy(envelope.ptrw() + offset, &p_channel, sizeof(int32_t));
+    offset += sizeof(int32_t);
+    envelope[offset++] = static_cast<uint8_t>(p_mode);
+    if (p_size > 0) {
+        std::memcpy(envelope.ptrw() + offset, p_buffer, p_size);
+    }
+    return envelope;
+}
+
+bool unwrap_gameplay_payload(const uint8_t *p_buffer, uint32_t p_size, int32_t *r_source_peer, int32_t *r_channel, MultiplayerPeer::TransferMode *r_mode, PackedByteArray *r_payload) {
+    if (p_buffer == nullptr || p_size < 1 + sizeof(int32_t) + sizeof(int32_t) + 1) {
+        return false;
+    }
+    if (p_buffer[0] != PACKET_KIND_GAMEPLAY) {
+        return false;
+    }
+    int32_t source_peer = 0;
+    int32_t channel = 0;
+    std::memcpy(&source_peer, p_buffer + 1, sizeof(int32_t));
+    std::memcpy(&channel, p_buffer + 1 + sizeof(int32_t), sizeof(int32_t));
+    const uint8_t mode_value = p_buffer[1 + sizeof(int32_t) * 2];
+    const uint32_t payload_size = p_size - (1 + sizeof(int32_t) * 2 + 1);
+    if (r_source_peer != nullptr) {
+        *r_source_peer = source_peer;
+    }
+    if (r_channel != nullptr) {
+        *r_channel = channel;
+    }
+    if (r_mode != nullptr) {
+        *r_mode = static_cast<MultiplayerPeer::TransferMode>(mode_value);
+    }
+    if (r_payload != nullptr) {
+        r_payload->resize(payload_size);
+        if (payload_size > 0) {
+            std::memcpy(r_payload->ptrw(), p_buffer + (1 + sizeof(int32_t) * 2 + 1), payload_size);
+        }
+    }
+    return true;
+}
+
+} // namespace pf_party_codec
+} // namespace godot

--- a/addons/godot_playfab/src/playfab_party_codec.h
+++ b/addons/godot_playfab/src/playfab_party_codec.h
@@ -1,0 +1,64 @@
+// playfab_party_codec.h — Engine-free seam for the PlayFab Party transport
+// wire codec.
+//
+// PlayFabParty layers its own length-prefixed packet format on top of the
+// opaque data messages delivered by PlayFab Party. Every packet begins with a
+// one-byte kind marker; handshake packets carry entity-id/peer-id fields and
+// gameplay packets wrap an arbitrary payload. The parse_* functions consume
+// bytes that originate from a remote peer, so they are the addon's primary
+// untrusted-input surface and the reason this codec lives in its own seam:
+// the functions use only godot-cpp built-in types (PackedByteArray, String)
+// and the MultiplayerPeer::TransferMode enum, with no dependency on the
+// PlayFab Party SDK headers, which makes them fuzzable in the standalone
+// harness (see tests/cpp/fuzz/fuzz_playfab_party_codec.cpp).
+//
+// Per-addon copy: lives in godot_playfab/src, matching the repo convention
+// that avoids cross-addon include paths.
+#ifndef GODOT_PLAYFAB_PARTY_CODEC_H
+#define GODOT_PLAYFAB_PARTY_CODEC_H
+
+#include <cstdint>
+
+#include <godot_cpp/classes/multiplayer_peer.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+namespace pf_party_codec {
+
+// Wire packet kind markers. The first byte of every envelope identifies the
+// packet kind; gameplay packets are forwarded to the multiplayer peer, control
+// packets are consumed internally by the handshake state machine.
+constexpr uint8_t PACKET_KIND_GAMEPLAY = 0x00;
+constexpr uint8_t PACKET_KIND_HANDSHAKE_REQUEST = 0x01;
+constexpr uint8_t PACKET_KIND_HANDSHAKE_REPLY = 0x02;
+
+// Build a handshake request packet: kind(1) nonce(4) id_len(2) id type_len(2)
+// type. The entity id/type are UTF-8 encoded; lengths are truncated to 16 bits.
+PackedByteArray build_handshake_request(uint32_t p_nonce, const String &p_entity_id, const String &p_entity_type);
+
+// Build a handshake reply packet: kind(1) nonce(4) assigned_peer_id(4).
+PackedByteArray build_handshake_reply(uint32_t p_nonce, int32_t p_assigned_peer_id);
+
+// Parse a handshake request from untrusted peer bytes. Returns false on any
+// truncation, kind mismatch, or out-of-range length field. Output pointers may
+// be null to skip a field.
+bool parse_handshake_request(const uint8_t *p_buffer, uint32_t p_size, uint32_t *r_nonce, String *r_entity_id, String *r_entity_type);
+
+// Parse a handshake reply from untrusted peer bytes. Returns false on
+// truncation or kind mismatch.
+bool parse_handshake_reply(const uint8_t *p_buffer, uint32_t p_size, uint32_t *r_nonce, int32_t *r_assigned_peer_id);
+
+// Wrap an arbitrary gameplay payload: kind(1) source_peer(4) channel(4)
+// mode(1) payload.
+PackedByteArray wrap_gameplay_payload(int32_t p_source_peer, int32_t p_channel, MultiplayerPeer::TransferMode p_mode, const uint8_t *p_buffer, uint32_t p_size);
+
+// Unwrap a gameplay envelope from untrusted peer bytes. Returns false on
+// truncation or kind mismatch. The trailing payload (which may be empty) is
+// copied into *r_payload when non-null.
+bool unwrap_gameplay_payload(const uint8_t *p_buffer, uint32_t p_size, int32_t *r_source_peer, int32_t *r_channel, MultiplayerPeer::TransferMode *r_mode, PackedByteArray *r_payload);
+
+} // namespace pf_party_codec
+} // namespace godot
+
+#endif // GODOT_PLAYFAB_PARTY_CODEC_H

--- a/addons/godot_playfab/src/playfab_request_key.cpp
+++ b/addons/godot_playfab/src/playfab_request_key.cpp
@@ -1,0 +1,43 @@
+#include "playfab_request_key.h"
+
+#include <cstring>
+
+namespace playfab_internal {
+
+int match_request_key(
+        const char *const *keys, std::size_t key_count,
+        const char *primary,
+        const char *fallback) noexcept {
+    if (keys == nullptr || key_count == 0) {
+        return -1;
+    }
+
+    bool found_primary = false;
+    bool found_fallback = false;
+
+    for (std::size_t i = 0; i < key_count; ++i) {
+        if (keys[i] == nullptr) {
+            continue;
+        }
+        if (!found_primary && primary != nullptr && std::strcmp(keys[i], primary) == 0) {
+            found_primary = true;
+        }
+        if (!found_fallback && fallback != nullptr && std::strcmp(keys[i], fallback) == 0) {
+            found_fallback = true;
+        }
+        if (found_primary) {
+            // primary takes precedence; no need to keep scanning for it
+            break;
+        }
+    }
+
+    if (found_primary) {
+        return 0;
+    }
+    if (found_fallback) {
+        return 1;
+    }
+    return -1;
+}
+
+} // namespace playfab_internal

--- a/addons/godot_playfab/src/playfab_request_key.h
+++ b/addons/godot_playfab/src/playfab_request_key.h
@@ -1,0 +1,42 @@
+#ifndef GODOT_PLAYFAB_REQUEST_KEY_H
+#define GODOT_PLAYFAB_REQUEST_KEY_H
+
+// Pure C++ helper for PlayFab request-field key matching.
+//
+// `get_request_value` in playfab_api_helpers accepts godot::Dictionary
+// requests that callers may populate with either the PascalCase field name
+// (matching the PlayFab REST schema) or the snake_case Godot-style name.
+// This module extracts the pure key-matching logic into a form that:
+//
+//   1. Has no Godot or GDK dependencies.
+//   2. Can be exercised from the doctest suite and the libFuzzer target.
+//   3. Is noexcept throughout so it is safe to call from async paths.
+//
+// Production code in playfab_api_helpers.cpp delegates to match_request_key
+// for the key-selection step and then performs the Godot-side lookup by
+// position/name.
+
+#include <cstddef>
+
+namespace playfab_internal {
+
+// match_request_key
+//
+// Given a flat array of `key_count` C-string keys present in a request dict,
+// searches for `primary` (the snake_case name) first, then `fallback` (the
+// PascalCase name). Returns:
+//
+//   0  — primary matched
+//   1  — fallback matched (primary was absent or null)
+//  -1  — neither matched (or both primary and fallback are null)
+//
+// Null pointers are treated as absent (never match). An empty key array
+// always returns -1. The function is noexcept and has no allocations.
+int match_request_key(
+        const char *const *keys, std::size_t key_count,
+        const char *primary,
+        const char *fallback) noexcept;
+
+} // namespace playfab_internal
+
+#endif // GODOT_PLAYFAB_REQUEST_KEY_H

--- a/addons/godot_playfab/src/playfab_request_value.cpp
+++ b/addons/godot_playfab/src/playfab_request_value.cpp
@@ -1,0 +1,44 @@
+// playfab_request_value.cpp — Implementation of get_request_value.
+//
+// See playfab_request_value.h for the contract. This translation unit has no
+// dependency on the GDK or PlayFab SDK headers so it can be compiled as part
+// of the standalone fuzz harness.
+
+#include "playfab_request_value.h"
+
+#include <godot_cpp/variant/string_name.hpp>
+
+namespace godot {
+namespace playfab_api {
+
+bool get_request_value(const Dictionary &p_request,
+                       const char *p_field_name,
+                       const char *p_snake_name,
+                       Variant *r_value) {
+    if (r_value == nullptr) {
+        return false;
+    }
+
+    // Priority: snake_case name first, PascalCase fallback. The pure equivalent
+    // of this selection logic is playfab_internal::match_request_key, which
+    // is fuzz-tested in tests/cpp/fuzz/fuzz_playfab_key_lookup.cpp and
+    // doctest-covered in tests/cpp/request_key/test_playfab_request_key.cpp.
+    // Production code uses O(1) hash lookups via StringName to avoid the linear
+    // scan in match_request_key.
+    const StringName snake_name(p_snake_name);
+    if (p_request.has(snake_name)) {
+        *r_value = p_request[snake_name];
+        return true;
+    }
+
+    const StringName field_name(p_field_name);
+    if (p_request.has(field_name)) {
+        *r_value = p_request[field_name];
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace playfab_api
+} // namespace godot

--- a/addons/godot_playfab/src/playfab_request_value.h
+++ b/addons/godot_playfab/src/playfab_request_value.h
@@ -1,0 +1,41 @@
+// playfab_request_value.h — Engine-free seam for the PlayFab request
+// Dictionary field-lookup helper.
+//
+// get_request_value resolves a field from a GDScript request Dictionary by
+// trying the snake_case key first and falling back to the PascalCase key.
+// This is the same priority used by every PlayFab API service binding when
+// reading caller-supplied request parameters.
+//
+// The function uses only godot-cpp built-in types (Dictionary, StringName,
+// Variant) and has no dependency on the GDK or PlayFab SDK headers, which
+// makes it suitable for the standalone fuzz harness.
+//
+// Per-addon copy: lives in godot_playfab/src rather than being shared with
+// godot_gdk, per the repo convention that avoids cross-addon include paths.
+#ifndef GODOT_PLAYFAB_REQUEST_VALUE_H
+#define GODOT_PLAYFAB_REQUEST_VALUE_H
+
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+namespace godot {
+namespace playfab_api {
+
+// Resolve p_field_name or p_snake_name from p_request.
+//
+// Priority: snake_case (p_snake_name) is tried first; PascalCase
+// (p_field_name) is the fallback. This mirrors the GDScript convention
+// where callers may pass either casing style.
+//
+// Returns true and writes the matched value into *r_value if found.
+// Returns false (and leaves *r_value unchanged) if neither key is present.
+// Returns false immediately if r_value is nullptr.
+bool get_request_value(const Dictionary &p_request,
+                       const char *p_field_name,
+                       const char *p_snake_name,
+                       Variant *r_value);
+
+} // namespace playfab_api
+} // namespace godot
+
+#endif // GODOT_PLAYFAB_REQUEST_VALUE_H

--- a/cmake/GodotExtensionCommon.cmake
+++ b/cmake/GodotExtensionCommon.cmake
@@ -428,3 +428,98 @@ function(godot_addon_doctest_target)
     )
 endfunction()
 
+
+#[[ godot_addon_fuzzer_target
+
+Defines a libFuzzer-based fuzz-test executable for an addon. Requires the
+ClangCL toolset (the `fuzz` configure preset sets this). Applies
+`-fsanitize=fuzzer,address` to both the compile and link steps; the linker
+then provides the LLVMFuzzerRunDriver entry point, so fuzz source files must
+define `LLVMFuzzerTestOneInput` (and optionally `LLVMFuzzerInitialize`) but
+NOT `main()`.
+
+This function may only be called when `GDK_BUILD_FUZZ_TARGETS` is ON (see
+`tests/cpp/CMakeLists.txt`). Calling it from an MSVC (non-ClangCL) build will
+emit a FATAL_ERROR pointing to the `fuzz` preset.
+
+Arguments:
+    TARGET_NAME    The CMake target name to create.
+    SOURCES        Fuzz source files (each contains LLVMFuzzerTestOneInput).
+    LINK_LIBS      Optional libraries to link (e.g. godot_stub_harness, or
+                   a static helper extracted from the addon under test).
+    INCLUDES       Extra include directories.
+
+Output binary: `${CMAKE_BINARY_DIR}/bin/<config>/<TARGET_NAME>.exe`
+
+Run a fuzz target:
+    .\\build\\fuzz\\bin\\Debug\\<TARGET_NAME>.exe [libFuzzer flags]
+    e.g.: -max_len=256 -runs=100000 -artifact_prefix=crashes/
+
+Corpus directory convention: `tests/cpp/fuzz/corpus/<TARGET_NAME>/`
+]]
+function(godot_addon_fuzzer_target)
+    set(one_value_args TARGET_NAME)
+    set(multi_value_args SOURCES LINK_LIBS INCLUDES)
+    cmake_parse_arguments(ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    if(NOT ARG_TARGET_NAME OR NOT ARG_SOURCES)
+        message(FATAL_ERROR
+            "godot_addon_fuzzer_target requires TARGET_NAME and SOURCES.")
+    endif()
+
+    # Guard: this function only works with clang-cl. The fuzz configure preset
+    # sets toolset=ClangCL which CMake surfaces as CMAKE_CXX_COMPILER_ID=Clang
+    # with MSVC-compatible flags. MSVC itself does not support /fsanitize=fuzzer.
+    if(MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        message(FATAL_ERROR
+            "godot_addon_fuzzer_target requires the clang-cl toolset. "
+            "Configure with the 'fuzz' preset (toolset: ClangCL) instead of the default MSVC preset.")
+    endif()
+
+    add_executable(${ARG_TARGET_NAME}
+        ${ARG_SOURCES}
+    )
+
+    # -fsanitize=fuzzer,address instruments the code at compile time.
+    # Note: clang-cl uses '-' prefix for sanitizer flags (not '/' like MSVC flags).
+    target_compile_options(${ARG_TARGET_NAME} PRIVATE -fsanitize=fuzzer,address)
+
+    # lld-link (used by VS+ClangCL) does not auto-resolve -fsanitize=... to runtime
+    # libs. Link them explicitly from the LLVM install alongside clang-cl.exe.
+    # Paths: <Llvm>/bin/clang-cl.exe → <Llvm>/lib/clang/<ver>/lib/windows/*.lib
+    #
+    # All three libs are compiled with /MT (MT_StaticRelease), which matches the
+    # CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded setting in the fuzz configure preset.
+    get_filename_component(_clang_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+    file(GLOB _clang_rt_dirs "${_clang_bin_dir}/../lib/clang/*/lib/windows")
+    if(_clang_rt_dirs)
+    list(GET _clang_rt_dirs 0 _clang_rt_dir)
+    get_filename_component(_clang_rt_dir "${_clang_rt_dir}" ABSOLUTE)
+    # Static ASan + fuzzer driver — no DLL dependency at runtime.
+    target_link_libraries(${ARG_TARGET_NAME} PRIVATE
+        "${_clang_rt_dir}/clang_rt.fuzzer-x86_64.lib"
+        "${_clang_rt_dir}/clang_rt.asan-x86_64.lib"
+        "${_clang_rt_dir}/clang_rt.asan_cxx-x86_64.lib"
+    )
+    else()
+    message(FATAL_ERROR
+        "godot_addon_fuzzer_target: cannot find LLVM runtime directory "
+        "alongside ${CMAKE_CXX_COMPILER}. Check that the LLVM toolchain is "
+        "installed via Visual Studio Installer.")
+    endif()
+
+    target_include_directories(${ARG_TARGET_NAME} PRIVATE
+        ${ARG_INCLUDES}
+    )
+
+    if(ARG_LINK_LIBS)
+        target_link_libraries(${ARG_TARGET_NAME} PRIVATE ${ARG_LINK_LIBS})
+    endif()
+
+    set_target_properties(${ARG_TARGET_NAME} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY         "${CMAKE_BINARY_DIR}/bin"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG   "${CMAKE_BINARY_DIR}/bin/Debug"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release"
+        FOLDER                           "tests/fuzz"
+    )
+endfunction()

--- a/spec/testing-strategy.md
+++ b/spec/testing-strategy.md
@@ -310,3 +310,142 @@ The Wave -1 spike surfaced seven behaviors that bind future waves. Each is a nor
 - **Sync `ReadToEnd()` deadlocks** on Godot's stderr in clean trees. Missing GDExtensions flood stderr with `Condition "!FileAccess::exists(path)"` lines and fill the pipe buffer in seconds. Both stdout and stderr are drained asynchronously (`BeginOutputReadLine()` / `BeginErrorReadLine()` or concurrent `ReadToEndAsync()`).
 - **The headless validator exclusion list is generalised** in Wave 1. Vendored or `extends GutTest` paths skip via `.gdignore` / sentinel marker file rather than a hard-coded array.
 - **Version pinning matches `--version` output, not the file name.** `Godot_v4.6.1-stable_win64_console.exe` reports `4.6.2.stable.official.71f334935`. Discovery and version-pinning logic compares against the runtime `--version` string; the file name is unreliable as a version identifier and is not used in `run-summary.md`.
+
+## AddressSanitizer preset (`debug-asan`)
+
+Branch `infra/fuzz-testing` adds a dedicated configure preset that compiles the doctest target with MSVC's AddressSanitizer instrumentation.
+
+**Configure preset:** `debug-asan` — inherits from `default`, sets `CMAKE_CXX_FLAGS=/fsanitize=address`, turns all addon builds OFF and `GDK_BUILD_TESTS=ON`.
+
+**Build preset:** `debug-asan` — targets the `asan` binary directory (`build\asan`), Debug configuration.
+
+```powershell
+cmake --preset debug-asan
+cmake --build build/asan --preset debug-asan --target gdk_unit_tests
+```
+
+**Runtime requirement:** MSVC ASan DLLs must be on PATH:
+
+```powershell
+$asanDir = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64"
+$env:PATH = "$asanDir;$env:PATH"
+.\build\asan\bin\Debug\gdk_unit_tests.exe
+```
+
+**Verified:** 16/16 doctest cases pass under ASan with no error report.
+
+The preset intentionally targets only the pure-C++ doctest exe. GDExtension addon builds and GDScript test hosts are out of scope for ASan standalone runs.
+
+## libFuzzer layout
+
+Branch `infra/fuzz-testing` adds a clang-cl + libFuzzer build path that is entirely separate from the default MSVC preset.
+
+### Configure and build presets
+
+| Preset | Role |
+| --- | --- |
+| `fuzz` (configure) | Inherits `_fuzz-base`: VS 17 2022 generator, ClangCL toolset, `build\fuzz` binary dir. Sets `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded` (`/MT`, required by `clang_rt.fuzzer-x86_64.lib`), `CMAKE_CXX_FLAGS=-fsanitize=address` globally (required for consistent `annotate_string` FAILIFMISMATCH linking), `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` (avoids configure-time link failure when ASan runtime is not resolved), `GDK_BUILD_TESTS=OFF`, `GDK_BUILD_FUZZ_TARGETS=ON`. All addon builds (`BUILD_GODOT_GDK`, `BUILD_GODOT_GAMEINPUT`, `BUILD_GODOT_PLAYFAB`) are OFF. |
+| `debug-fuzz` (build) | Targets `build\fuzz`, Debug configuration. |
+
+```powershell
+cmake --preset fuzz
+cmake --build build/fuzz --preset debug-fuzz
+```
+
+### `godot_addon_fuzzer_target` CMake function
+
+Defined in `cmake\GodotExtensionCommon.cmake`. Adds a libFuzzer executable with:
+
+- `-fsanitize=fuzzer,address` compile flag (clang-cl uses `-`, not `/`)
+- Explicit link of `clang_rt.fuzzer-x86_64.lib`, `clang_rt.asan-x86_64.lib`, `clang_rt.asan_cxx-x86_64.lib` from the LLVM install alongside `clang-cl.exe` (lld-link does not auto-resolve `-fsanitize=...` to libraries)
+- `FATAL_ERROR` if called with a non-ClangCL compiler
+
+**Guard:** `GDK_BUILD_FUZZ_TARGETS` is declared at the root `CMakeLists.txt` level. The `tests/cpp` subdirectory is added when `GDK_BUILD_TESTS OR GDK_BUILD_FUZZ_TARGETS`. The doctest exe (`gdk_unit_tests`) is gated solely on `GDK_BUILD_TESTS`, so the fuzz preset (which sets `GDK_BUILD_TESTS=OFF`) does not attempt to build or link the doctest exe.
+
+### Seam extraction pattern
+
+Each fuzz target exercises a *pure seam* — a helper extracted from production code that has no GDK, GDExtension-interface, or Godot-type dependency.
+
+**Existing seams (Wave 2, `infra/fuzz-testing`):**
+- `addons\godot_playfab\src\playfab_request_key.{h,cpp}` — pure `std::string` / `std::string_view` key-match and signature helper. Does not touch `godot::String` or PlayFab SDK types. Covered by `tests\cpp\request_key\test_playfab_request_key.cpp` (doctest) and `tests\cpp\fuzz\fuzz_playfab_key_lookup.cpp` (libFuzzer).
+
+New pure seams follow the same extraction pattern: move pure logic to a `*_internal.{h,cpp}` sibling, call it from the production site, reference the same file from the fuzz target.
+
+### Fuzz target layout
+
+Fuzz sources live under `tests\cpp\fuzz\`:
+
+| File | Phase | Description |
+| --- | --- | --- |
+| `fuzz_playfab_key_lookup.cpp` | 2 | Key-match seam — no Godot types, no stub harness. |
+| `fuzz_gdk_result_formatting.cpp` | 3 | HRESULT-formatting helpers — uses `godot::String`, links `godot_stub_harness`. |
+| `fuzz_playfab_api_models.cpp` | 3 | PlayFab API model parsing — conditional; skipped when `PLAYFAB_SDK_PATH` is not set. |
+
+Each fuzz target defines `LLVMFuzzerTestOneInput` (and optionally `LLVMFuzzerInitialize`) but NOT `main()`. Targets that use Godot types call `godot_stub::init()` from `LLVMFuzzerInitialize`.
+
+## Phase 3 GDExtension stub harness
+
+The stub harness satisfies all 176 GDExtension interface function slots so `godot::String`, `godot::Dictionary`, `godot::Variant`, and `godot::Array` work in a standalone fuzz exe without a live Godot engine.
+
+### Constraint (why a stub harness is necessary)
+
+Every `godot::String` (and every other Variant-family type) constructor dispatches through `gdextension_interface::*` function pointers populated during the GDExtension entry-point handshake. In a standalone exe these pointers stay null and the first `String` construction segfaults. The doctest target avoids this by banning Variant-family types (see "godot::String constraint" above). The stub harness lifts that restriction for fuzz targets.
+
+### Blob size contract (float\_64 / x64 Windows)
+
+| Type | Blob size | Backing storage |
+| --- | --- | --- |
+| `godot::String` | 8 bytes | `std::u32string *` |
+| `godot::StringName` | 8 bytes | `std::string *` (interned; pool owns) |
+| `godot::NodePath` | 8 bytes | `std::string *` (same interned pool) |
+| `godot::Dictionary` | 8 bytes | `StubDict *` |
+| `godot::Array` | 8 bytes | `StubArray *` |
+| `godot::Variant` | 24 bytes | `{ uint32_t type_id; uint32_t _pad; StubVariantData data; }` |
+
+### Source layout
+
+All harness source lives under `tests\cpp\fuzz_harness\`:
+
+| File | Responsibility |
+| --- | --- |
+| `stub_types.h` | Shared internal header: `StubVariant` (24 bytes), `StubDict`, `StubArray`, blob accessor helpers, `sn_intern` declaration. |
+| `stub_memory.cpp` | `mem_alloc/realloc/free` wrappers; `print_error/warning` stubs. |
+| `stub_string.cpp` | String creation/mutation stubs via `std::u32string`; UTF-8/Latin-1/UTF-32/wide conversions; interned StringName pool via `std::unordered_set<std::string>`. |
+| `stub_variant.cpp` | Full Variant ctor/dtor/type system; `get_variant_from/to_type_constructor`; `variant_get_ptr_constructor/destructor`; `variant_get_ptr_builtin_method` dispatch (Array, Dictionary, String); `s_string_op_add` for `STRING + STRING` via `variant_get_ptr_operator_evaluator`; noop for all utility functions. |
+| `stub_dict_array.cpp` | Direct `dictionary_operator_index` / `array_operator_index` stubs. |
+| `stub_noop.cpp` | Single `s_stub_noop()` fallback; `get_godot_version`/`get_godot_version2` returning 4.6.0. |
+| `godot_stub_init.cpp` | 176-entry `unordered_map<string_view, void**>` dispatch table; `stub_get_proc_address`; `godot_stub::init()` bootstraps `GDExtensionBinding` with the stub proc address resolver. |
+| `godot_stub_init.h` | Public API: `godot_stub::init()`. |
+
+### Key design decisions
+
+- **String destruction uses `variant_get_ptr_destructor(STRING)`, not a direct `string_destroy` call.** There is no `string_destroy` interface function; the destructor slot for STRING is populated from `variant_get_ptr_destructor`.
+- **`string_new_with_*` functions free old content before assigning.** godot-cpp calls `string_new_with_utf8_chars_and_len2` on an already-initialized blob (from `String::parse_utf8`). The stub deletes the old `std::u32string*` before assigning the new one.
+- **`variant_get_ptr_operator_evaluator` returns real implementations, never null.** Returning null causes a PC=0 crash when godot-cpp calls `String::operator+(const String&)`. `OP_ADD + STRING + STRING` returns `s_string_op_add`; all other operator combinations return `s_noop_op_eval`.
+- **`variant_get_ptr_utility_function` returns a noop, never null.** Same reasoning — godot-cpp may cache the returned pointer and call it later.
+- **All TUs compiled with `/MT` (`MultiThreaded` static CRT).** `clang_rt.fuzzer-x86_64.lib` embeds `FAILIFMISMATCH:RuntimeLibrary=MT_StaticRelease`. Mixing `/MD` code with `/MT` runtime libs fails at link. The fuzz preset therefore sets `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded` globally.
+- **`-fsanitize=address` is set globally in the fuzz preset.** Without it, `godot-cpp` objects emit `annotate_string=0` and fuzz-target objects emit `annotate_string=1`, causing a `FAILIFMISMATCH` link failure. Applying ASan globally makes all objects consistent.
+- **`CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY` is required for configure.** CMake's compiler detection builds a test executable; with `-fsanitize=address` in `CMAKE_CXX_FLAGS` it can't link without the ASan runtime. Setting the try-compile target to a static library skips the link step.
+
+### `godot_stub::init()` contract
+
+```cpp
+// In LLVMFuzzerInitialize:
+extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+    godot_stub::init();   // call exactly once before any Godot type use
+    return 0;
+}
+```
+
+`godot_stub::init()` creates a `GDExtensionInitialization` on the stack, registers a no-op initializer (required — `init_callback` must be non-null), and calls `GDExtensionBinding::init()` with `stub_get_proc_address`. It aborts with a message if `init()` returns false.
+
+### Verification
+
+```powershell
+cmake --preset fuzz
+cmake --build build/fuzz --preset debug-fuzz
+.\build\fuzz\bin\Debug\playfab_fuzz_key_lookup.exe     -runs=10000
+.\build\fuzz\bin\Debug\gdk_fuzz_result_formatting.exe  -runs=10000
+```
+
+Both targets exit 0 with `Done 10000 runs in N second(s)`. The default-preset `gdk_unit_tests.exe` still passes 16/16 doctest cases (non-regression confirmed).

--- a/spec/testing-strategy.md
+++ b/spec/testing-strategy.md
@@ -368,8 +368,10 @@ Each fuzz target exercises a *pure seam* — a helper extracted from production 
 
 **Existing seams (Wave 2, `infra/fuzz-testing`):**
 - `addons\godot_playfab\src\playfab_request_key.{h,cpp}` — pure `std::string` / `std::string_view` key-match and signature helper. Does not touch `godot::String` or PlayFab SDK types. Covered by `tests\cpp\request_key\test_playfab_request_key.cpp` (doctest) and `tests\cpp\fuzz\fuzz_playfab_key_lookup.cpp` (libFuzzer).
+- `addons\godot_playfab\src\playfab_party_codec.{h,cpp}` — wire codec for the PlayFab Party transport (`build_*`/`parse_*`/`wrap_*`/`unwrap_*`). Uses `godot::String` and `godot::PackedByteArray` but no PlayFab Party SDK types, so it builds into both the addon and the stub harness. The `parse_*`/`unwrap_*` functions decode untrusted peer bytes — the addon's primary attacker-controlled-input surface. Covered by `tests\cpp\fuzz\fuzz_playfab_party_codec.cpp`.
+- `addons\godot_gdk\src\gdk_request_parsing.{h,cpp}` — GDK request-input parsing seam (`try_parse_xuid`, `parse_uint32`, `copy_utf8_to_buffer`, `to_packed_byte_array` / `to_byte_vector`). Uses godot-cpp built-in types plus the SDK-free `GDKResult`, with no Xbox GDK service headers. Consumed by `gdk_title_storage.cpp`, `gdk_game_ui.cpp`, and `gdk_profile.cpp` via thin private forwarders (game-UI passes `reject_zero=true`; the other two pass `false`). Covered by `tests\cpp\fuzz\fuzz_gdk_request_parsing.cpp`.
 
-New pure seams follow the same extraction pattern: move pure logic to a `*_internal.{h,cpp}` sibling, call it from the production site, reference the same file from the fuzz target.
+New pure seams follow the same extraction pattern: move pure logic to a `*_internal.{h,cpp}` (or a similarly SDK-free) sibling, call it from the production site, reference the same file from the fuzz target.
 
 ### Fuzz target layout
 
@@ -379,6 +381,10 @@ Fuzz sources live under `tests\cpp\fuzz\`:
 | --- | --- | --- |
 | `fuzz_playfab_key_lookup.cpp` | 2 | Key-match seam — no Godot types, no stub harness. |
 | `fuzz_gdk_result_formatting.cpp` | 3 | HRESULT-formatting helpers — uses `godot::String`, links `godot_stub_harness`. |
+| `fuzz_gdk_result_factories.cpp` | 3 | `GDKResult` / `PlayFabResult` factory + accessor round-trips — `Ref<RefCounted>`, links `godot_stub_harness`. |
+| `fuzz_playfab_request_dictionary.cpp` | 3 | `playfab_api::get_request_value` over arbitrary `Dictionary` content — links `godot_stub_harness`. |
+| `fuzz_playfab_party_codec.cpp` | 3 | PlayFab Party wire codec — decodes untrusted peer bytes (`PackedByteArray` + `String`); raw-decode + build/parse round-trip oracles. |
+| `fuzz_gdk_request_parsing.cpp` | 3 | GDK request-input parsing seam — `try_parse_xuid` (both reject-zero modes), `parse_uint32`, `copy_utf8_to_buffer`, `PackedByteArray`<->`std::vector` round-trip oracle. |
 | `fuzz_playfab_api_models.cpp` | 3 | PlayFab API model parsing — conditional; skipped when `PLAYFAB_SDK_PATH` is not set. |
 
 Each fuzz target defines `LLVMFuzzerTestOneInput` (and optionally `LLVMFuzzerInitialize`) but NOT `main()`. Targets that use Godot types call `godot_stub::init()` from `LLVMFuzzerInitialize`.
@@ -400,6 +406,7 @@ Every `godot::String` (and every other Variant-family type) constructor dispatch
 | `godot::NodePath` | 8 bytes | `std::string *` (same interned pool) |
 | `godot::Dictionary` | 8 bytes | `StubDict *` |
 | `godot::Array` | 8 bytes | `StubArray *` |
+| `godot::PackedByteArray` | 16 bytes | `std::vector<uint8_t> *` (blob zero-init; moved-from reads nullptr) |
 | `godot::Variant` | 24 bytes | `{ uint32_t type_id; uint32_t _pad; StubVariantData data; }` |
 
 ### Source layout
@@ -408,11 +415,12 @@ All harness source lives under `tests\cpp\fuzz_harness\`:
 
 | File | Responsibility |
 | --- | --- |
-| `stub_types.h` | Shared internal header: `StubVariant` (24 bytes), `StubDict`, `StubArray`, blob accessor helpers, `sn_intern` declaration. |
+| `stub_types.h` | Shared internal header: `StubVariant` (24 bytes), `StubDict`, `StubArray`, blob accessor helpers (incl. `SVT_PACKED_BYTE_ARRAY` / `pba_blob_*` for `std::vector<uint8_t>*`), `sn_intern` declaration. |
 | `stub_memory.cpp` | `mem_alloc/realloc/free` wrappers; `print_error/warning` stubs. |
 | `stub_string.cpp` | String creation/mutation stubs via `std::u32string`; UTF-8/Latin-1/UTF-32/wide conversions; interned StringName pool via `std::unordered_set<std::string>`. |
 | `stub_variant.cpp` | Full Variant ctor/dtor/type system; `get_variant_from/to_type_constructor`; `variant_get_ptr_constructor/destructor`; `variant_get_ptr_builtin_method` dispatch (Array, Dictionary, String); `s_string_op_add` for `STRING + STRING` via `variant_get_ptr_operator_evaluator`; noop for all utility functions. |
 | `stub_dict_array.cpp` | Direct `dictionary_operator_index` / `array_operator_index` stubs. |
+| `stub_packed_array.cpp` | `packed_byte_array_operator_index(_const)` stubs returning `&vec[index]` (bounds-checked, nullptr on OOB); PackedByteArray ctor/dtor and builtin methods (`resize`/`size`/`set`/`get`/`push_back`/`clear`) live in `stub_variant.cpp`. |
 | `stub_noop.cpp` | Single `s_stub_noop()` fallback; `get_godot_version`/`get_godot_version2` returning 4.6.0. |
 | `godot_stub_init.cpp` | 176-entry `unordered_map<string_view, void**>` dispatch table; `stub_get_proc_address`; `godot_stub::init()` bootstraps `GDExtensionBinding` with the stub proc address resolver. |
 | `godot_stub_init.h` | Public API: `godot_stub::init()`. |

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,33 +1,52 @@
 # C++ unit tests (doctest). Built when GDK_BUILD_TESTS is enabled.
-# This subdirectory is added from the root CMakeLists guarded by that option,
-# so we do NOT re-check the option here.
+# This subdirectory is added from the root CMakeLists guarded by
+# GDK_BUILD_TESTS OR GDK_BUILD_FUZZ_TARGETS. The doctest exe itself is gated
+# on GDK_BUILD_TESTS so the fuzz preset (which sets GDK_BUILD_TESTS=OFF) only
+# builds the fuzz subdirectories.
 #
-# Layout (see spec/testing-strategy.md "doctest layout"):
+# Layout (see spec/testing-strategy.md "doctest layout" and "libFuzzer layout"):
 #   main.cpp              — lone TU defining DOCTEST_CONFIG_IMPLEMENT
 #   result_codes/         — pure HRESULT formatting helper coverage
+#   request_key/          — pure PlayFab request key-match helper coverage (Phase 2)
+#   fuzz/                 — libFuzzer fuzz targets, guarded by GDK_BUILD_FUZZ_TARGETS
+#   fuzz_harness/         — GDExtension stub harness (Phase 3), linked by fuzz targets
 #   third_party/doctest/  — vendored upstream header (do not modify)
 
-# Wave 2: pull the per-addon HRESULT formatting helpers
-# (gdk_internal:: and playfab_internal::) directly into the doctest TU.
-# These helpers are pure and self-contained — the headers self-include
-# <windows.h> for HRESULT and only depend on godot::cpp for godot::String —
-# so we can compile them straight in here without a dedicated static lib.
-# See tests/cpp/result_codes/test_*.cpp and spec/testing-strategy.md
-# ("C++ test scope rules") for the contract under test.
-set(_GDK_RC_SRC "${CMAKE_SOURCE_DIR}/addons/godot_gdk/src")
-set(_PF_RC_SRC  "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src")
+if(GDK_BUILD_TESTS)
+    # Wave 2: pull the per-addon HRESULT formatting helpers
+    # (gdk_internal:: and playfab_internal::) directly into the doctest TU.
+    # These helpers are pure and self-contained — the headers self-include
+    # <windows.h> for HRESULT and only depend on godot::cpp for godot::String —
+    # so we can compile them straight in here without a dedicated static lib.
+    # See tests/cpp/result_codes/test_*.cpp and spec/testing-strategy.md
+    # ("C++ test scope rules") for the contract under test.
+    set(_GDK_RC_SRC "${CMAKE_SOURCE_DIR}/addons/godot_gdk/src")
+    set(_PF_RC_SRC  "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src")
 
-godot_addon_doctest_target(
-    TARGET_NAME gdk_unit_tests
-    IMPL_TU     "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
-    SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/result_codes/test_gdk_result_codes.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/result_codes/test_playfab_result_codes.cpp"
-        "${_GDK_RC_SRC}/gdk_result_codes_internal.cpp"
-        "${_PF_RC_SRC}/playfab_result_codes_internal.cpp"
-    LINK_LIBS   godot::cpp
-    INCLUDES
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        "${_GDK_RC_SRC}"
-        "${_PF_RC_SRC}"
-)
+    godot_addon_doctest_target(
+        TARGET_NAME gdk_unit_tests
+        IMPL_TU     "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
+        SOURCES
+            "${CMAKE_CURRENT_SOURCE_DIR}/result_codes/test_gdk_result_codes.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/result_codes/test_playfab_result_codes.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/request_key/test_playfab_request_key.cpp"
+            "${_GDK_RC_SRC}/gdk_result_codes_internal.cpp"
+            "${_PF_RC_SRC}/playfab_result_codes_internal.cpp"
+            "${_PF_RC_SRC}/playfab_request_key.cpp"
+        LINK_LIBS   godot::cpp
+        INCLUDES
+            "${CMAKE_CURRENT_SOURCE_DIR}"
+            "${_GDK_RC_SRC}"
+            "${_PF_RC_SRC}"
+    )
+endif()
+
+# ── libFuzzer fuzz targets ────────────────────────────────────────
+# Requires the `fuzz` configure preset (toolset: ClangCL).
+# GDK_BUILD_FUZZ_TARGETS is declared at the root CMakeLists level and
+# inherited here. Do NOT enable this option with the default MSVC preset —
+# it will fail at godot_addon_fuzzer_target() with a clear error message.
+if(GDK_BUILD_FUZZ_TARGETS)
+    add_subdirectory(fuzz_harness)
+    add_subdirectory(fuzz)
+endif()

--- a/tests/cpp/fuzz/CMakeLists.txt
+++ b/tests/cpp/fuzz/CMakeLists.txt
@@ -81,6 +81,42 @@ godot_addon_fuzzer_target(
         "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
 )
 
+# fuzz_playfab_party_codec: exercises the PlayFab Party wire codec — the parse_*
+# / unwrap_* functions decode untrusted peer bytes (PackedByteArray + String).
+# Requires the PackedByteArray stubs in godot_stub_harness.
+godot_addon_fuzzer_target(
+    TARGET_NAME playfab_fuzz_party_codec
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_playfab_party_codec.cpp"
+        "${_PF_SRC}/playfab_party_codec.cpp"
+    LINK_LIBS
+        godot_stub_harness
+        godot::cpp
+    INCLUDES
+        "${_PF_SRC}"
+        "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
+)
+
+# fuzz_gdk_request_parsing: exercises the GDK request-input parsing seam
+# (try_parse_xuid, parse_uint32, copy_utf8_to_buffer, to_packed_byte_array /
+# to_byte_vector). These touch raw memory (strtoull, memcpy into fixed buffers,
+# byte-buffer round-trips) on script-supplied values. parse_uint32 /
+# copy_utf8_to_buffer return Ref<GDKResult>, so gdk_result.cpp is linked too.
+godot_addon_fuzzer_target(
+    TARGET_NAME gdk_fuzz_request_parsing
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_gdk_request_parsing.cpp"
+        "${_GDK_SRC}/gdk_request_parsing.cpp"
+        "${_GDK_SRC}/gdk_result.cpp"
+        "${_GDK_SRC}/gdk_result_codes_internal.cpp"
+    LINK_LIBS
+        godot_stub_harness
+        godot::cpp
+    INCLUDES
+        "${_GDK_SRC}"
+        "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
+)
+
 if(PLAYFAB_SDK_PATH AND EXISTS "${PLAYFAB_SDK_PATH}/include/playfab/core/PFTypes.h")
     godot_addon_fuzzer_target(
         TARGET_NAME playfab_fuzz_api_models

--- a/tests/cpp/fuzz/CMakeLists.txt
+++ b/tests/cpp/fuzz/CMakeLists.txt
@@ -1,0 +1,65 @@
+# libFuzzer fuzz targets. Built when GDK_BUILD_FUZZ_TARGETS=ON (the `fuzz`
+# configure preset sets this). Requires clang-cl toolset.
+#
+# Phase 2 targets: pure C++ seams, no Godot types.
+# Phase 3 targets: link against godot_stub_harness; full Godot-type coverage.
+#
+# Corpus convention: tests/cpp/fuzz/corpus/<target_name>/
+# To run a target: .\build\fuzz\bin\Debug\<target>.exe -runs=100000 -max_len=256
+
+set(_PF_SRC "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src")
+
+# ── Phase 2: pure seam fuzz targets ──────────────────────────────
+godot_addon_fuzzer_target(
+    TARGET_NAME playfab_fuzz_key_lookup
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_playfab_key_lookup.cpp"
+        "${_PF_SRC}/playfab_request_key.cpp"
+    INCLUDES
+        "${_PF_SRC}"
+)
+
+# ── Phase 3: Godot-type fuzz targets (stub harness) ───────────────
+# These targets link against godot_stub_harness (built in ../fuzz_harness/)
+# and godot::cpp. They must call init_godot_stub_harness() in
+# LLVMFuzzerInitialize before using any Godot type.
+
+godot_addon_fuzzer_target(
+    TARGET_NAME gdk_fuzz_result_formatting
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_gdk_result_formatting.cpp"
+        "${CMAKE_SOURCE_DIR}/addons/godot_gdk/src/gdk_result_codes_internal.cpp"
+        "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src/playfab_result_codes_internal.cpp"
+    LINK_LIBS
+        godot_stub_harness
+        godot::cpp
+    INCLUDES
+        "${CMAKE_SOURCE_DIR}/addons/godot_gdk/src"
+        "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src"
+        "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
+)
+
+# playfab_fuzz_api_models requires the PlayFab SDK headers (PFTypes.h etc.).
+# Enable by setting PLAYFAB_SDK_PATH and turning BUILD_GODOT_PLAYFAB=ON in the
+# fuzz configure preset, or by passing -DPLAYFAB_SDK_PATH=<path> explicitly.
+# The target is skipped automatically when the SDK is not found.
+if(PLAYFAB_SDK_PATH AND EXISTS "${PLAYFAB_SDK_PATH}/include/playfab/core/PFTypes.h")
+    godot_addon_fuzzer_target(
+        TARGET_NAME playfab_fuzz_api_models
+        SOURCES
+            "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_playfab_api_models.cpp"
+            "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src/api/playfab_api_models.cpp"
+            "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src/playfab_request_key.cpp"
+        LINK_LIBS
+            godot_stub_harness
+            godot::cpp
+        INCLUDES
+            "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src"
+            "${PLAYFAB_SDK_PATH}/include"
+            "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
+    )
+else()
+    message(STATUS
+        "playfab_fuzz_api_models: skipped (PLAYFAB_SDK_PATH not set or SDK not found). "
+        "Set PLAYFAB_SDK_PATH=<path> to enable.")
+endif()

--- a/tests/cpp/fuzz/CMakeLists.txt
+++ b/tests/cpp/fuzz/CMakeLists.txt
@@ -8,6 +8,7 @@
 # To run a target: .\build\fuzz\bin\Debug\<target>.exe -runs=100000 -max_len=256
 
 set(_PF_SRC "${CMAKE_SOURCE_DIR}/addons/godot_playfab/src")
+set(_GDK_SRC "${CMAKE_SOURCE_DIR}/addons/godot_gdk/src")
 
 # ── Phase 2: pure seam fuzz targets ──────────────────────────────
 godot_addon_fuzzer_target(
@@ -43,6 +44,43 @@ godot_addon_fuzzer_target(
 # Enable by setting PLAYFAB_SDK_PATH and turning BUILD_GODOT_PLAYFAB=ON in the
 # fuzz configure preset, or by passing -DPLAYFAB_SDK_PATH=<path> explicitly.
 # The target is skipped automatically when the SDK is not found.
+
+# ── Wrapped API fuzz targets (factory + accessor round-trips) ────────────
+# fuzz_gdk_result_factories: exercises GDKResult and PlayFabResult factory
+# methods (ok_result, error_result, hresult_error, cancelled) and accessors.
+# Requires the object lifecycle stubs (stub_object.cpp) in godot_stub_harness.
+godot_addon_fuzzer_target(
+    TARGET_NAME gdk_fuzz_result_factories
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_gdk_result_factories.cpp"
+        "${_GDK_SRC}/gdk_result.cpp"
+        "${_GDK_SRC}/gdk_result_codes_internal.cpp"
+        "${_PF_SRC}/playfab_result.cpp"
+        "${_PF_SRC}/playfab_result_codes_internal.cpp"
+    LINK_LIBS
+        godot_stub_harness
+        godot::cpp
+    INCLUDES
+        "${_GDK_SRC}"
+        "${_PF_SRC}"
+        "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
+)
+
+# fuzz_playfab_request_dictionary: exercises playfab_api::get_request_value
+# with arbitrary Dictionary content and field-name pairs.  No SDK headers needed.
+godot_addon_fuzzer_target(
+    TARGET_NAME playfab_fuzz_request_dictionary
+    SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/fuzz_playfab_request_dictionary.cpp"
+        "${_PF_SRC}/playfab_request_value.cpp"
+    LINK_LIBS
+        godot_stub_harness
+        godot::cpp
+    INCLUDES
+        "${_PF_SRC}"
+        "${CMAKE_SOURCE_DIR}/tests/cpp/fuzz_harness"
+)
+
 if(PLAYFAB_SDK_PATH AND EXISTS "${PLAYFAB_SDK_PATH}/include/playfab/core/PFTypes.h")
     godot_addon_fuzzer_target(
         TARGET_NAME playfab_fuzz_api_models

--- a/tests/cpp/fuzz/fuzz_gdk_request_parsing.cpp
+++ b/tests/cpp/fuzz/fuzz_gdk_request_parsing.cpp
@@ -1,0 +1,137 @@
+// fuzz_gdk_request_parsing.cpp — Phase 3 libFuzzer target.
+//
+// Fuzzes the GDK request-input parsing seam (addons/godot_gdk/src/
+// gdk_request_parsing.cpp). These helpers validate caller-supplied (ultimately
+// script-supplied) request values and touch raw memory: strtoull over a UTF-8
+// buffer (try_parse_xuid), memcpy into a fixed native buffer (copy_utf8_to_buffer),
+// integer bounds-checks (parse_uint32), and PackedByteArray<->std::vector
+// round-trips. A malformed value must never read/write out of bounds or crash.
+//
+// Two complementary strategies run on every input:
+//   (A) Raw decode — a String carved from the fuzz buffer is fed to try_parse_xuid
+//       (both reject_zero modes), parse_uint32, and copy_utf8_to_buffer against a
+//       fixed stack buffer of fuzz-chosen capacity, with both populated and null
+//       outputs, to surface out-of-bounds access on attacker-controlled lengths.
+//   (B) Round-trip oracle — bytes carved from the fuzz buffer are converted
+//       vector -> PackedByteArray -> vector; any mismatch trips __builtin_trap().
+
+#include "godot_stub_init.h"
+
+#include "gdk_request_parsing.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+namespace parsing = godot::gdk_request_parsing;
+
+using godot::PackedByteArray;
+using godot::String;
+
+// Carve a length-prefixed string out of the cursor. Bytes are masked to
+// 0x01..0x7F so the carved characters survive String round-tripping and the
+// parsed UTF-8 stays single-byte.
+size_t take_ascii(const uint8_t *d, size_t rem, char *out, size_t out_max, size_t &out_len) {
+    if (rem == 0) {
+        out[0] = '\0';
+        out_len = 0;
+        return 0;
+    }
+    size_t len = static_cast<size_t>(d[0]) & 0x3F; // 0..63
+    if (len > rem - 1) {
+        len = rem - 1;
+    }
+    if (len >= out_max) {
+        len = out_max - 1;
+    }
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t b = d[1 + i] & 0x7F;
+        out[i] = static_cast<char>(b == 0 ? 0x20 : b);
+    }
+    out[len] = '\0';
+    out_len = len;
+    return 1 + len;
+}
+
+// Read a fixed-width little-endian integer from the cursor, or 0 if short.
+template <typename T>
+size_t take_int(const uint8_t *d, size_t rem, T &out) {
+    if (rem < sizeof(T)) {
+        out = T(0);
+        return rem;
+    }
+    std::memcpy(&out, d, sizeof(T));
+    return sizeof(T);
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+    godot_stub::init();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    size_t pos = 0;
+
+    // ── (A) Raw decode of an untrusted request value ─────────────────────
+    char text_buf[128] = {};
+    size_t text_len = 0;
+    pos += take_ascii(data + pos, size - pos, text_buf, sizeof(text_buf), text_len);
+    const String value = String::utf8(text_buf, static_cast<int64_t>(text_len));
+
+    {
+        uint64_t xuid = 0;
+        parsing::try_parse_xuid(value, &xuid, /*p_reject_zero=*/false);
+        parsing::try_parse_xuid(value, &xuid, /*p_reject_zero=*/true);
+        // Null output must be handled gracefully (returns false, no deref).
+        parsing::try_parse_xuid(value, nullptr, /*p_reject_zero=*/false);
+    }
+
+    {
+        int64_t raw_value = 0;
+        pos += take_int(data + pos, size - pos, raw_value);
+        uint32_t parsed = 0;
+        parsing::parse_uint32(value, raw_value, &parsed);
+        parsing::parse_uint32(value, raw_value, nullptr);
+    }
+
+    {
+        // Copy into a fixed buffer whose capacity is chosen by the fuzzer so the
+        // over-length and exact-fit boundaries are both exercised.
+        uint8_t cap_byte = 0;
+        pos += take_int(data + pos, size - pos, cap_byte);
+        const size_t cap = static_cast<size_t>(cap_byte) % 65; // 0..64
+        char dest[64] = {};
+        parsing::copy_utf8_to_buffer(value, dest, cap, String("field"));
+        // Null / zero-size buffer paths.
+        parsing::copy_utf8_to_buffer(value, nullptr, sizeof(dest), String("field"));
+        parsing::copy_utf8_to_buffer(value, dest, 0, String("field"));
+    }
+
+    // ── (B) PackedByteArray <-> std::vector round-trip oracle ────────────
+    {
+        size_t blob_len = size - pos;
+        if (blob_len > 4096) {
+            blob_len = 4096;
+        }
+        std::vector<uint8_t> in(data + pos, data + pos + blob_len);
+
+        const PackedByteArray packed = parsing::to_packed_byte_array(in);
+        if (static_cast<size_t>(packed.size()) != in.size()) {
+            __builtin_trap();
+        }
+
+        const std::vector<uint8_t> out = parsing::to_byte_vector(packed);
+        if (out.size() != in.size()) {
+            __builtin_trap();
+        }
+        if (!in.empty() && std::memcmp(out.data(), in.data(), in.size()) != 0) {
+            __builtin_trap();
+        }
+    }
+
+    return 0;
+}

--- a/tests/cpp/fuzz/fuzz_gdk_result_factories.cpp
+++ b/tests/cpp/fuzz/fuzz_gdk_result_factories.cpp
@@ -1,0 +1,164 @@
+// fuzz_gdk_result_factories.cpp — Phase 3 libFuzzer target.
+//
+// Fuzzes the GDKResult and PlayFabResult factory methods (ok_result,
+// error_result, hresult_error, cancelled) and their field accessors.
+// These classes use Ref<RefCounted> internally, which requires the Phase 3
+// stub harness's object lifecycle stubs (stub_object.cpp) to work without
+// a live Godot engine.
+//
+// Input layout (all fuzz bytes consumed):
+//   [0..3]   HRESULT value (4 bytes, little-endian)
+//   [4]      variant data type byte (0=nil, 1=int, 2=float, 3=bool)
+//   [5..8]   int/float payload for variant (4 bytes)
+//   [9]      action string length  (1 byte, 0..127)
+//   [10..]   action string bytes
+//   [10+action_len]      code string length (1 byte, 0..127)
+//   [10+action_len+1..]  code string bytes
+
+#include "godot_stub_init.h"
+
+#include "gdk_result.h"
+#include "playfab_result.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+// Decode a length-prefixed string from the fuzz buffer.
+// Returns number of bytes consumed (1 + actual string length).
+size_t decode_string(const uint8_t *data, size_t remaining,
+                     char *out_buf, size_t out_max) {
+    if (remaining == 0) {
+        out_buf[0] = '\0';
+        return 0;
+    }
+    size_t len = static_cast<size_t>(data[0] & 0x7F); // cap at 127
+    if (len > remaining - 1) len = remaining - 1;
+    if (len >= out_max) len = out_max - 1;
+    ::memcpy(out_buf, data + 1, len);
+    out_buf[len] = '\0';
+    return 1 + len;
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+    godot_stub::init();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 10) return 0;
+
+    // Decode HRESULT
+    HRESULT hr;
+    ::memcpy(&hr, data, 4);
+
+    // Decode simple Variant payload (nil, int, float, bool)
+    const uint8_t vtype = data[4];
+    uint32_t vpayload;
+    ::memcpy(&vpayload, data + 5, 4);
+
+    godot::Variant v;
+    switch (vtype & 0x03) {
+    case 0: /* nil */ break;
+    case 1: v = godot::Variant(static_cast<int64_t>(vpayload)); break;
+    case 2: {
+        float f;
+        ::memcpy(&f, &vpayload, 4);
+        v = godot::Variant(static_cast<double>(f));
+        break;
+    }
+    case 3: v = godot::Variant(static_cast<bool>(vpayload & 1)); break;
+    }
+
+    // Decode action and code strings
+    char action_buf[128] = {};
+    char code_buf[128]   = {};
+    size_t pos = 9;
+    pos += decode_string(data + pos, size - pos, action_buf, sizeof(action_buf));
+    if (pos < size) {
+        decode_string(data + pos, size - pos, code_buf, sizeof(code_buf));
+    }
+
+    const godot::String action(action_buf);
+    const godot::String code(code_buf);
+
+    // ── GDKResult factory + accessor round-trips ──────────────────────────
+    {
+        godot::Ref<godot::GDKResult> ok = godot::GDKResult::ok_result(v);
+        if (ok.is_valid()) {
+            (void)ok->is_ok();
+            (void)ok->get_hresult();
+            (void)ok->get_code();
+            (void)ok->get_message();
+            (void)ok->get_data();
+        }
+    }
+    {
+        godot::Ref<godot::GDKResult> err =
+            godot::GDKResult::error_result(hr, code, action, v);
+        if (err.is_valid()) {
+            (void)err->is_ok();
+            (void)err->get_hresult();
+            (void)err->get_code();
+            (void)err->get_message();
+        }
+    }
+    {
+        godot::Ref<godot::GDKResult> herr =
+            godot::GDKResult::hresult_error(hr, action, code, v);
+        if (herr.is_valid()) {
+            (void)herr->get_code();
+            (void)herr->get_message();
+        }
+    }
+    {
+        godot::Ref<godot::GDKResult> canc =
+            godot::GDKResult::cancelled(action);
+        if (canc.is_valid()) {
+            (void)canc->is_ok();
+            (void)canc->get_code();
+        }
+    }
+
+    // ── PlayFabResult factory + accessor round-trips ──────────────────────
+    {
+        godot::Ref<godot::PlayFabResult> ok = godot::PlayFabResult::ok_result(v);
+        if (ok.is_valid()) {
+            (void)ok->is_ok();
+            (void)ok->get_hresult();
+            (void)ok->get_code();
+            (void)ok->get_message();
+            (void)ok->get_data();
+        }
+    }
+    {
+        godot::Ref<godot::PlayFabResult> err =
+            godot::PlayFabResult::error_result(hr, code, action, v);
+        if (err.is_valid()) {
+            (void)err->is_ok();
+            (void)err->get_hresult();
+            (void)err->get_code();
+        }
+    }
+    {
+        godot::Ref<godot::PlayFabResult> herr =
+            godot::PlayFabResult::hresult_error(hr, action, code, v);
+        if (herr.is_valid()) {
+            (void)herr->get_code();
+            (void)herr->get_message();
+        }
+    }
+    {
+        godot::Ref<godot::PlayFabResult> canc =
+            godot::PlayFabResult::cancelled(action);
+        if (canc.is_valid()) {
+            (void)canc->is_ok();
+            (void)canc->get_code();
+        }
+    }
+
+    return 0;
+}

--- a/tests/cpp/fuzz/fuzz_gdk_result_formatting.cpp
+++ b/tests/cpp/fuzz/fuzz_gdk_result_formatting.cpp
@@ -1,0 +1,59 @@
+// fuzz_gdk_result_formatting.cpp — Phase 3 libFuzzer target.
+//
+// Fuzzes the HRESULT-formatting helpers from gdk_result_codes_internal and
+// playfab_result_codes_internal.  These functions return godot::String values
+// so they require the Phase 3 stub harness.
+//
+// Call pattern:
+//   LLVMFuzzerInitialize — call godot_stub::init() exactly once.
+//   LLVMFuzzerTestOneInput — decode fuzz bytes as an HRESULT + optional
+//   action string, then exercise the three formatting entry points.
+
+#include "godot_stub_init.h"
+
+#include "gdk_result_codes_internal.h"
+#include "playfab_result_codes_internal.h"
+
+#include <cstdint>
+#include <cstring>
+
+extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+    godot_stub::init();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 4) return 0;
+
+    // First 4 bytes → HRESULT value
+    HRESULT hr;
+    ::memcpy(&hr, data, 4);
+
+    // Remaining bytes → null-terminated action string (limit to 256 chars)
+    const size_t action_len = (size - 4) < 256 ? (size - 4) : 256;
+    char action_buf[257] = {};
+    if (action_len > 0) {
+        ::memcpy(action_buf, data + 4, action_len);
+        // Ensure null termination (may already be embedded in fuzz bytes)
+        action_buf[action_len] = '\0';
+    }
+
+    // Build a godot::String from the action buffer (stub harness handles conversion)
+    godot::String action = godot::String(action_buf);
+
+    // Exercise gdk_internal formatting
+    godot::String hex_str = gdk_internal::format_hresult_string(hr);
+    godot::String msg_str = gdk_internal::format_hresult_message(action, hr);
+    godot::String code_or = gdk_internal::code_or_format_hresult(action, hr);
+
+    // Exercise playfab_internal formatting
+    godot::String pf_hex = playfab_internal::format_hresult_string(hr);
+    godot::String pf_msg = playfab_internal::format_hresult_message(action, hr);
+    godot::String pf_code_or = playfab_internal::code_or_format_hresult(action, hr);
+
+    // Prevent the compiler from optimizing away the results
+    (void)hex_str; (void)msg_str; (void)code_or;
+    (void)pf_hex;  (void)pf_msg;  (void)pf_code_or;
+
+    return 0;
+}

--- a/tests/cpp/fuzz/fuzz_playfab_key_lookup.cpp
+++ b/tests/cpp/fuzz/fuzz_playfab_key_lookup.cpp
@@ -1,0 +1,48 @@
+// Phase 2 fuzz target: playfab_internal::match_request_key
+//
+// Exercises the pure key-selection helper with arbitrary byte inputs.
+// No Godot types are used; no harness initialization is required.
+//
+// Input layout (best-effort split on NUL bytes):
+//   [primary\0fallback\0key0\0key1\0...\0keyN]
+// If the input has fewer than 2 NUL-separated fields, the missing segments
+// default to empty strings. This layout gives the fuzzer maximum freedom to
+// vary all inputs independently.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "playfab_request_key.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) {
+        return 0;
+    }
+
+    // Split the input into NUL-terminated segments.
+    std::vector<const char *> segments;
+    const char *start = reinterpret_cast<const char *>(data);
+    const char *end = start + size;
+    const char *seg = start;
+
+    for (const char *p = start; p < end; ++p) {
+        if (*p == '\0') {
+            segments.push_back(seg);
+            seg = p + 1;
+        }
+    }
+    // Last segment (may not be NUL-terminated — skip it to avoid OOB read).
+    // We only use segments that are properly NUL-terminated by the scan above.
+
+    const char *primary  = segments.size() > 0 ? segments[0] : "";
+    const char *fallback = segments.size() > 1 ? segments[1] : "";
+
+    // Remaining segments are the key array.
+    const size_t key_count = segments.size() > 2 ? segments.size() - 2 : 0;
+    const char *const *keys = key_count > 0 ? segments.data() + 2 : nullptr;
+
+    playfab_internal::match_request_key(keys, key_count, primary, fallback);
+    return 0;
+}

--- a/tests/cpp/fuzz/fuzz_playfab_party_codec.cpp
+++ b/tests/cpp/fuzz/fuzz_playfab_party_codec.cpp
@@ -1,0 +1,166 @@
+// fuzz_playfab_party_codec.cpp — Phase 3 libFuzzer target.
+//
+// Fuzzes the PlayFab Party wire codec (addons/godot_playfab/src/
+// playfab_party_codec.cpp). The parse_*/unwrap_* functions decode bytes that
+// originate from a remote peer, so they are the addon's primary untrusted-input
+// surface: a malformed packet must never read out of bounds or crash.
+//
+// Two complementary strategies run on every input:
+//   (A) Raw decode — the whole fuzz buffer is fed to every parse/unwrap entry
+//       point (with both populated and null output pointers) to surface
+//       out-of-bounds reads on attacker-controlled length fields.
+//   (B) Round-trip oracles — values carved from the fuzz buffer are encoded
+//       with the build_*/wrap_* helpers and decoded back; any mismatch trips
+//       __builtin_trap(), catching encode/decode asymmetry bugs.
+
+#include "godot_stub_init.h"
+
+#include "playfab_party_codec.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+using godot::MultiplayerPeer;
+using godot::PackedByteArray;
+using godot::String;
+
+namespace codec = godot::pf_party_codec;
+
+// Carve a length-prefixed ASCII string out of the cursor. Bytes are masked to
+// 0x01..0x7F so the UTF-8 encode/decode performed by the codec is the identity
+// transform and the round-trip oracle can compare bytes exactly.
+size_t take_ascii(const uint8_t *d, size_t rem, char *out, size_t out_max, size_t &out_len) {
+    if (rem == 0) { out[0] = '\0'; out_len = 0; return 0; }
+    size_t len = static_cast<size_t>(d[0]) & 0x3F; // 0..63
+    if (len > rem - 1) len = rem - 1;
+    if (len >= out_max) len = out_max - 1;
+    for (size_t i = 0; i < len; ++i) {
+        uint8_t b = d[1 + i] & 0x7F;
+        out[i] = static_cast<char>(b == 0 ? 0x20 : b);
+    }
+    out[len] = '\0';
+    out_len = len;
+    return 1 + len;
+}
+
+// Read a fixed-width little-endian integer from the cursor, or 0 if short.
+template <typename T>
+size_t take_int(const uint8_t *d, size_t rem, T &out) {
+    if (rem < sizeof(T)) { out = T(0); return rem; }
+    std::memcpy(&out, d, sizeof(T));
+    return sizeof(T);
+}
+
+bool string_utf8_equals(const String &s, const char *buf, size_t len) {
+    const godot::CharString cs = s.utf8();
+    return static_cast<size_t>(cs.length()) == len &&
+           (len == 0 || std::memcmp(cs.get_data(), buf, len) == 0);
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+    godot_stub::init();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    const uint32_t raw_size = size > 0xFFFFFFFFu ? 0xFFFFFFFFu : static_cast<uint32_t>(size);
+
+    // ── (A) Raw decode of untrusted bytes ────────────────────────────────
+    {
+        uint32_t nonce = 0;
+        int32_t peer = 0, source = 0, channel = 0;
+        String entity_id, entity_type;
+        MultiplayerPeer::TransferMode mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE;
+        PackedByteArray payload;
+
+        codec::parse_handshake_request(data, raw_size, &nonce, &entity_id, &entity_type);
+        codec::parse_handshake_request(data, raw_size, nullptr, nullptr, nullptr);
+        codec::parse_handshake_reply(data, raw_size, &nonce, &peer);
+        codec::parse_handshake_reply(data, raw_size, nullptr, nullptr);
+        codec::unwrap_gameplay_payload(data, raw_size, &source, &channel, &mode, &payload);
+        codec::unwrap_gameplay_payload(data, raw_size, nullptr, nullptr, nullptr, nullptr);
+    }
+
+    // ── (B) Round-trip oracles ───────────────────────────────────────────
+    size_t pos = 0;
+
+    // Handshake request: nonce(4) + id + type.
+    {
+        uint32_t nonce_in = 0;
+        pos += take_int(data + pos, size - pos, nonce_in);
+        char id_buf[64] = {}, type_buf[64] = {};
+        size_t id_len = 0, type_len = 0;
+        pos += take_ascii(data + pos, size - pos, id_buf, sizeof(id_buf), id_len);
+        pos += take_ascii(data + pos, size - pos, type_buf, sizeof(type_buf), type_len);
+
+        const String id_in = String::utf8(id_buf, static_cast<int64_t>(id_len));
+        const String type_in = String::utf8(type_buf, static_cast<int64_t>(type_len));
+        PackedByteArray packet = codec::build_handshake_request(nonce_in, id_in, type_in);
+
+        uint32_t nonce_out = 0;
+        String id_out, type_out;
+        if (!codec::parse_handshake_request(packet.ptr(), static_cast<uint32_t>(packet.size()),
+                                            &nonce_out, &id_out, &type_out)) {
+            __builtin_trap();
+        }
+        if (nonce_out != nonce_in) __builtin_trap();
+        if (!string_utf8_equals(id_out, id_buf, id_len)) __builtin_trap();
+        if (!string_utf8_equals(type_out, type_buf, type_len)) __builtin_trap();
+    }
+
+    // Handshake reply: nonce(4) + assigned_peer_id(4).
+    {
+        uint32_t nonce_in = 0;
+        int32_t peer_in = 0;
+        pos += take_int(data + pos, size - pos, nonce_in);
+        pos += take_int(data + pos, size - pos, peer_in);
+
+        PackedByteArray packet = codec::build_handshake_reply(nonce_in, peer_in);
+        uint32_t nonce_out = 0;
+        int32_t peer_out = 0;
+        if (!codec::parse_handshake_reply(packet.ptr(), static_cast<uint32_t>(packet.size()),
+                                          &nonce_out, &peer_out)) {
+            __builtin_trap();
+        }
+        if (nonce_out != nonce_in || peer_out != peer_in) __builtin_trap();
+    }
+
+    // Gameplay envelope: source(4) + channel(4) + mode(1) + payload(rest).
+    {
+        int32_t source_in = 0, channel_in = 0;
+        pos += take_int(data + pos, size - pos, source_in);
+        pos += take_int(data + pos, size - pos, channel_in);
+
+        uint8_t mode_byte = 0;
+        if (pos < size) { mode_byte = data[pos]; ++pos; }
+        const MultiplayerPeer::TransferMode mode_in =
+            static_cast<MultiplayerPeer::TransferMode>(mode_byte % 3);
+
+        const uint8_t *payload_in = data + pos;
+        size_t payload_len = size - pos;
+        if (payload_len > 4096) payload_len = 4096;
+
+        PackedByteArray envelope = codec::wrap_gameplay_payload(
+            source_in, channel_in, mode_in, payload_in, static_cast<uint32_t>(payload_len));
+
+        int32_t source_out = 0, channel_out = 0;
+        MultiplayerPeer::TransferMode mode_out = MultiplayerPeer::TRANSFER_MODE_RELIABLE;
+        PackedByteArray payload_out;
+        if (!codec::unwrap_gameplay_payload(envelope.ptr(), static_cast<uint32_t>(envelope.size()),
+                                            &source_out, &channel_out, &mode_out, &payload_out)) {
+            __builtin_trap();
+        }
+        if (source_out != source_in || channel_out != channel_in) __builtin_trap();
+        if (static_cast<uint8_t>(mode_out) != static_cast<uint8_t>(mode_in)) __builtin_trap();
+        if (static_cast<size_t>(payload_out.size()) != payload_len) __builtin_trap();
+        if (payload_len > 0 && std::memcmp(payload_out.ptr(), payload_in, payload_len) != 0) {
+            __builtin_trap();
+        }
+    }
+
+    return 0;
+}

--- a/tests/cpp/fuzz/fuzz_playfab_request_dictionary.cpp
+++ b/tests/cpp/fuzz/fuzz_playfab_request_dictionary.cpp
@@ -1,0 +1,104 @@
+// fuzz_playfab_request_dictionary.cpp — Phase 3 libFuzzer target.
+//
+// Fuzzes playfab_api::get_request_value() — the function that resolves a
+// field from a GDScript request Dictionary by trying the snake_case key first
+// and falling back to the PascalCase key.
+//
+// This is interesting to fuzz because the production code path goes through
+// StringName construction + Dictionary::has() lookup for every PlayFab API
+// call that reads a request parameter.
+//
+// Input layout:
+//   [0]          field_name length (1 byte, 0..63)
+//   [1..N]       field_name bytes (PascalCase key)
+//   [N+1]        snake_name length (1 byte, 0..63)
+//   [N+2..M]     snake_name bytes (snake_case key)
+//   remaining    Dictionary entries: repeated { key_len(1), key(key_len),
+//                                               val_type(1), val_data(4) }
+
+#include "godot_stub_init.h"
+
+#include "playfab_request_value.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+size_t decode_cstr(const uint8_t *data, size_t remaining,
+                   char *out_buf, size_t out_max, size_t cap = 63) {
+    if (remaining == 0) { out_buf[0] = '\0'; return 0; }
+    size_t len = static_cast<size_t>(data[0]) & 0x3F; // 0..63
+    if (cap < 63) len = len > cap ? cap : len;
+    if (len > remaining - 1) len = remaining - 1;
+    if (len >= out_max) len = out_max - 1;
+    ::memcpy(out_buf, data + 1, len);
+    out_buf[len] = '\0';
+    return 1 + len;
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+    godot_stub::init();
+    return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 4) return 0;
+
+    size_t pos = 0;
+
+    // Decode field names
+    char field_name[65] = {};
+    char snake_name[65] = {};
+    pos += decode_cstr(data + pos, size - pos, field_name, sizeof(field_name));
+    if (pos >= size) return 0;
+    pos += decode_cstr(data + pos, size - pos, snake_name, sizeof(snake_name));
+
+    // Build a Dictionary from the remaining fuzz bytes.
+    // Each entry: key_len(1) + key_bytes + val_type(1) + val_data(4)
+    godot::Dictionary dict;
+
+    while (pos + 6 <= size) {
+        // Key string
+        char key_buf[65] = {};
+        size_t consumed = decode_cstr(data + pos, size - pos, key_buf, sizeof(key_buf));
+        pos += consumed;
+        if (pos >= size) break;
+
+        // Value: 1-byte type selector + 4-byte payload
+        const uint8_t vtype = data[pos++];
+        if (pos + 4 > size) break;
+        uint32_t payload;
+        ::memcpy(&payload, data + pos, 4);
+        pos += 4;
+
+        godot::Variant val;
+        switch (vtype & 0x03) {
+        case 0: /* nil */ break;
+        case 1: val = godot::Variant(static_cast<int64_t>(payload)); break;
+        case 2: {
+            float f;
+            ::memcpy(&f, &payload, 4);
+            val = godot::Variant(static_cast<double>(f));
+            break;
+        }
+        case 3: val = godot::Variant(static_cast<bool>(payload & 1)); break;
+        }
+
+        dict[godot::String(key_buf)] = val;
+    }
+
+    // Exercise the priority-lookup logic with both key orderings.
+    godot::Variant out_val;
+    bool found = godot::playfab_api::get_request_value(dict, field_name, snake_name, &out_val);
+    (void)found;
+
+    // Also test with swapped order to exercise both branches.
+    godot::Variant out_val2;
+    bool found2 = godot::playfab_api::get_request_value(dict, snake_name, field_name, &out_val2);
+    (void)found2;
+
+    return 0;
+}

--- a/tests/cpp/fuzz_harness/CMakeLists.txt
+++ b/tests/cpp/fuzz_harness/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(godot_stub_harness STATIC
     stub_string.cpp
     stub_variant.cpp
     stub_dict_array.cpp
+    stub_packed_array.cpp
     stub_object.cpp
     stub_noop.cpp
     godot_stub_init.cpp

--- a/tests/cpp/fuzz_harness/CMakeLists.txt
+++ b/tests/cpp/fuzz_harness/CMakeLists.txt
@@ -1,0 +1,31 @@
+# godot_stub_harness — static library that satisfies all 176 GDExtension interface
+# function slots so that godot::String, Dictionary, Variant, and Array work in a
+# standalone fuzz exe with no live Godot engine.
+#
+# Built automatically when GDK_BUILD_FUZZ_TARGETS=ON (the `fuzz` configure preset
+# enables this). Fuzz targets that use Godot types link against this library.
+#
+# See godot_stub_init.h for the public API and usage pattern.
+
+add_library(godot_stub_harness STATIC
+    stub_memory.cpp
+    stub_string.cpp
+    stub_variant.cpp
+    stub_dict_array.cpp
+    stub_noop.cpp
+    godot_stub_init.cpp
+)
+
+target_include_directories(godot_stub_harness PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+target_link_libraries(godot_stub_harness PUBLIC godot::cpp)
+
+# ASan+fuzzer flags must be consistent across the entire link unit.
+# Note: clang-cl uses '-' prefix (not '/') for sanitizer flags.
+target_compile_options(godot_stub_harness PRIVATE -fsanitize=fuzzer,address)
+
+set_target_properties(godot_stub_harness PROPERTIES
+    FOLDER "tests/fuzz"
+)

--- a/tests/cpp/fuzz_harness/CMakeLists.txt
+++ b/tests/cpp/fuzz_harness/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(godot_stub_harness STATIC
     stub_string.cpp
     stub_variant.cpp
     stub_dict_array.cpp
+    stub_object.cpp
     stub_noop.cpp
     godot_stub_init.cpp
 )

--- a/tests/cpp/fuzz_harness/godot_stub_init.cpp
+++ b/tests/cpp/fuzz_harness/godot_stub_init.cpp
@@ -117,6 +117,16 @@ extern void *stub_array_operator_index_const_ptr;
 extern void *stub_array_ref_ptr;
 extern void *stub_array_set_typed_ptr;
 
+// stub_object.cpp
+extern void *stub_classdb_construct_object_ptr;
+extern void *stub_classdb_construct_object2_ptr;
+extern void *stub_object_set_instance_ptr;
+extern void *stub_object_set_instance_binding_ptr;
+extern void *stub_object_get_instance_binding_ptr;
+extern void *stub_object_destroy_ptr;
+extern void *stub_classdb_get_method_bind_ptr;
+extern void *stub_object_method_bind_ptrcall_ptr;
+
 // stub_noop.cpp
 extern void *stub_noop_ptr;
 extern void *stub_get_godot_version_ptr;
@@ -239,10 +249,10 @@ static const std::unordered_map<std::string_view, void **> &dispatch_table() {
         { "array_set_typed",                         &stub_array_set_typed_ptr },
 
         // ── No-ops: class system, objects, scripts, editor, packed arrays ──
-        { "classdb_construct_object",                   &stub_noop_ptr },
-        { "classdb_construct_object2",                  &stub_noop_ptr },
+        { "classdb_construct_object",                   &stub_classdb_construct_object_ptr },
+        { "classdb_construct_object2",                  &stub_classdb_construct_object2_ptr },
         { "classdb_get_class_tag",                      &stub_noop_ptr },
-        { "classdb_get_method_bind",                    &stub_noop_ptr },
+        { "classdb_get_method_bind",                    &stub_classdb_get_method_bind_ptr },
         { "classdb_register_extension_class",           &stub_noop_ptr },
         { "classdb_register_extension_class2",          &stub_noop_ptr },
         { "classdb_register_extension_class3",          &stub_noop_ptr },
@@ -274,18 +284,18 @@ static const std::unordered_map<std::string_view, void **> &dispatch_table() {
         { "image_ptrw",                                 &stub_noop_ptr },
         { "object_call_script_method",                  &stub_noop_ptr },
         { "object_cast_to",                             &stub_noop_ptr },
-        { "object_destroy",                             &stub_noop_ptr },
+        { "object_destroy",                             &stub_object_destroy_ptr },
         { "object_free_instance_binding",               &stub_noop_ptr },
         { "object_get_class_name",                      &stub_noop_ptr },
-        { "object_get_instance_binding",                &stub_noop_ptr },
+        { "object_get_instance_binding",                &stub_object_get_instance_binding_ptr },
         { "object_get_instance_from_id",                &stub_noop_ptr },
         { "object_get_instance_id",                     &stub_noop_ptr },
         { "object_get_script_instance",                 &stub_noop_ptr },
         { "object_has_script_method",                   &stub_noop_ptr },
         { "object_method_bind_call",                    &stub_noop_ptr },
-        { "object_method_bind_ptrcall",                 &stub_noop_ptr },
-        { "object_set_instance",                        &stub_noop_ptr },
-        { "object_set_instance_binding",                &stub_noop_ptr },
+        { "object_method_bind_ptrcall",                 &stub_object_method_bind_ptrcall_ptr },
+        { "object_set_instance",                        &stub_object_set_instance_ptr },
+        { "object_set_instance_binding",                &stub_object_set_instance_binding_ptr },
         { "object_set_script_instance",                 &stub_noop_ptr },
         { "packed_byte_array_operator_index",           &stub_noop_ptr },
         { "packed_byte_array_operator_index_const",     &stub_noop_ptr },

--- a/tests/cpp/fuzz_harness/godot_stub_init.cpp
+++ b/tests/cpp/fuzz_harness/godot_stub_init.cpp
@@ -117,6 +117,10 @@ extern void *stub_array_operator_index_const_ptr;
 extern void *stub_array_ref_ptr;
 extern void *stub_array_set_typed_ptr;
 
+// stub_packed_array.cpp
+extern void *stub_packed_byte_array_operator_index_ptr;
+extern void *stub_packed_byte_array_operator_index_const_ptr;
+
 // stub_object.cpp
 extern void *stub_classdb_construct_object_ptr;
 extern void *stub_classdb_construct_object2_ptr;
@@ -297,8 +301,8 @@ static const std::unordered_map<std::string_view, void **> &dispatch_table() {
         { "object_set_instance",                        &stub_object_set_instance_ptr },
         { "object_set_instance_binding",                &stub_object_set_instance_binding_ptr },
         { "object_set_script_instance",                 &stub_noop_ptr },
-        { "packed_byte_array_operator_index",           &stub_noop_ptr },
-        { "packed_byte_array_operator_index_const",     &stub_noop_ptr },
+        { "packed_byte_array_operator_index",           &stub_packed_byte_array_operator_index_ptr },
+        { "packed_byte_array_operator_index_const",     &stub_packed_byte_array_operator_index_const_ptr },
         { "packed_color_array_operator_index",          &stub_noop_ptr },
         { "packed_color_array_operator_index_const",    &stub_noop_ptr },
         { "packed_float32_array_operator_index",        &stub_noop_ptr },

--- a/tests/cpp/fuzz_harness/godot_stub_init.cpp
+++ b/tests/cpp/fuzz_harness/godot_stub_init.cpp
@@ -1,0 +1,373 @@
+// godot_stub_init.cpp — GDExtension stub harness dispatch table and init.
+//
+// Provides stub_get_proc_address() which maps all 176 GDExtension interface
+// function names to the stub implementations defined in the sibling .cpp files.
+// Functions not needed by our fuzz targets are mapped to stub_noop_ptr.
+//
+// Usage: call godot_stub::init() once from LLVMFuzzerInitialize before using
+// any Godot type.  See godot_stub_init.h for the full API contract.
+
+#include "godot_stub_init.h"
+#include "stub_types.h"
+
+#include <cstring>
+#include <string_view>
+#include <unordered_map>
+
+// ─── Extern declarations for all function pointer tables ──────────────────
+
+// stub_memory.cpp
+extern void *stub_mem_alloc_ptr;
+extern void *stub_mem_alloc2_ptr;
+extern void *stub_mem_realloc_ptr;
+extern void *stub_mem_realloc2_ptr;
+extern void *stub_mem_free_ptr;
+extern void *stub_mem_free2_ptr;
+extern void *stub_print_error_ptr;
+extern void *stub_print_error_with_message_ptr;
+extern void *stub_print_warning_ptr;
+extern void *stub_print_warning_with_message_ptr;
+
+// stub_string.cpp
+extern void *stub_string_new_with_latin1_chars_ptr;
+extern void *stub_string_new_with_latin1_chars_and_len_ptr;
+extern void *stub_string_new_with_utf8_chars_ptr;
+extern void *stub_string_new_with_utf8_chars_and_len_ptr;
+extern void *stub_string_new_with_utf8_chars_and_len2_ptr;
+extern void *stub_string_new_with_utf32_chars_ptr;
+extern void *stub_string_new_with_utf32_chars_and_len_ptr;
+extern void *stub_string_new_with_wide_chars_ptr;
+extern void *stub_string_new_with_wide_chars_and_len_ptr;
+extern void *stub_string_new_with_utf16_chars_ptr;
+extern void *stub_string_new_with_utf16_chars_and_len_ptr;
+extern void *stub_string_new_with_utf16_chars_and_len2_ptr;
+extern void *stub_string_operator_plus_eq_string_ptr;
+extern void *stub_string_operator_plus_eq_cstr_ptr;
+extern void *stub_string_operator_plus_eq_wcstr_ptr;
+extern void *stub_string_operator_plus_eq_c32str_ptr;
+extern void *stub_string_operator_plus_eq_char_ptr;
+extern void *stub_string_operator_index_ptr;
+extern void *stub_string_operator_index_const_ptr;
+extern void *stub_string_to_latin1_chars_ptr;
+extern void *stub_string_to_utf8_chars_ptr;
+extern void *stub_string_to_utf16_chars_ptr;
+extern void *stub_string_to_utf32_chars_ptr;
+extern void *stub_string_to_wide_chars_ptr;
+extern void *stub_string_resize_ptr;
+extern void *stub_string_name_new_with_latin1_chars_ptr;
+extern void *stub_string_name_new_with_utf8_chars_ptr;
+extern void *stub_string_name_new_with_utf8_chars_and_len_ptr;
+
+// stub_variant.cpp
+extern void *stub_variant_new_nil_ptr;
+extern void *stub_variant_new_copy_ptr;
+extern void *stub_variant_destroy_ptr;
+extern void *stub_variant_get_type_ptr;
+extern void *stub_variant_get_type_name_ptr;
+extern void *stub_variant_booleanize_ptr;
+extern void *stub_variant_hash_ptr;
+extern void *stub_variant_hash_compare_ptr;
+extern void *stub_variant_stringify_ptr;
+extern void *stub_variant_call_ptr;
+extern void *stub_variant_call_static_ptr;
+extern void *stub_variant_construct_ptr;
+extern void *stub_variant_duplicate_ptr;
+extern void *stub_variant_get_ptr;
+extern void *stub_variant_set_ptr;
+extern void *stub_variant_get_named_ptr;
+extern void *stub_variant_set_named_ptr;
+extern void *stub_variant_get_indexed_ptr;
+extern void *stub_variant_set_indexed_ptr;
+extern void *stub_variant_get_keyed_ptr;
+extern void *stub_variant_set_keyed_ptr;
+extern void *stub_variant_has_key_ptr;
+extern void *stub_variant_can_convert_ptr;
+extern void *stub_variant_can_convert_strict_ptr;
+extern void *stub_variant_evaluate_ptr;
+extern void *stub_variant_recursive_hash_ptr;
+extern void *stub_variant_has_member_ptr;
+extern void *stub_variant_has_method_ptr;
+extern void *stub_variant_get_object_instance_id_ptr;
+extern void *stub_variant_get_constant_value_ptr;
+extern void *stub_variant_iter_init_ptr;
+extern void *stub_variant_iter_next_ptr;
+extern void *stub_variant_iter_get_ptr;
+extern void *stub_variant_get_ptr_setter_ptr;
+extern void *stub_variant_get_ptr_getter_ptr;
+extern void *stub_variant_get_ptr_indexed_setter_ptr;
+extern void *stub_variant_get_ptr_indexed_getter_ptr;
+extern void *stub_variant_get_ptr_keyed_setter_ptr;
+extern void *stub_variant_get_ptr_keyed_getter_ptr;
+extern void *stub_variant_get_ptr_keyed_checker_ptr;
+extern void *stub_variant_get_ptr_operator_evaluator_ptr;
+extern void *stub_variant_get_ptr_utility_function_ptr;
+extern void *stub_variant_get_ptr_internal_getter_ptr;
+extern void *stub_variant_get_ptr_constructor_ptr;
+extern void *stub_variant_get_ptr_destructor_ptr;
+extern void *stub_variant_get_ptr_builtin_method_ptr;
+extern void *stub_get_variant_from_type_constructor_ptr;
+extern void *stub_get_variant_to_type_constructor_ptr;
+
+// stub_dict_array.cpp
+extern void *stub_dictionary_operator_index_ptr;
+extern void *stub_dictionary_operator_index_const_ptr;
+extern void *stub_dictionary_set_typed_ptr;
+extern void *stub_array_operator_index_ptr;
+extern void *stub_array_operator_index_const_ptr;
+extern void *stub_array_ref_ptr;
+extern void *stub_array_set_typed_ptr;
+
+// stub_noop.cpp
+extern void *stub_noop_ptr;
+extern void *stub_get_godot_version_ptr;
+extern void *stub_get_godot_version2_ptr;
+
+// ─── Dispatch table ───────────────────────────────────────────────────────
+
+static const std::unordered_map<std::string_view, void **> &dispatch_table() {
+    // Each entry maps the function name (string) → pointer to the function-pointer variable.
+    // Indirection through void** allows the table to be static-initialized without
+    // depending on global constructor ordering.
+    static const std::unordered_map<std::string_view, void **> table = {
+        // ── Memory ──────────────────────────────────────────────────────
+        { "mem_alloc",                            &stub_mem_alloc_ptr },
+        { "mem_alloc2",                           &stub_mem_alloc2_ptr },
+        { "mem_realloc",                          &stub_mem_realloc_ptr },
+        { "mem_realloc2",                         &stub_mem_realloc2_ptr },
+        { "mem_free",                             &stub_mem_free_ptr },
+        { "mem_free2",                            &stub_mem_free2_ptr },
+        { "print_error",                          &stub_print_error_ptr },
+        { "print_error_with_message",             &stub_print_error_with_message_ptr },
+        { "print_warning",                        &stub_print_warning_ptr },
+        { "print_warning_with_message",           &stub_print_warning_with_message_ptr },
+
+        // ── Version ──────────────────────────────────────────────────────
+        { "get_godot_version",                    &stub_get_godot_version_ptr },
+        { "get_godot_version2",                   &stub_get_godot_version2_ptr },
+
+        // ── String ───────────────────────────────────────────────────────
+        { "string_new_with_latin1_chars",            &stub_string_new_with_latin1_chars_ptr },
+        { "string_new_with_latin1_chars_and_len",    &stub_string_new_with_latin1_chars_and_len_ptr },
+        { "string_new_with_utf8_chars",              &stub_string_new_with_utf8_chars_ptr },
+        { "string_new_with_utf8_chars_and_len",      &stub_string_new_with_utf8_chars_and_len_ptr },
+        { "string_new_with_utf8_chars_and_len2",     &stub_string_new_with_utf8_chars_and_len2_ptr },
+        { "string_new_with_utf32_chars",             &stub_string_new_with_utf32_chars_ptr },
+        { "string_new_with_utf32_chars_and_len",     &stub_string_new_with_utf32_chars_and_len_ptr },
+        { "string_new_with_wide_chars",              &stub_string_new_with_wide_chars_ptr },
+        { "string_new_with_wide_chars_and_len",      &stub_string_new_with_wide_chars_and_len_ptr },
+        { "string_new_with_utf16_chars",             &stub_string_new_with_utf16_chars_ptr },
+        { "string_new_with_utf16_chars_and_len",     &stub_string_new_with_utf16_chars_and_len_ptr },
+        { "string_new_with_utf16_chars_and_len2",    &stub_string_new_with_utf16_chars_and_len2_ptr },
+        { "string_operator_plus_eq_string",          &stub_string_operator_plus_eq_string_ptr },
+        { "string_operator_plus_eq_cstr",            &stub_string_operator_plus_eq_cstr_ptr },
+        { "string_operator_plus_eq_wcstr",           &stub_string_operator_plus_eq_wcstr_ptr },
+        { "string_operator_plus_eq_c32str",          &stub_string_operator_plus_eq_c32str_ptr },
+        { "string_operator_plus_eq_char",            &stub_string_operator_plus_eq_char_ptr },
+        { "string_operator_index",                   &stub_string_operator_index_ptr },
+        { "string_operator_index_const",             &stub_string_operator_index_const_ptr },
+        { "string_to_latin1_chars",                  &stub_string_to_latin1_chars_ptr },
+        { "string_to_utf8_chars",                    &stub_string_to_utf8_chars_ptr },
+        { "string_to_utf16_chars",                   &stub_string_to_utf16_chars_ptr },
+        { "string_to_utf32_chars",                   &stub_string_to_utf32_chars_ptr },
+        { "string_to_wide_chars",                    &stub_string_to_wide_chars_ptr },
+        { "string_resize",                           &stub_string_resize_ptr },
+
+        // ── StringName ────────────────────────────────────────────────────
+        { "string_name_new_with_latin1_chars",       &stub_string_name_new_with_latin1_chars_ptr },
+        { "string_name_new_with_utf8_chars",         &stub_string_name_new_with_utf8_chars_ptr },
+        { "string_name_new_with_utf8_chars_and_len", &stub_string_name_new_with_utf8_chars_and_len_ptr },
+
+        // ── Variant ───────────────────────────────────────────────────────
+        { "variant_new_nil",                         &stub_variant_new_nil_ptr },
+        { "variant_new_copy",                        &stub_variant_new_copy_ptr },
+        { "variant_destroy",                         &stub_variant_destroy_ptr },
+        { "variant_get_type",                        &stub_variant_get_type_ptr },
+        { "variant_get_type_name",                   &stub_variant_get_type_name_ptr },
+        { "variant_booleanize",                      &stub_variant_booleanize_ptr },
+        { "variant_hash",                            &stub_variant_hash_ptr },
+        { "variant_hash_compare",                    &stub_variant_hash_compare_ptr },
+        { "variant_stringify",                       &stub_variant_stringify_ptr },
+        { "variant_call",                            &stub_variant_call_ptr },
+        { "variant_call_static",                     &stub_variant_call_static_ptr },
+        { "variant_construct",                       &stub_variant_construct_ptr },
+        { "variant_duplicate",                       &stub_variant_duplicate_ptr },
+        { "variant_get",                             &stub_variant_get_ptr },
+        { "variant_set",                             &stub_variant_set_ptr },
+        { "variant_get_named",                       &stub_variant_get_named_ptr },
+        { "variant_set_named",                       &stub_variant_set_named_ptr },
+        { "variant_get_indexed",                     &stub_variant_get_indexed_ptr },
+        { "variant_set_indexed",                     &stub_variant_set_indexed_ptr },
+        { "variant_get_keyed",                       &stub_variant_get_keyed_ptr },
+        { "variant_set_keyed",                       &stub_variant_set_keyed_ptr },
+        { "variant_has_key",                         &stub_variant_has_key_ptr },
+        { "variant_can_convert",                     &stub_variant_can_convert_ptr },
+        { "variant_can_convert_strict",              &stub_variant_can_convert_strict_ptr },
+        { "variant_evaluate",                        &stub_variant_evaluate_ptr },
+        { "variant_recursive_hash",                  &stub_variant_recursive_hash_ptr },
+        { "variant_has_member",                      &stub_variant_has_member_ptr },
+        { "variant_has_method",                      &stub_variant_has_method_ptr },
+        { "variant_get_object_instance_id",          &stub_variant_get_object_instance_id_ptr },
+        { "variant_get_constant_value",              &stub_variant_get_constant_value_ptr },
+        { "variant_iter_init",                       &stub_variant_iter_init_ptr },
+        { "variant_iter_next",                       &stub_variant_iter_next_ptr },
+        { "variant_iter_get",                        &stub_variant_iter_get_ptr },
+        { "variant_get_ptr_setter",                  &stub_variant_get_ptr_setter_ptr },
+        { "variant_get_ptr_getter",                  &stub_variant_get_ptr_getter_ptr },
+        { "variant_get_ptr_indexed_setter",          &stub_variant_get_ptr_indexed_setter_ptr },
+        { "variant_get_ptr_indexed_getter",          &stub_variant_get_ptr_indexed_getter_ptr },
+        { "variant_get_ptr_keyed_setter",            &stub_variant_get_ptr_keyed_setter_ptr },
+        { "variant_get_ptr_keyed_getter",            &stub_variant_get_ptr_keyed_getter_ptr },
+        { "variant_get_ptr_keyed_checker",           &stub_variant_get_ptr_keyed_checker_ptr },
+        { "variant_get_ptr_operator_evaluator",      &stub_variant_get_ptr_operator_evaluator_ptr },
+        { "variant_get_ptr_utility_function",        &stub_variant_get_ptr_utility_function_ptr },
+        { "variant_get_ptr_internal_getter",         &stub_variant_get_ptr_internal_getter_ptr },
+        { "variant_get_ptr_constructor",             &stub_variant_get_ptr_constructor_ptr },
+        { "variant_get_ptr_destructor",              &stub_variant_get_ptr_destructor_ptr },
+        { "variant_get_ptr_builtin_method",          &stub_variant_get_ptr_builtin_method_ptr },
+        { "get_variant_from_type_constructor",       &stub_get_variant_from_type_constructor_ptr },
+        { "get_variant_to_type_constructor",         &stub_get_variant_to_type_constructor_ptr },
+
+        // ── Dictionary ────────────────────────────────────────────────────
+        { "dictionary_operator_index",               &stub_dictionary_operator_index_ptr },
+        { "dictionary_operator_index_const",         &stub_dictionary_operator_index_const_ptr },
+        { "dictionary_set_typed",                    &stub_dictionary_set_typed_ptr },
+
+        // ── Array ─────────────────────────────────────────────────────────
+        { "array_operator_index",                    &stub_array_operator_index_ptr },
+        { "array_operator_index_const",              &stub_array_operator_index_const_ptr },
+        { "array_ref",                               &stub_array_ref_ptr },
+        { "array_set_typed",                         &stub_array_set_typed_ptr },
+
+        // ── No-ops: class system, objects, scripts, editor, packed arrays ──
+        { "classdb_construct_object",                   &stub_noop_ptr },
+        { "classdb_construct_object2",                  &stub_noop_ptr },
+        { "classdb_get_class_tag",                      &stub_noop_ptr },
+        { "classdb_get_method_bind",                    &stub_noop_ptr },
+        { "classdb_register_extension_class",           &stub_noop_ptr },
+        { "classdb_register_extension_class2",          &stub_noop_ptr },
+        { "classdb_register_extension_class3",          &stub_noop_ptr },
+        { "classdb_register_extension_class4",          &stub_noop_ptr },
+        { "classdb_register_extension_class5",          &stub_noop_ptr },
+        { "classdb_register_extension_class_integer_constant", &stub_noop_ptr },
+        { "classdb_register_extension_class_method",    &stub_noop_ptr },
+        { "classdb_register_extension_class_property",  &stub_noop_ptr },
+        { "classdb_register_extension_class_property_group", &stub_noop_ptr },
+        { "classdb_register_extension_class_property_indexed", &stub_noop_ptr },
+        { "classdb_register_extension_class_property_subgroup", &stub_noop_ptr },
+        { "classdb_register_extension_class_signal",    &stub_noop_ptr },
+        { "classdb_register_extension_class_virtual_method", &stub_noop_ptr },
+        { "classdb_unregister_extension_class",         &stub_noop_ptr },
+        { "callable_custom_create",                     &stub_noop_ptr },
+        { "callable_custom_create2",                    &stub_noop_ptr },
+        { "callable_custom_get_userdata",               &stub_noop_ptr },
+        { "editor_add_plugin",                          &stub_noop_ptr },
+        { "editor_help_load_xml_from_utf8_chars",       &stub_noop_ptr },
+        { "editor_help_load_xml_from_utf8_chars_and_len", &stub_noop_ptr },
+        { "editor_register_get_classes_used_callback",  &stub_noop_ptr },
+        { "editor_remove_plugin",                       &stub_noop_ptr },
+        { "file_access_get_buffer",                     &stub_noop_ptr },
+        { "file_access_store_buffer",                   &stub_noop_ptr },
+        { "get_library_path",                           &stub_noop_ptr },
+        { "get_native_struct_size",                     &stub_noop_ptr },
+        { "global_get_singleton",                       &stub_noop_ptr },
+        { "image_ptr",                                  &stub_noop_ptr },
+        { "image_ptrw",                                 &stub_noop_ptr },
+        { "object_call_script_method",                  &stub_noop_ptr },
+        { "object_cast_to",                             &stub_noop_ptr },
+        { "object_destroy",                             &stub_noop_ptr },
+        { "object_free_instance_binding",               &stub_noop_ptr },
+        { "object_get_class_name",                      &stub_noop_ptr },
+        { "object_get_instance_binding",                &stub_noop_ptr },
+        { "object_get_instance_from_id",                &stub_noop_ptr },
+        { "object_get_instance_id",                     &stub_noop_ptr },
+        { "object_get_script_instance",                 &stub_noop_ptr },
+        { "object_has_script_method",                   &stub_noop_ptr },
+        { "object_method_bind_call",                    &stub_noop_ptr },
+        { "object_method_bind_ptrcall",                 &stub_noop_ptr },
+        { "object_set_instance",                        &stub_noop_ptr },
+        { "object_set_instance_binding",                &stub_noop_ptr },
+        { "object_set_script_instance",                 &stub_noop_ptr },
+        { "packed_byte_array_operator_index",           &stub_noop_ptr },
+        { "packed_byte_array_operator_index_const",     &stub_noop_ptr },
+        { "packed_color_array_operator_index",          &stub_noop_ptr },
+        { "packed_color_array_operator_index_const",    &stub_noop_ptr },
+        { "packed_float32_array_operator_index",        &stub_noop_ptr },
+        { "packed_float32_array_operator_index_const",  &stub_noop_ptr },
+        { "packed_float64_array_operator_index",        &stub_noop_ptr },
+        { "packed_float64_array_operator_index_const",  &stub_noop_ptr },
+        { "packed_int32_array_operator_index",          &stub_noop_ptr },
+        { "packed_int32_array_operator_index_const",    &stub_noop_ptr },
+        { "packed_int64_array_operator_index",          &stub_noop_ptr },
+        { "packed_int64_array_operator_index_const",    &stub_noop_ptr },
+        { "packed_string_array_operator_index",         &stub_noop_ptr },
+        { "packed_string_array_operator_index_const",   &stub_noop_ptr },
+        { "packed_vector2_array_operator_index",        &stub_noop_ptr },
+        { "packed_vector2_array_operator_index_const",  &stub_noop_ptr },
+        { "packed_vector3_array_operator_index",        &stub_noop_ptr },
+        { "packed_vector3_array_operator_index_const",  &stub_noop_ptr },
+        { "packed_vector4_array_operator_index",        &stub_noop_ptr },
+        { "packed_vector4_array_operator_index_const",  &stub_noop_ptr },
+        { "placeholder_script_instance_create",         &stub_noop_ptr },
+        { "placeholder_script_instance_update",         &stub_noop_ptr },
+        { "print_script_error",                         &stub_noop_ptr },
+        { "print_script_error_with_message",            &stub_noop_ptr },
+        { "ref_get_object",                             &stub_noop_ptr },
+        { "ref_set_object",                             &stub_noop_ptr },
+        { "register_main_loop_callbacks",               &stub_noop_ptr },
+        { "script_instance_create",                     &stub_noop_ptr },
+        { "script_instance_create2",                    &stub_noop_ptr },
+        { "script_instance_create3",                    &stub_noop_ptr },
+        { "worker_thread_pool_add_native_group_task",   &stub_noop_ptr },
+        { "worker_thread_pool_add_native_task",         &stub_noop_ptr },
+        { "xml_parser_open_buffer",                     &stub_noop_ptr },
+    };
+    return table;
+}
+
+// ─── stub_get_proc_address ────────────────────────────────────────────────
+
+static void *stub_get_proc_address(const char *p_function_name) {
+    const auto &table = dispatch_table();
+    auto it = table.find(std::string_view(p_function_name));
+    if (it != table.end()) return *it->second;
+    // Unknown function: return the no-op rather than nullptr to avoid
+    // a null-pointer dereference in godot-cpp's LOAD_PROC_ADDRESS macro.
+    return stub_noop_ptr;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+// godot-cpp's GDExtensionBinding::init is declared in godot_cpp/godot.hpp.
+#include <godot_cpp/godot.hpp>
+
+namespace godot_stub {
+
+static void noop_init_level(godot::ModuleInitializationLevel) {}
+
+void init() {
+    // GDExtensionBinding::init() requires:
+    //   1. A non-null init_callback (set via register_initializer).
+    //   2. A non-null GDExtensionInitialization* (written by init, not read back by us).
+    //
+    // We pass a no-op initializer — the fuzz targets only use built-in Godot
+    // types (String, Dictionary, Variant, Array), which are initialized by
+    // Variant::init_bindings() inside GDExtensionBinding::init() before any
+    // user-level initialization callbacks run.
+    GDExtensionInitialization gdext_init = {};
+    godot::GDExtensionBinding::InitObject init_obj(
+        reinterpret_cast<GDExtensionInterfaceGetProcAddress>(stub_get_proc_address),
+        nullptr,
+        &gdext_init);
+    init_obj.register_initializer(noop_init_level);
+    GDExtensionBool ok = init_obj.init();
+    if (!ok) {
+        ::fprintf(stderr, "godot_stub::init() — GDExtensionBinding::init failed!\n");
+        ::abort();
+    }
+}
+
+void shutdown() {
+    // Optional; the process exits cleanly either way for fuzz targets.
+}
+
+} // namespace godot_stub

--- a/tests/cpp/fuzz_harness/godot_stub_init.h
+++ b/tests/cpp/fuzz_harness/godot_stub_init.h
@@ -27,9 +27,9 @@
 //   - godot::String: each instance owns a heap-allocated std::u32string.
 //     The 8-byte godot::String opaque blob stores a `std::u32string *`.
 //   - godot::StringName: interned in a global std::unordered_set<std::string>.
-//   - godot::Dictionary: heap-allocated struct wrapping
-//     std::unordered_map<std::string, StubVariant>.
-//   - godot::Array: heap-allocated struct wrapping std::vector<StubVariant>.
+//   - godot::Dictionary: heap-allocated StubDict wrapping an ordered
+//     std::vector<Entry> (each Entry holds the string key-repr, key, value).
+//   - godot::Array: heap-allocated StubArray wrapping std::deque<StubVariant>.
 //   - godot::Variant: tagged union over NIL / bool / int64 / float64 /
 //     String* / Dictionary* / Array*.
 //   - Memory: malloc / realloc / free.

--- a/tests/cpp/fuzz_harness/godot_stub_init.h
+++ b/tests/cpp/fuzz_harness/godot_stub_init.h
@@ -1,0 +1,50 @@
+#ifndef GODOT_STUB_INIT_H
+#define GODOT_STUB_INIT_H
+
+// GDExtension stub harness — Phase 3 fuzz testing infrastructure.
+//
+// Provides a minimal implementation of all 176 GDExtension interface functions
+// so that godot::String, godot::Dictionary, godot::Variant, godot::Array, and
+// related Godot types work in a standalone exe without a real Godot engine.
+//
+// Usage in a fuzz target:
+//
+//   #include "godot_stub_init.h"
+//
+//   extern "C" int LLVMFuzzerInitialize(int *, char ***) {
+//       godot_stub::init();
+//       return 0;
+//   }
+//
+//   extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+//       // godot::String, Dictionary, Variant etc. are safe to use here.
+//       return 0;
+//   }
+//
+// The harness is not thread-safe. All fuzz targets are single-threaded.
+//
+// Implementation notes:
+//   - godot::String: each instance owns a heap-allocated std::u32string.
+//     The 8-byte godot::String opaque blob stores a `std::u32string *`.
+//   - godot::StringName: interned in a global std::unordered_set<std::string>.
+//   - godot::Dictionary: heap-allocated struct wrapping
+//     std::unordered_map<std::string, StubVariant>.
+//   - godot::Array: heap-allocated struct wrapping std::vector<StubVariant>.
+//   - godot::Variant: tagged union over NIL / bool / int64 / float64 /
+//     String* / Dictionary* / Array*.
+//   - Memory: malloc / realloc / free.
+//   - All 85 class-system / engine functions: no-op stubs.
+
+namespace godot_stub {
+
+// Initialize the stub harness. Calls GDExtensionBinding::init() with the
+// stub dispatch table. Must be called exactly once before any Godot type is
+// used. Calling it from LLVMFuzzerInitialize is the recommended pattern.
+void init();
+
+// Tear down the stub harness. Optional; the process exits cleanly either way.
+void shutdown();
+
+} // namespace godot_stub
+
+#endif // GODOT_STUB_INIT_H

--- a/tests/cpp/fuzz_harness/stub_dict_array.cpp
+++ b/tests/cpp/fuzz_harness/stub_dict_array.cpp
@@ -1,0 +1,74 @@
+// stub_dict_array.cpp — GDExtension Dictionary and Array direct interface stubs.
+//
+// These are the "direct" interface functions (dictionary_operator_index,
+// array_operator_index, etc.) as opposed to the built-in methods dispatched
+// through variant_get_ptr_builtin_method.
+
+#include "stub_types.h"
+
+extern "C" {
+
+// ─── Dictionary ───────────────────────────────────────────────────────────
+
+static void *s_dictionary_operator_index(void *p_self, const void *p_key) {
+    StubDict *d = dict_blob_get(p_self);
+    if (!d) return nullptr;
+    std::string key_repr = stub_variant_to_key(
+        reinterpret_cast<const StubVariant *>(p_key));
+    StubVariant *slot = d->insert_or_find(
+        key_repr, *reinterpret_cast<const StubVariant *>(p_key));
+    return slot;
+}
+
+static const void *s_dictionary_operator_index_const(const void *p_self, const void *p_key) {
+    StubDict *d = dict_blob_get(p_self);
+    if (!d) return nullptr;
+    std::string key_repr = stub_variant_to_key(
+        reinterpret_cast<const StubVariant *>(p_key));
+    return d->find(key_repr);
+}
+
+// dictionary_set_typed: used when constructing a typed dictionary.
+// For our stub, just treat it as a no-op (we don't enforce type constraints).
+static void s_dictionary_set_typed(void */*p_self*/, uint32_t /*key_type*/,
+                                   const void */*key_class_name*/,
+                                   const void */*key_script*/,
+                                   uint32_t /*value_type*/,
+                                   const void */*value_class_name*/,
+                                   const void */*value_script*/) {
+}
+
+// ─── Array ────────────────────────────────────────────────────────────────
+
+static void *s_array_operator_index(void *p_self, int64_t p_index) {
+    StubArray *a = arr_blob_get(p_self);
+    if (!a || p_index < 0 || (size_t)p_index >= a->elements.size())
+        return nullptr;
+    return &a->elements[(size_t)p_index];
+}
+
+static const void *s_array_operator_index_const(const void *p_self, int64_t p_index) {
+    StubArray *a = arr_blob_get(p_self);
+    if (!a || p_index < 0 || (size_t)p_index >= a->elements.size())
+        return nullptr;
+    return &a->elements[(size_t)p_index];
+}
+
+// array_ref: used for typed array construction; stub as no-op.
+static void s_array_ref(void */*p_self*/, const void */*p_from*/) {}
+
+// array_set_typed: type annotation for typed arrays; stub as no-op.
+static void s_array_set_typed(void */*p_self*/, uint32_t /*elem_type*/,
+                               const void */*elem_class_name*/,
+                               const void */*elem_script*/) {}
+
+} // extern "C"
+
+// ─── Exported function pointer table ─────────────────────────────────────
+void *stub_dictionary_operator_index_ptr       = (void *)s_dictionary_operator_index;
+void *stub_dictionary_operator_index_const_ptr = (void *)s_dictionary_operator_index_const;
+void *stub_dictionary_set_typed_ptr            = (void *)s_dictionary_set_typed;
+void *stub_array_operator_index_ptr            = (void *)s_array_operator_index;
+void *stub_array_operator_index_const_ptr      = (void *)s_array_operator_index_const;
+void *stub_array_ref_ptr                       = (void *)s_array_ref;
+void *stub_array_set_typed_ptr                 = (void *)s_array_set_typed;

--- a/tests/cpp/fuzz_harness/stub_memory.cpp
+++ b/tests/cpp/fuzz_harness/stub_memory.cpp
@@ -1,0 +1,76 @@
+// stub_memory.cpp — GDExtension memory interface stubs.
+// Maps mem_alloc / mem_realloc / mem_free (and their _2 pad-align variants)
+// to the standard C allocator.
+
+#include "stub_types.h"
+
+#include <cstdlib>
+
+extern "C" {
+
+static void *s_mem_alloc(size_t p_bytes) {
+    return ::malloc(p_bytes);
+}
+
+static void *s_mem_alloc2(size_t p_bytes, uint8_t /*pad_align*/) {
+    return ::malloc(p_bytes);
+}
+
+static void *s_mem_realloc(void *p_memory, size_t p_bytes) {
+    return ::realloc(p_memory, p_bytes);
+}
+
+static void *s_mem_realloc2(void *p_memory, size_t p_bytes, uint8_t /*pad_align*/) {
+    return ::realloc(p_memory, p_bytes);
+}
+
+static void s_mem_free(void *p_memory) {
+    ::free(p_memory);
+}
+
+static void s_mem_free2(void *p_memory, uint8_t /*pad_align*/) {
+    ::free(p_memory);
+}
+
+static void s_print_error(const char *p_desc, const char *p_function,
+                          const char *p_file, int32_t p_line, uint8_t /*p_editor_notify*/) {
+    ::fprintf(stderr, "STUB ERROR: %s | %s (%s:%d)\n",
+              p_desc ? p_desc : "", p_function ? p_function : "",
+              p_file ? p_file : "", (int)p_line);
+}
+
+static void s_print_error_with_message(const char *p_desc, const char *p_message,
+                                       const char *p_function, const char *p_file,
+                                       int32_t p_line, uint8_t /*p_editor_notify*/) {
+    ::fprintf(stderr, "STUB ERROR: %s (%s) | %s (%s:%d)\n",
+              p_desc ? p_desc : "", p_message ? p_message : "",
+              p_function ? p_function : "",
+              p_file ? p_file : "", (int)p_line);
+}
+
+static void s_print_warning(const char *p_desc, const char *p_function,
+                             const char *p_file, int32_t p_line, uint8_t /*p_editor_notify*/) {
+    ::fprintf(stderr, "STUB WARNING: %s | %s (%s:%d)\n",
+              p_desc ? p_desc : "", p_function ? p_function : "",
+              p_file ? p_file : "", (int)p_line);
+}
+
+static void s_print_warning_with_message(const char *p_desc, const char *p_message,
+                                          const char *p_function, const char *p_file,
+                                          int32_t p_line, uint8_t /*p_editor_notify*/) {
+    (void)p_desc; (void)p_message; (void)p_function; (void)p_file; (void)p_line;
+}
+
+} // extern "C"
+
+// Exported function pointer table (used by godot_stub_init.cpp)
+void *stub_mem_alloc_ptr               = (void *)s_mem_alloc;
+void *stub_mem_alloc2_ptr              = (void *)s_mem_alloc2;
+void *stub_mem_realloc_ptr             = (void *)s_mem_realloc;
+void *stub_mem_realloc2_ptr            = (void *)s_mem_realloc2;
+void *stub_mem_free_ptr                = (void *)s_mem_free;
+void *stub_mem_free2_ptr               = (void *)s_mem_free2;
+void *stub_print_error_ptr             = (void *)s_print_error;
+void *stub_print_error_with_message_ptr = (void *)s_print_error_with_message;
+void *stub_print_warning_ptr           = (void *)s_print_warning;
+void *stub_print_warning_with_message_ptr = (void *)s_print_warning_with_message;

--- a/tests/cpp/fuzz_harness/stub_noop.cpp
+++ b/tests/cpp/fuzz_harness/stub_noop.cpp
@@ -1,0 +1,60 @@
+// stub_noop.cpp — A single no-op function used as the fallback stub for all
+// GDExtension interface functions that are not needed by our fuzz targets
+// (class registration, object binding, script instances, editor APIs, etc.).
+
+#include "stub_types.h"
+
+extern "C" {
+
+static void s_stub_noop() {}
+
+// get_godot_version / get_godot_version2
+// Return version 4.6.0 so GDExtensionBinding::init() passes the compatibility check.
+// These structs are layout-compatible with GDExtensionGodotVersion{2} from the header;
+// we avoid including the engine header here to keep the harness self-contained.
+
+struct StubGDVersion {
+    uint32_t major;
+    uint32_t minor;
+    uint32_t patch;
+    const char *string;
+};
+
+struct StubGDVersion2 {
+    uint32_t    major;
+    uint32_t    minor;
+    uint32_t    patch;
+    uint32_t    hex;
+    const char *status;
+    const char *build;
+    const char *hash;
+    uint64_t    timestamp;
+    const char *string;
+};
+
+static void s_get_godot_version(StubGDVersion *r) {
+    if (!r) return;
+    r->major  = 4;
+    r->minor  = 6;
+    r->patch  = 0;
+    r->string = "4.6.0.stable";
+}
+
+static void s_get_godot_version2(StubGDVersion2 *r) {
+    if (!r) return;
+    r->major     = 4;
+    r->minor     = 6;
+    r->patch     = 0;
+    r->hex       = 0x040600;
+    r->status    = "stable";
+    r->build     = "official";
+    r->hash      = "0000000000000000000000000000000000000000";
+    r->timestamp = 0;
+    r->string    = "Godot v4.6.0.stable.official";
+}
+
+} // extern "C"
+
+void *stub_noop_ptr             = (void *)s_stub_noop;
+void *stub_get_godot_version_ptr  = (void *)s_get_godot_version;
+void *stub_get_godot_version2_ptr = (void *)s_get_godot_version2;

--- a/tests/cpp/fuzz_harness/stub_object.cpp
+++ b/tests/cpp/fuzz_harness/stub_object.cpp
@@ -1,0 +1,142 @@
+// stub_object.cpp — Minimal Object / RefCounted lifecycle stubs.
+//
+// Enables Ref<T>::instantiate() to work for any T that extends RefCounted
+// (e.g. GDKResult, PlayFabResult) without a live Godot engine.
+//
+// Design:
+//   classdb_construct_object2  →  allocates a StubObject on the heap;
+//                                  its address is the _owner handle.
+//   classdb_get_method_bind    →  returns a tagged sentinel for the three
+//                                  RefCounted lifecycle methods; returns
+//                                  MB_GENERIC for everything else (non-null
+//                                  so CHECK_METHOD_BIND_RET passes).
+//   object_method_bind_ptrcall →  dispatches on the sentinel tag to track
+//                                  refcount and write the correct bool return.
+//   object_destroy             →  deletes the StubObject allocated above.
+//
+// All other object functions (object_set_instance, _binding, etc.) are
+// lightweight stubs that do just enough to keep Wrapped::Wrapped() happy.
+//
+// Thread safety: each fuzz iteration runs sequentially on one thread;
+// no locking is needed.
+
+#include "stub_types.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+// ─── Internal object representation ───────────────────────────────────────
+
+struct StubObject {
+    int32_t  refcount     = 0;
+    void    *instance_ptr = nullptr;
+};
+
+// ─── Method-bind sentinel tags ─────────────────────────────────────────────
+// Small integer values cast to void*.  Cannot overlap with real function
+// pointers (OS never maps pages at these addresses on x64).
+
+static void *const MB_INIT_REF    = reinterpret_cast<void *>(static_cast<uintptr_t>(0x10));
+static void *const MB_REFERENCE   = reinterpret_cast<void *>(static_cast<uintptr_t>(0x11));
+static void *const MB_UNREFERENCE = reinterpret_cast<void *>(static_cast<uintptr_t>(0x12));
+// Non-null sentinel for all other method binds (CHECK_METHOD_BIND_RET passes).
+static void *const MB_GENERIC     = reinterpret_cast<void *>(static_cast<uintptr_t>(0x01));
+
+// ─── Stub implementations ─────────────────────────────────────────────────
+
+extern "C" {
+
+// classdb_construct_object / classdb_construct_object2
+// Allocates a StubObject.  The raw pointer IS the _owner handle.
+static void *s_classdb_construct_object(const void * /*class_name*/) {
+    return new StubObject{};
+}
+
+static void *s_classdb_construct_object2(const void * /*class_name*/) {
+    return new StubObject{};
+}
+
+// object_set_instance — record the GDExtension C++ instance pointer.
+static void s_object_set_instance(void *owner,
+                                   const void * /*ext_class_name*/,
+                                   void *instance_ptr) {
+    if (owner) {
+        reinterpret_cast<StubObject *>(owner)->instance_ptr = instance_ptr;
+    }
+}
+
+// object_set_instance_binding — no-op; we don't need binding callbacks.
+static void s_object_set_instance_binding(void * /*owner*/,
+                                           void * /*token*/,
+                                           void * /*binding*/,
+                                           const void * /*callbacks*/) {}
+
+// object_get_instance_binding — return the stored C++ instance pointer.
+static void *s_object_get_instance_binding(void *owner,
+                                            void * /*token*/,
+                                            const void * /*callbacks*/) {
+    if (!owner) return nullptr;
+    return reinterpret_cast<StubObject *>(owner)->instance_ptr;
+}
+
+// object_destroy — called by memdelete<T> for Wrapped subclasses.
+static void s_object_destroy(void *owner) {
+    delete reinterpret_cast<StubObject *>(owner);
+}
+
+// classdb_get_method_bind — return a method-bind sentinel.
+// p_methodname is a GDExtensionConstStringNamePtr, which in our stub is
+// a pointer to the StringName's opaque blob (8 bytes containing a std::string*
+// interned in the global StringName pool).  Same layout as sn_blob_get().
+static void *s_classdb_get_method_bind(const void * /*class_name*/,
+                                        const void *method_name,
+                                        int64_t /*hash*/) {
+    if (!method_name) return MB_GENERIC;
+    // Double-dereference: method_name → blob → std::string*
+    const std::string *sn_ptr =
+        *reinterpret_cast<std::string * const *>(method_name);
+    if (!sn_ptr) return MB_GENERIC;
+    const std::string &name = *sn_ptr;
+    if (name == "init_ref")    return MB_INIT_REF;
+    if (name == "reference")   return MB_REFERENCE;
+    if (name == "unreference") return MB_UNREFERENCE;
+    return MB_GENERIC;
+}
+
+// object_method_bind_ptrcall — dispatch refcount ops; no-op for all others.
+// r_ret for RefCounted bool methods points to an int8_t value-initialized to 0.
+static void s_object_method_bind_ptrcall(void *method_bind,
+                                          void *owner,
+                                          const void * /*args*/,
+                                          void *r_ret) {
+    if (method_bind == MB_INIT_REF || method_bind == MB_REFERENCE) {
+        if (owner) {
+            reinterpret_cast<StubObject *>(owner)->refcount++;
+        }
+        if (r_ret) *reinterpret_cast<int8_t *>(r_ret) = 1;
+
+    } else if (method_bind == MB_UNREFERENCE) {
+        bool was_last = false;
+        if (owner) {
+            auto *obj = reinterpret_cast<StubObject *>(owner);
+            was_last = (--obj->refcount <= 0);
+        }
+        if (r_ret) *reinterpret_cast<int8_t *>(r_ret) = was_last ? 1 : 0;
+    }
+    // MB_GENERIC and unknown tags: no-op (r_ret stays 0 / void)
+}
+
+} // extern "C"
+
+// ─── Exported function-pointer variables ──────────────────────────────────
+
+void *stub_classdb_construct_object_ptr      = reinterpret_cast<void *>(s_classdb_construct_object);
+void *stub_classdb_construct_object2_ptr     = reinterpret_cast<void *>(s_classdb_construct_object2);
+void *stub_object_set_instance_ptr           = reinterpret_cast<void *>(s_object_set_instance);
+void *stub_object_set_instance_binding_ptr   = reinterpret_cast<void *>(s_object_set_instance_binding);
+void *stub_object_get_instance_binding_ptr   = reinterpret_cast<void *>(s_object_get_instance_binding);
+void *stub_object_destroy_ptr                = reinterpret_cast<void *>(s_object_destroy);
+void *stub_classdb_get_method_bind_ptr       = reinterpret_cast<void *>(s_classdb_get_method_bind);
+void *stub_object_method_bind_ptrcall_ptr    = reinterpret_cast<void *>(s_object_method_bind_ptrcall);

--- a/tests/cpp/fuzz_harness/stub_packed_array.cpp
+++ b/tests/cpp/fuzz_harness/stub_packed_array.cpp
@@ -1,0 +1,39 @@
+// stub_packed_array.cpp — PackedByteArray element-access interface functions.
+//
+// godot-cpp implements PackedByteArray::operator[](), ptr() and ptrw() in terms
+// of the GDExtension interface functions packed_byte_array_operator_index and
+// packed_byte_array_operator_index_const (see godot-cpp
+// src/variant/packed_arrays.cpp).  The constructor / destructor / builtin
+// methods (resize, size, set, …) are handled by the dispatch switches in
+// stub_variant.cpp; this translation unit only provides the raw indexing slots.
+//
+// p_self points at the 16-byte opaque blob, whose first 8 bytes store the
+// std::vector<uint8_t> * (see pba_blob_* accessors in stub_types.h).
+
+#include "stub_types.h"
+
+#include <cstdint>
+#include <vector>
+
+extern "C" {
+
+// GDExtensionInterfacePackedByteArrayOperatorIndex:
+//   uint8_t *f(GDExtensionTypePtr p_self, GDExtensionInt p_index)
+static uint8_t *s_packed_byte_array_operator_index(void *p_self, int64_t p_index) {
+    std::vector<uint8_t> *v = pba_blob_get(p_self);
+    if (!v || p_index < 0 || (size_t)p_index >= v->size()) return nullptr;
+    return v->data() + p_index;
+}
+
+// GDExtensionInterfacePackedByteArrayOperatorIndexConst:
+//   const uint8_t *f(GDExtensionConstTypePtr p_self, GDExtensionInt p_index)
+static const uint8_t *s_packed_byte_array_operator_index_const(const void *p_self, int64_t p_index) {
+    const std::vector<uint8_t> *v = pba_blob_get(p_self);
+    if (!v || p_index < 0 || (size_t)p_index >= v->size()) return nullptr;
+    return v->data() + p_index;
+}
+
+} // extern "C"
+
+void *stub_packed_byte_array_operator_index_ptr       = (void *)s_packed_byte_array_operator_index;
+void *stub_packed_byte_array_operator_index_const_ptr = (void *)s_packed_byte_array_operator_index_const;

--- a/tests/cpp/fuzz_harness/stub_string.cpp
+++ b/tests/cpp/fuzz_harness/stub_string.cpp
@@ -71,7 +71,10 @@ ptrdiff_t stub_str_to_utf8(const std::u32string *s, char *out, ptrdiff_t out_len
         else if (cp < 0x800)   bytes = 2;
         else if (cp < 0x10000) bytes = 3;
         else                   bytes = 4;
-        if (out && needed + bytes < out_len) {
+        // godot-cpp's String::utf8() passes out_len == content byte length and
+        // writes its own NUL at str[length]; write every byte that fits in the
+        // buffer (<=, not <) so the final content byte is never dropped.
+        if (out && needed + bytes <= out_len) {
             if (bytes == 1) { out[needed] = (char)cp; }
             else if (bytes == 2) {
                 out[needed]   = (char)(0xC0 | (cp >> 6));
@@ -89,7 +92,8 @@ ptrdiff_t stub_str_to_utf8(const std::u32string *s, char *out, ptrdiff_t out_len
         }
         needed += bytes;
     }
-    if (out && out_len > 0) out[needed < out_len ? needed : out_len - 1] = '\0';
+    // Only NUL-terminate when a spare slot exists beyond the content.
+    if (out && needed < out_len) out[needed] = '\0';
     return needed;
 }
 
@@ -97,10 +101,13 @@ ptrdiff_t stub_str_to_latin1(const std::u32string *s, char *out, ptrdiff_t out_l
     if (!s) { if (out && out_len > 0) out[0] = '\0'; return 0; }
     ptrdiff_t n = (ptrdiff_t)s->size();
     if (out) {
-        ptrdiff_t write = n < out_len ? n : out_len - 1;
+        // godot-cpp's String::ascii() passes out_len == content length and
+        // writes its own NUL at str[length]; only fill a spare slot here so the
+        // final content byte is never clobbered.
+        ptrdiff_t write = n < out_len ? n : out_len;
         for (ptrdiff_t i = 0; i < write; ++i)
             out[i] = (char)((*s)[i] & 0xFF);
-        if (out_len > 0) out[write] = '\0';
+        if (write < out_len) out[write] = '\0';
     }
     return n;
 }

--- a/tests/cpp/fuzz_harness/stub_string.cpp
+++ b/tests/cpp/fuzz_harness/stub_string.cpp
@@ -1,0 +1,362 @@
+// stub_string.cpp — GDExtension String and StringName interface stubs.
+//
+// String blob (8 bytes): stores a heap-allocated std::u32string*.
+//   Construction: allocate new std::u32string, store pointer.
+//   Destruction:  delete the std::u32string, store nullptr.
+//   Copy:         clone the std::u32string.
+//
+// StringName blob (8 bytes): stores a pointer into a global interned pool
+//   (std::unordered_set<std::string>).  All StringNames with the same
+//   bytes share the same pool node, so equality is pointer equality.
+
+#include "stub_types.h"
+
+#include <cstring>
+#include <unordered_set>
+
+// ─── Internal helpers ─────────────────────────────────────────────────────
+
+// Simple UTF-8 decode to char32_t.  Handles ASCII fast-path; multi-byte sequences
+// are decoded per RFC 3629.  Invalid bytes are replaced with U+FFFD.
+static char32_t utf8_next(const char **pp, const char *end) {
+    const unsigned char *p = reinterpret_cast<const unsigned char *>(*pp);
+    if (p >= reinterpret_cast<const unsigned char *>(end)) return 0;
+    uint8_t b = *p++;
+    char32_t cp;
+    int extra = 0;
+    if (b < 0x80)        { cp = b;           extra = 0; }
+    else if (b < 0xC0)   { cp = 0xFFFD;      extra = 0; }
+    else if (b < 0xE0)   { cp = b & 0x1F;    extra = 1; }
+    else if (b < 0xF0)   { cp = b & 0x0F;    extra = 2; }
+    else                 { cp = b & 0x07;     extra = 3; }
+    while (extra-- > 0) {
+        if (p >= reinterpret_cast<const unsigned char *>(end)) { cp = 0xFFFD; break; }
+        uint8_t c = *p++;
+        if ((c & 0xC0) != 0x80) { cp = 0xFFFD; break; }
+        cp = (cp << 6) | (c & 0x3F);
+    }
+    *pp = reinterpret_cast<const char *>(p);
+    return cp;
+}
+
+std::u32string *stub_str_from_utf8(const char *p, ptrdiff_t len) {
+    auto *s = new std::u32string();
+    if (!p) return s;
+    const char *end = (len < 0) ? p + ::strlen(p) : p + len;
+    while (p < end) {
+        char32_t cp = utf8_next(&p, end);
+        if (cp == 0) break;
+        s->push_back(cp);
+    }
+    return s;
+}
+
+std::u32string *stub_str_from_latin1(const char *p, ptrdiff_t len) {
+    auto *s = new std::u32string();
+    if (!p) return s;
+    ptrdiff_t n = (len < 0) ? (ptrdiff_t)::strlen(p) : len;
+    s->reserve((size_t)n);
+    for (ptrdiff_t i = 0; i < n; ++i) {
+        s->push_back((unsigned char)p[i]);
+    }
+    return s;
+}
+
+ptrdiff_t stub_str_to_utf8(const std::u32string *s, char *out, ptrdiff_t out_len) {
+    if (!s) { if (out && out_len > 0) out[0] = '\0'; return 0; }
+    ptrdiff_t needed = 0;
+    for (char32_t cp : *s) {
+        int bytes;
+        if      (cp < 0x80)    bytes = 1;
+        else if (cp < 0x800)   bytes = 2;
+        else if (cp < 0x10000) bytes = 3;
+        else                   bytes = 4;
+        if (out && needed + bytes < out_len) {
+            if (bytes == 1) { out[needed] = (char)cp; }
+            else if (bytes == 2) {
+                out[needed]   = (char)(0xC0 | (cp >> 6));
+                out[needed+1] = (char)(0x80 | (cp & 0x3F));
+            } else if (bytes == 3) {
+                out[needed]   = (char)(0xE0 | (cp >> 12));
+                out[needed+1] = (char)(0x80 | ((cp >> 6) & 0x3F));
+                out[needed+2] = (char)(0x80 | (cp & 0x3F));
+            } else {
+                out[needed]   = (char)(0xF0 | (cp >> 18));
+                out[needed+1] = (char)(0x80 | ((cp >> 12) & 0x3F));
+                out[needed+2] = (char)(0x80 | ((cp >> 6) & 0x3F));
+                out[needed+3] = (char)(0x80 | (cp & 0x3F));
+            }
+        }
+        needed += bytes;
+    }
+    if (out && out_len > 0) out[needed < out_len ? needed : out_len - 1] = '\0';
+    return needed;
+}
+
+ptrdiff_t stub_str_to_latin1(const std::u32string *s, char *out, ptrdiff_t out_len) {
+    if (!s) { if (out && out_len > 0) out[0] = '\0'; return 0; }
+    ptrdiff_t n = (ptrdiff_t)s->size();
+    if (out) {
+        ptrdiff_t write = n < out_len ? n : out_len - 1;
+        for (ptrdiff_t i = 0; i < write; ++i)
+            out[i] = (char)((*s)[i] & 0xFF);
+        if (out_len > 0) out[write] = '\0';
+    }
+    return n;
+}
+
+// ─── Global interned StringName pool ─────────────────────────────────────
+
+static std::unordered_set<std::string> &sn_pool() {
+    static std::unordered_set<std::string> pool;
+    return pool;
+}
+
+std::string *sn_intern(const char *p, ptrdiff_t len) {
+    std::string key = (len < 0) ? std::string(p ? p : "") : std::string(p ? p : "", (size_t)len);
+    auto [it, _] = sn_pool().insert(std::move(key));
+    return const_cast<std::string *>(&*it);
+}
+
+// ─── GDExtension C interface functions ───────────────────────────────────
+
+extern "C" {
+
+// ── String new helpers ────────────────────────────────────────────────────
+
+static void s_string_new_with_latin1_chars(void *r_dest, const char *p_contents) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, stub_str_from_latin1(p_contents));
+}
+
+static void s_string_new_with_latin1_chars_and_len(void *r_dest, const char *p_contents, int64_t p_size) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, stub_str_from_latin1(p_contents, (ptrdiff_t)p_size));
+}
+
+static void s_string_new_with_utf8_chars(void *r_dest, const char *p_contents) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, stub_str_from_utf8(p_contents));
+}
+
+static void s_string_new_with_utf8_chars_and_len(void *r_dest, const char *p_contents, int64_t p_size) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, stub_str_from_utf8(p_contents, (ptrdiff_t)p_size));
+}
+
+// Returns an error code (0 = OK).  Same semantics as parse_utf8.
+static int64_t s_string_new_with_utf8_chars_and_len2(void *r_dest, const char *p_contents, int64_t p_size) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, stub_str_from_utf8(p_contents, (ptrdiff_t)p_size));
+    return 0; // OK
+}
+
+static void s_string_new_with_utf32_chars(void *r_dest, const char32_t *p_contents) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, p_contents ? new std::u32string(p_contents) : new std::u32string());
+}
+
+static void s_string_new_with_utf32_chars_and_len(void *r_dest, const char32_t *p_contents, int64_t p_size) {
+    delete str_blob_get(r_dest);
+    str_blob_set(r_dest, p_contents && p_size > 0
+                         ? new std::u32string(p_contents, (size_t)p_size)
+                         : new std::u32string());
+}
+
+static void s_string_new_with_wide_chars(void *r_dest, const wchar_t *p_contents) {
+    delete str_blob_get(r_dest);
+    auto *s = new std::u32string();
+    if (p_contents) {
+        for (const wchar_t *p = p_contents; *p; ++p)
+            s->push_back((char32_t)*p);
+    }
+    str_blob_set(r_dest, s);
+}
+
+static void s_string_new_with_wide_chars_and_len(void *r_dest, const wchar_t *p_contents, int64_t p_size) {
+    delete str_blob_get(r_dest);
+    auto *s = new std::u32string();
+    if (p_contents && p_size > 0) {
+        for (int64_t i = 0; i < p_size; ++i)
+            s->push_back((char32_t)p_contents[i]);
+    }
+    str_blob_set(r_dest, s);
+}
+
+// UTF-16: simplistic (BMP only; surrogates are passed through as-is)
+static void s_string_new_with_utf16_chars(void *r_dest, const char16_t *p_contents) {
+    delete str_blob_get(r_dest);
+    auto *s = new std::u32string();
+    if (p_contents) {
+        for (const char16_t *p = p_contents; *p; ++p)
+            s->push_back((char32_t)*p);
+    }
+    str_blob_set(r_dest, s);
+}
+
+static void s_string_new_with_utf16_chars_and_len(void *r_dest, const char16_t *p_contents, int64_t p_size) {
+    delete str_blob_get(r_dest);
+    auto *s = new std::u32string();
+    if (p_contents && p_size > 0) {
+        for (int64_t i = 0; i < p_size; ++i)
+            s->push_back((char32_t)p_contents[i]);
+    }
+    str_blob_set(r_dest, s);
+}
+
+static int64_t s_string_new_with_utf16_chars_and_len2(void *r_dest, const char16_t *p_contents, int64_t p_size, uint8_t /*p_default_little_endian*/) {
+    s_string_new_with_utf16_chars_and_len(r_dest, p_contents, p_size);
+    return 0;
+}
+
+// ── String operator helpers ───────────────────────────────────────────────
+
+static void s_string_operator_plus_eq_string(void *p_self, const void *p_b) {
+    std::u32string *a = str_blob_get(p_self);
+    const std::u32string *b = str_blob_get(p_b);
+    if (a && b) *a += *b;
+}
+
+static void s_string_operator_plus_eq_cstr(void *p_self, const char *p_b) {
+    std::u32string *a = str_blob_get(p_self);
+    if (a && p_b) {
+        for (const char *p = p_b; *p; ++p)
+            a->push_back((unsigned char)*p);
+    }
+}
+
+static void s_string_operator_plus_eq_wcstr(void *p_self, const wchar_t *p_b) {
+    std::u32string *a = str_blob_get(p_self);
+    if (a && p_b) {
+        for (const wchar_t *p = p_b; *p; ++p)
+            a->push_back((char32_t)*p);
+    }
+}
+
+static void s_string_operator_plus_eq_c32str(void *p_self, const char32_t *p_b) {
+    std::u32string *a = str_blob_get(p_self);
+    if (a && p_b) {
+        for (const char32_t *p = p_b; *p; ++p)
+            a->push_back(*p);
+    }
+}
+
+static void s_string_operator_plus_eq_char(void *p_self, int32_t p_b) {
+    std::u32string *a = str_blob_get(p_self);
+    if (a) a->push_back((char32_t)p_b);
+}
+
+static char32_t *s_string_operator_index(void *p_self, int64_t p_index) {
+    std::u32string *s = str_blob_get(p_self);
+    if (!s || p_index < 0 || (size_t)p_index >= s->size()) return nullptr;
+    return reinterpret_cast<char32_t *>(&(*s)[(size_t)p_index]);
+}
+
+static const char32_t *s_string_operator_index_const(const void *p_self, int64_t p_index) {
+    const std::u32string *s = str_blob_get(p_self);
+    if (!s || p_index < 0 || (size_t)p_index >= s->size()) return nullptr;
+    return reinterpret_cast<const char32_t *>(&(*s)[(size_t)p_index]);
+}
+
+// ── String to / resize ───────────────────────────────────────────────────
+
+static int64_t s_string_to_latin1_chars(const void *p_self, char *r_chars, int64_t p_size) {
+    const std::u32string *s = str_blob_get(p_self);
+    if (!s) { if (r_chars && p_size > 0) r_chars[0] = '\0'; return 0; }
+    return (int64_t)stub_str_to_latin1(s, r_chars, (ptrdiff_t)p_size);
+}
+
+static int64_t s_string_to_utf8_chars(const void *p_self, char *r_chars, int64_t p_size) {
+    const std::u32string *s = str_blob_get(p_self);
+    if (!s) { if (r_chars && p_size > 0) r_chars[0] = '\0'; return 0; }
+    return (int64_t)stub_str_to_utf8(s, r_chars, (ptrdiff_t)p_size);
+}
+
+static int64_t s_string_to_utf16_chars(const void *p_self, char16_t *r_chars, int64_t p_size) {
+    const std::u32string *s = str_blob_get(p_self);
+    if (!s) return 0;
+    int64_t n = (int64_t)s->size();
+    if (r_chars && p_size > 0) {
+        for (int64_t i = 0; i < n && i < p_size - 1; ++i)
+            r_chars[i] = (char16_t)((*s)[(size_t)i] & 0xFFFF);
+        r_chars[n < p_size ? n : p_size - 1] = 0;
+    }
+    return n;
+}
+
+static int64_t s_string_to_utf32_chars(const void *p_self, char32_t *r_chars, int64_t p_size) {
+    const std::u32string *s = str_blob_get(p_self);
+    if (!s) return 0;
+    int64_t n = (int64_t)s->size();
+    if (r_chars && p_size > 0) {
+        int64_t copy = n < p_size - 1 ? n : p_size - 1;
+        ::memcpy(r_chars, s->data(), (size_t)copy * sizeof(char32_t));
+        r_chars[copy] = 0;
+    }
+    return n;
+}
+
+static int64_t s_string_to_wide_chars(const void *p_self, wchar_t *r_chars, int64_t p_size) {
+    const std::u32string *s = str_blob_get(p_self);
+    if (!s) return 0;
+    int64_t n = (int64_t)s->size();
+    if (r_chars && p_size > 0) {
+        for (int64_t i = 0; i < n && i < p_size - 1; ++i)
+            r_chars[i] = (wchar_t)((*s)[(size_t)i]);
+        r_chars[n < p_size ? n : p_size - 1] = 0;
+    }
+    return n;
+}
+
+static int64_t s_string_resize(void *p_self, int64_t p_length) {
+    std::u32string *s = str_blob_get(p_self);
+    if (!s) return -1; // error
+    s->resize((size_t)p_length, U'\0');
+    return 0; // OK
+}
+
+// ── StringName new helpers ────────────────────────────────────────────────
+
+static void s_string_name_new_with_latin1_chars(void *r_dest, const char *p_contents, uint8_t /*p_is_static*/) {
+    sn_blob_set(r_dest, sn_intern(p_contents));
+}
+
+static void s_string_name_new_with_utf8_chars(void *r_dest, const char *p_contents) {
+    sn_blob_set(r_dest, sn_intern(p_contents));
+}
+
+static void s_string_name_new_with_utf8_chars_and_len(void *r_dest, const char *p_contents, int64_t p_size) {
+    sn_blob_set(r_dest, sn_intern(p_contents, (ptrdiff_t)p_size));
+}
+
+} // extern "C"
+
+// Exported function pointer table
+void *stub_string_new_with_latin1_chars_ptr              = (void *)s_string_new_with_latin1_chars;
+void *stub_string_new_with_latin1_chars_and_len_ptr      = (void *)s_string_new_with_latin1_chars_and_len;
+void *stub_string_new_with_utf8_chars_ptr                = (void *)s_string_new_with_utf8_chars;
+void *stub_string_new_with_utf8_chars_and_len_ptr        = (void *)s_string_new_with_utf8_chars_and_len;
+void *stub_string_new_with_utf8_chars_and_len2_ptr       = (void *)s_string_new_with_utf8_chars_and_len2;
+void *stub_string_new_with_utf32_chars_ptr               = (void *)s_string_new_with_utf32_chars;
+void *stub_string_new_with_utf32_chars_and_len_ptr       = (void *)s_string_new_with_utf32_chars_and_len;
+void *stub_string_new_with_wide_chars_ptr                = (void *)s_string_new_with_wide_chars;
+void *stub_string_new_with_wide_chars_and_len_ptr        = (void *)s_string_new_with_wide_chars_and_len;
+void *stub_string_new_with_utf16_chars_ptr               = (void *)s_string_new_with_utf16_chars;
+void *stub_string_new_with_utf16_chars_and_len_ptr       = (void *)s_string_new_with_utf16_chars_and_len;
+void *stub_string_new_with_utf16_chars_and_len2_ptr      = (void *)s_string_new_with_utf16_chars_and_len2;
+void *stub_string_operator_plus_eq_string_ptr            = (void *)s_string_operator_plus_eq_string;
+void *stub_string_operator_plus_eq_cstr_ptr              = (void *)s_string_operator_plus_eq_cstr;
+void *stub_string_operator_plus_eq_wcstr_ptr             = (void *)s_string_operator_plus_eq_wcstr;
+void *stub_string_operator_plus_eq_c32str_ptr            = (void *)s_string_operator_plus_eq_c32str;
+void *stub_string_operator_plus_eq_char_ptr              = (void *)s_string_operator_plus_eq_char;
+void *stub_string_operator_index_ptr                     = (void *)s_string_operator_index;
+void *stub_string_operator_index_const_ptr               = (void *)s_string_operator_index_const;
+void *stub_string_to_latin1_chars_ptr                    = (void *)s_string_to_latin1_chars;
+void *stub_string_to_utf8_chars_ptr                      = (void *)s_string_to_utf8_chars;
+void *stub_string_to_utf16_chars_ptr                     = (void *)s_string_to_utf16_chars;
+void *stub_string_to_utf32_chars_ptr                     = (void *)s_string_to_utf32_chars;
+void *stub_string_to_wide_chars_ptr                      = (void *)s_string_to_wide_chars;
+void *stub_string_resize_ptr                             = (void *)s_string_resize;
+void *stub_string_name_new_with_latin1_chars_ptr         = (void *)s_string_name_new_with_latin1_chars;
+void *stub_string_name_new_with_utf8_chars_ptr           = (void *)s_string_name_new_with_utf8_chars;
+void *stub_string_name_new_with_utf8_chars_and_len_ptr   = (void *)s_string_name_new_with_utf8_chars_and_len;

--- a/tests/cpp/fuzz_harness/stub_types.h
+++ b/tests/cpp/fuzz_harness/stub_types.h
@@ -7,6 +7,7 @@
 //   NodePath    8 bytes → stores std::string * (interned globally, same pool)
 //   Dictionary  8 bytes → stores StubDict *
 //   Array       8 bytes → stores StubArray *
+//   PackedByteArray 16 bytes → first 8 store std::vector<uint8_t> * (rest unused)
 //   Variant    24 bytes → { uint32_t type_id; uint32_t _pad; StubVariantData data; }
 //
 // All heap objects are owned by the blob that contains their pointer.
@@ -35,6 +36,7 @@ enum StubVariantType : uint32_t {
     SVT_NODE_PATH    = 22,
     SVT_DICTIONARY   = 27,
     SVT_ARRAY        = 28,
+    SVT_PACKED_BYTE_ARRAY = 29,
 };
 
 // ─── Forward declarations ──────────────────────────────────────────────────
@@ -177,4 +179,22 @@ inline StubArray *arr_blob_get(const void *blob) {
 }
 inline void arr_blob_set(void *blob, StubArray *a) {
     *arr_blob_ptr(blob) = a;
+}
+
+// ─── PackedByteArray blob accessors ──────────────────────────────────────
+// The opaque blob is 16 bytes (PACKED_BYTE_ARRAY_SIZE); we use the first 8 to
+// store a std::vector<uint8_t> *.  godot-cpp zero-initialises the opaque, so a
+// default/moved-from blob reads back as nullptr (safe to delete).
+
+inline std::vector<uint8_t> **pba_blob_ptr(void *blob) {
+    return reinterpret_cast<std::vector<uint8_t> **>(blob);
+}
+inline std::vector<uint8_t> *pba_blob_get(void *blob) {
+    return *pba_blob_ptr(blob);
+}
+inline std::vector<uint8_t> *pba_blob_get(const void *blob) {
+    return *reinterpret_cast<std::vector<uint8_t> * const *>(blob);
+}
+inline void pba_blob_set(void *blob, std::vector<uint8_t> *v) {
+    *pba_blob_ptr(blob) = v;
 }

--- a/tests/cpp/fuzz_harness/stub_types.h
+++ b/tests/cpp/fuzz_harness/stub_types.h
@@ -1,0 +1,180 @@
+// Internal stub type definitions shared across all stub_*.cpp translation units.
+// Not installed; only used within tests/cpp/fuzz_harness/.
+//
+// Blob layout summary (matching extension_api-4-5.json float_64 sizes):
+//   String      8 bytes → stores std::u32string *
+//   StringName  8 bytes → stores std::string * (interned globally)
+//   NodePath    8 bytes → stores std::string * (interned globally, same pool)
+//   Dictionary  8 bytes → stores StubDict *
+//   Array       8 bytes → stores StubArray *
+//   Variant    24 bytes → { uint32_t type_id; uint32_t _pad; StubVariantData data; }
+//
+// All heap objects are owned by the blob that contains their pointer.
+// Copying a blob clones the heap object (no reference counting).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+// Variant type ids (mirrors GDExtensionVariantType)
+enum StubVariantType : uint32_t {
+    SVT_NIL          =  0,
+    SVT_BOOL         =  1,
+    SVT_INT          =  2,
+    SVT_FLOAT        =  3,
+    SVT_STRING       =  4,
+    SVT_STRING_NAME  = 21,
+    SVT_NODE_PATH    = 22,
+    SVT_DICTIONARY   = 27,
+    SVT_ARRAY        = 28,
+};
+
+// ─── Forward declarations ──────────────────────────────────────────────────
+
+struct StubDict;
+struct StubArray;
+
+// ─── Variant blob ─────────────────────────────────────────────────────────
+// Matches 24 bytes on float_64 builds.
+
+struct StubVariantData {
+    union {
+        int64_t  as_int;
+        double   as_double;
+        uint8_t  as_bool;
+        void    *as_ptr;    // for String*, StringName*, StubDict*, StubArray*
+        uint8_t  raw[16];
+    };
+};
+
+struct StubVariant {
+    uint32_t       type_id;  // StubVariantType
+    uint32_t       _pad;
+    StubVariantData data;
+};
+static_assert(sizeof(StubVariant) == 24, "StubVariant must be 24 bytes");
+
+// ─── Dictionary ───────────────────────────────────────────────────────────
+
+struct StubDict {
+    // Keyed by string form of the key Variant (covers all string and int keys).
+    // A parallel entries vector preserves key ordering and provides stable
+    // pointers for dictionary_operator_index.
+    struct Entry {
+        std::string   key_repr;  // for lookup
+        StubVariant   key;
+        StubVariant   value;
+    };
+    std::vector<Entry> entries;
+
+    StubVariant *find(std::string_view key_repr);
+    StubVariant *insert_or_find(std::string_view key_repr, const StubVariant &key);
+};
+
+// ─── Array ────────────────────────────────────────────────────────────────
+
+struct StubArray {
+    // std::deque gives push_back without pointer invalidation of existing elements.
+    std::deque<StubVariant> elements;
+};
+
+// ─── Helpers (defined in stub_variant.cpp) ───────────────────────────────
+
+// Deep-clone a blob of the given type_id.  Ownership of the clone is transferred
+// to the caller (i.e. the caller owns any heap objects in the clone).
+void stub_variant_clone(StubVariant *dst, const StubVariant *src);
+
+// Free any heap objects owned by this variant blob.  Does NOT free the blob
+// itself (which is usually stack-allocated or part of a container).
+void stub_variant_free_owned(StubVariant *v);
+
+// Convert a Variant key to a string representation suitable for dictionary lookup.
+std::string stub_variant_to_key(const StubVariant *v);
+
+// ─── StringName helpers (defined in stub_string.cpp) ─────────────────────
+
+// Intern a string into the global StringName pool and return a stable pointer.
+std::string *sn_intern(const char *p, ptrdiff_t len = -1);
+
+// ─── String helpers (defined in stub_string.cpp) ─────────────────────────
+
+// Create a new std::u32string from a UTF-8 C string.
+std::u32string *stub_str_from_utf8(const char *p, ptrdiff_t len = -1);
+
+// Create a new std::u32string from a Latin-1 (ISO 8859-1) C string.
+std::u32string *stub_str_from_latin1(const char *p, ptrdiff_t len = -1);
+
+// Convert std::u32string back to UTF-8.  Returns byte count written (excluding NUL).
+ptrdiff_t stub_str_to_utf8(const std::u32string *s, char *out, ptrdiff_t out_len);
+
+// Convert std::u32string back to Latin-1.
+ptrdiff_t stub_str_to_latin1(const std::u32string *s, char *out, ptrdiff_t out_len);
+
+// ─── String blob accessors ────────────────────────────────────────────────
+
+inline std::u32string **str_blob_ptr(void *blob) {
+    return reinterpret_cast<std::u32string **>(blob);
+}
+inline std::u32string * const *str_blob_ptr(const void *blob) {
+    return reinterpret_cast<std::u32string * const *>(blob);
+}
+inline std::u32string *str_blob_get(void *blob) {
+    return *str_blob_ptr(blob);
+}
+inline std::u32string *str_blob_get(const void *blob) {
+    return *str_blob_ptr(blob);
+}
+inline void str_blob_set(void *blob, std::u32string *s) {
+    *str_blob_ptr(blob) = s;
+}
+
+// ─── StringName / NodePath blob accessors ────────────────────────────────
+
+inline std::string **sn_blob_ptr(void *blob) {
+    return reinterpret_cast<std::string **>(blob);
+}
+inline std::string *sn_blob_get(void *blob) {
+    return *sn_blob_ptr(blob);
+}
+inline std::string *sn_blob_get(const void *blob) {
+    return *reinterpret_cast<std::string * const *>(blob);
+}
+inline void sn_blob_set(void *blob, std::string *s) {
+    *sn_blob_ptr(blob) = s;
+}
+
+// ─── Dictionary / Array blob accessors ───────────────────────────────────
+
+inline StubDict **dict_blob_ptr(void *blob) {
+    return reinterpret_cast<StubDict **>(blob);
+}
+inline StubDict *dict_blob_get(void *blob) {
+    return *dict_blob_ptr(blob);
+}
+inline StubDict *dict_blob_get(const void *blob) {
+    return *reinterpret_cast<StubDict * const *>(blob);
+}
+inline void dict_blob_set(void *blob, StubDict *d) {
+    *dict_blob_ptr(blob) = d;
+}
+
+inline StubArray **arr_blob_ptr(void *blob) {
+    return reinterpret_cast<StubArray **>(blob);
+}
+inline StubArray *arr_blob_get(void *blob) {
+    return *arr_blob_ptr(blob);
+}
+inline StubArray *arr_blob_get(const void *blob) {
+    return *reinterpret_cast<StubArray * const *>(blob);
+}
+inline void arr_blob_set(void *blob, StubArray *a) {
+    *arr_blob_ptr(blob) = a;
+}

--- a/tests/cpp/fuzz_harness/stub_variant.cpp
+++ b/tests/cpp/fuzz_harness/stub_variant.cpp
@@ -1,0 +1,866 @@
+// stub_variant.cpp — GDExtension Variant interface stubs.
+//
+// Implements:
+//   variant_new_nil / variant_new_copy / variant_destroy
+//   variant_get_type / variant_get_type_name
+//   get_variant_from_type_constructor / get_variant_to_type_constructor
+//   variant_get_ptr_constructor / variant_get_ptr_destructor
+//   variant_get_ptr_builtin_method (dispatched by type + method name)
+//   variant_stringify
+//   variant_call / variant_call_static / variant_construct (stubs)
+//   variant_has_key / variant_get_keyed / variant_set_keyed (forwarded to dict stubs)
+//
+// All other variant_* functions (operators, iterators, etc.) are stubbed to
+// no-ops or trivial returns.  They are not used by our Phase 3 fuzz targets.
+
+#include "stub_types.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+// ─── StubVariant deep-clone / free ───────────────────────────────────────
+
+void stub_variant_clone(StubVariant *dst, const StubVariant *src) {
+    if (!dst || !src) return;
+    dst->type_id = src->type_id;
+    dst->_pad    = 0;
+    switch (src->type_id) {
+    case SVT_STRING: {
+        const std::u32string *orig = (const std::u32string *)src->data.as_ptr;
+        dst->data.as_ptr = orig ? new std::u32string(*orig) : new std::u32string();
+        break;
+    }
+    case SVT_STRING_NAME:
+    case SVT_NODE_PATH:
+        // Interned: just copy the pointer; pool owns the object.
+        dst->data.as_ptr = src->data.as_ptr;
+        break;
+    case SVT_DICTIONARY: {
+        auto *orig = (StubDict *)src->data.as_ptr;
+        if (orig) {
+            auto *copy = new StubDict();
+            for (const auto &e : orig->entries) {
+                StubDict::Entry ne;
+                ne.key_repr = e.key_repr;
+                stub_variant_clone(&ne.key, &e.key);
+                stub_variant_clone(&ne.value, &e.value);
+                copy->entries.push_back(std::move(ne));
+            }
+            dst->data.as_ptr = copy;
+        } else {
+            dst->data.as_ptr = new StubDict();
+        }
+        break;
+    }
+    case SVT_ARRAY: {
+        auto *orig = (StubArray *)src->data.as_ptr;
+        if (orig) {
+            auto *copy = new StubArray();
+            for (const auto &elem : orig->elements) {
+                StubVariant cv;
+                stub_variant_clone(&cv, &elem);
+                copy->elements.push_back(cv);
+            }
+            dst->data.as_ptr = copy;
+        } else {
+            dst->data.as_ptr = new StubArray();
+        }
+        break;
+    }
+    default:
+        ::memcpy(dst->data.raw, src->data.raw, sizeof(dst->data.raw));
+        break;
+    }
+}
+
+void stub_variant_free_owned(StubVariant *v) {
+    if (!v) return;
+    switch (v->type_id) {
+    case SVT_STRING:
+        delete (std::u32string *)v->data.as_ptr;
+        break;
+    case SVT_DICTIONARY:
+        if (auto *d = (StubDict *)v->data.as_ptr) {
+            for (auto &e : d->entries) {
+                stub_variant_free_owned(&e.key);
+                stub_variant_free_owned(&e.value);
+            }
+            delete d;
+        }
+        break;
+    case SVT_ARRAY:
+        if (auto *a = (StubArray *)v->data.as_ptr) {
+            for (auto &elem : a->elements)
+                stub_variant_free_owned(&elem);
+            delete a;
+        }
+        break;
+    default:
+        break;
+    }
+    v->type_id = SVT_NIL;
+    v->data.as_ptr = nullptr;
+}
+
+std::string stub_variant_to_key(const StubVariant *v) {
+    if (!v) return "";
+    switch (v->type_id) {
+    case SVT_STRING: {
+        auto *s = (const std::u32string *)v->data.as_ptr;
+        if (!s) return "";
+        std::string r;
+        r.reserve(s->size());
+        for (char32_t c : *s) r += (c < 128) ? (char)c : '?';
+        return r;
+    }
+    case SVT_STRING_NAME:
+    case SVT_NODE_PATH: {
+        auto *s = (const std::string *)v->data.as_ptr;
+        return s ? *s : "";
+    }
+    case SVT_INT:
+        return std::to_string(v->data.as_int);
+    default:
+        return "key_type" + std::to_string(v->type_id);
+    }
+}
+
+// ─── StubDict helpers ────────────────────────────────────────────────────
+
+StubVariant *StubDict::find(std::string_view key_repr) {
+    for (auto &e : entries)
+        if (e.key_repr == key_repr) return &e.value;
+    return nullptr;
+}
+
+StubVariant *StubDict::insert_or_find(std::string_view key_repr, const StubVariant &key) {
+    for (auto &e : entries)
+        if (e.key_repr == key_repr) return &e.value;
+    Entry ne;
+    ne.key_repr = std::string(key_repr);
+    stub_variant_clone(&ne.key, &key);
+    ne.value = StubVariant{};
+    entries.push_back(std::move(ne));
+    return &entries.back().value;
+}
+
+// ─── GDExtensionVariantType enum (mirror of the public header) ───────────
+
+// ─── Variant blob accessors ───────────────────────────────────────────────
+
+static inline StubVariant *vblob(void *p) { return reinterpret_cast<StubVariant *>(p); }
+static inline const StubVariant *vblob(const void *p) { return reinterpret_cast<const StubVariant *>(p); }
+
+// ─── variant_new_nil / new_copy / destroy ────────────────────────────────
+
+extern "C" {
+
+static void s_variant_new_nil(void *r_dest) {
+    StubVariant *v = vblob(r_dest);
+    ::memset(v, 0, sizeof(*v));
+}
+
+static void s_variant_new_copy(void *r_dest, const void *p_src) {
+    stub_variant_clone(vblob(r_dest), vblob(p_src));
+}
+
+static void s_variant_destroy(void *p_self) {
+    stub_variant_free_owned(vblob(p_self));
+}
+
+static uint32_t s_variant_get_type(const void *p_self) {
+    return vblob(p_self)->type_id;
+}
+
+static void s_variant_get_type_name(uint32_t p_type, void *r_name) {
+    static const char *names[] = {
+        "Nil","bool","int","float","String","Vector2","Vector2i","Rect2",
+        "Rect2i","Vector3","Vector3i","Transform2D","Vector4","Vector4i",
+        "Plane","Quaternion","AABB","Basis","Transform3D","Projection",
+        "Color","StringName","NodePath","RID","Object","Callable","Signal",
+        "Dictionary","Array","PackedByteArray","PackedInt32Array",
+        "PackedInt64Array","PackedFloat32Array","PackedFloat64Array",
+        "PackedStringArray","PackedVector2Array","PackedVector3Array",
+        "PackedColorArray","PackedVector4Array",
+    };
+    const char *name = (p_type < 39) ? names[p_type] : "Unknown";
+    // r_name is an uninitialized StringName blob; intern it
+    auto *interned = new std::string(name);
+    sn_blob_set(r_name, interned);
+}
+
+static void s_variant_stringify(const void *p_self, void *r_str) {
+    const StubVariant *v = vblob(p_self);
+    std::u32string *s = nullptr;
+    switch (v->type_id) {
+    case SVT_STRING:
+        s = v->data.as_ptr
+            ? new std::u32string(*(const std::u32string *)v->data.as_ptr)
+            : new std::u32string();
+        break;
+    case SVT_INT: {
+        auto tmp = std::to_string(v->data.as_int);
+        s = new std::u32string(tmp.begin(), tmp.end());
+        break;
+    }
+    case SVT_BOOL:
+        s = new std::u32string(v->data.as_bool ? U"true" : U"false");
+        break;
+    default:
+        s = new std::u32string(U"[variant]");
+        break;
+    }
+    delete str_blob_get(r_str);
+    str_blob_set(r_str, s);
+}
+
+static uint8_t s_variant_booleanize(const void *p_self) {
+    const StubVariant *v = vblob(p_self);
+    switch (v->type_id) {
+    case SVT_NIL:   return 0;
+    case SVT_BOOL:  return v->data.as_bool ? 1 : 0;
+    case SVT_INT:   return v->data.as_int != 0 ? 1 : 0;
+    case SVT_FLOAT: return v->data.as_double != 0.0 ? 1 : 0;
+    case SVT_STRING:
+        return (v->data.as_ptr && !((std::u32string *)v->data.as_ptr)->empty()) ? 1 : 0;
+    default: return 1;
+    }
+}
+
+static int64_t s_variant_hash(const void *p_self) {
+    const StubVariant *v = vblob(p_self);
+    switch (v->type_id) {
+    case SVT_INT:  return v->data.as_int;
+    case SVT_BOOL: return v->data.as_bool ? 1 : 0;
+    case SVT_STRING: {
+        const std::u32string *s = (const std::u32string *)v->data.as_ptr;
+        if (!s) return 0;
+        size_t h = 0;
+        for (char32_t c : *s) h = h * 31 + c;
+        return (int64_t)h;
+    }
+    default: return (int64_t)v->type_id;
+    }
+}
+
+static uint8_t s_variant_hash_compare(const void *p_self, const void *p_other) {
+    return (s_variant_hash(p_self) == s_variant_hash(p_other)) ? 1 : 0;
+}
+
+// ── from/to type constructors ─────────────────────────────────────────────
+
+// Called as: from_type_ctor(void* r_variant_blob, void* p_type_blob)
+// Packs a typed value into a Variant blob.
+
+static void s_from_bool(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_BOOL;
+    v->data.as_bool = *(uint8_t *)p_src;
+}
+static void s_from_int(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_INT;
+    v->data.as_int = *(int64_t *)p_src;
+}
+static void s_from_float(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_FLOAT;
+    v->data.as_double = *(double *)p_src;
+}
+static void s_from_string(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_STRING;
+    const std::u32string *orig = str_blob_get(p_src);
+    v->data.as_ptr = orig ? new std::u32string(*orig) : new std::u32string();
+}
+static void s_from_string_name(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_STRING_NAME;
+    v->data.as_ptr = sn_blob_get(p_src); // interned, no clone needed
+}
+static void s_from_node_path(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_NODE_PATH;
+    v->data.as_ptr = sn_blob_get(p_src);
+}
+static void s_from_dictionary(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_DICTIONARY;
+    StubDict *orig = dict_blob_get(p_src);
+    // Clone dictionary
+    if (orig) {
+        StubVariant tmp;
+        tmp.type_id = SVT_DICTIONARY;
+        tmp.data.as_ptr = orig;
+        StubVariant cloned;
+        stub_variant_clone(&cloned, &tmp);
+        v->data.as_ptr = cloned.data.as_ptr;
+    } else {
+        v->data.as_ptr = new StubDict();
+    }
+}
+static void s_from_array(void *r_dest, void *p_src) {
+    StubVariant *v = vblob(r_dest);
+    v->type_id = SVT_ARRAY;
+    StubArray *orig = arr_blob_get(p_src);
+    if (orig) {
+        StubVariant tmp;
+        tmp.type_id = SVT_ARRAY;
+        tmp.data.as_ptr = orig;
+        StubVariant cloned;
+        stub_variant_clone(&cloned, &tmp);
+        v->data.as_ptr = cloned.data.as_ptr;
+    } else {
+        v->data.as_ptr = new StubArray();
+    }
+}
+// Generic from_type for unsupported types: zero-fill + set type
+static void s_from_generic_nil(void *r_dest, void *) {
+    vblob(r_dest)->type_id = SVT_NIL;
+    ::memset(vblob(r_dest)->data.raw, 0, 16);
+}
+
+// to_type constructors (Variant → typed value)
+static void s_to_bool(void *r_dest, void *p_variant) {
+    *(uint8_t *)r_dest = (uint8_t)s_variant_booleanize(p_variant);
+}
+static void s_to_int(void *r_dest, void *p_variant) {
+    const StubVariant *v = vblob(p_variant);
+    switch (v->type_id) {
+    case SVT_INT:   *(int64_t *)r_dest = v->data.as_int;                     break;
+    case SVT_BOOL:  *(int64_t *)r_dest = v->data.as_bool ? 1 : 0;            break;
+    case SVT_FLOAT: *(int64_t *)r_dest = (int64_t)v->data.as_double;         break;
+    default:        *(int64_t *)r_dest = 0;                                  break;
+    }
+}
+static void s_to_float(void *r_dest, void *p_variant) {
+    const StubVariant *v = vblob(p_variant);
+    switch (v->type_id) {
+    case SVT_FLOAT: *(double *)r_dest = v->data.as_double;                   break;
+    case SVT_INT:   *(double *)r_dest = (double)v->data.as_int;              break;
+    default:        *(double *)r_dest = 0.0;                                 break;
+    }
+}
+static void s_to_string(void *r_dest, void *p_variant) {
+    const StubVariant *v = vblob(p_variant);
+    if (v->type_id == SVT_STRING) {
+        const std::u32string *orig = (const std::u32string *)v->data.as_ptr;
+        delete str_blob_get(r_dest);
+        str_blob_set(r_dest, orig ? new std::u32string(*orig) : new std::u32string());
+    }
+}
+static void s_to_dictionary(void *r_dest, void *p_variant) {
+    const StubVariant *v = vblob(p_variant);
+    if (v->type_id == SVT_DICTIONARY) {
+        // Clone from variant into the dict blob
+        StubVariant tmp;
+        stub_variant_clone(&tmp, v);
+        StubDict *old = dict_blob_get(r_dest);
+        if (old) {
+            StubVariant ov; ov.type_id = SVT_DICTIONARY; ov.data.as_ptr = old;
+            stub_variant_free_owned(&ov);
+        }
+        dict_blob_set(r_dest, (StubDict *)tmp.data.as_ptr);
+    }
+}
+static void s_to_array(void *r_dest, void *p_variant) {
+    const StubVariant *v = vblob(p_variant);
+    if (v->type_id == SVT_ARRAY) {
+        StubVariant tmp;
+        stub_variant_clone(&tmp, v);
+        StubArray *old = arr_blob_get(r_dest);
+        if (old) {
+            StubVariant ov; ov.type_id = SVT_ARRAY; ov.data.as_ptr = old;
+            stub_variant_free_owned(&ov);
+        }
+        arr_blob_set(r_dest, (StubArray *)tmp.data.as_ptr);
+    }
+}
+static void s_to_generic_nil(void *r_dest, void *) {
+    ::memset(r_dest, 0, 8);
+}
+
+typedef void (*FromTypeFunc)(void *, void *);
+typedef void (*ToTypeFunc)(void *, void *);
+
+static FromTypeFunc s_get_variant_from_type_constructor(uint32_t p_type) {
+    switch (p_type) {
+    case SVT_BOOL:        return s_from_bool;
+    case SVT_INT:         return s_from_int;
+    case SVT_FLOAT:       return s_from_float;
+    case SVT_STRING:      return s_from_string;
+    case SVT_STRING_NAME: return s_from_string_name;
+    case SVT_NODE_PATH:   return s_from_node_path;
+    case SVT_DICTIONARY:  return s_from_dictionary;
+    case SVT_ARRAY:       return s_from_array;
+    default:              return s_from_generic_nil;
+    }
+}
+
+static ToTypeFunc s_get_variant_to_type_constructor(uint32_t p_type) {
+    switch (p_type) {
+    case SVT_BOOL:        return s_to_bool;
+    case SVT_INT:         return s_to_int;
+    case SVT_FLOAT:       return s_to_float;
+    case SVT_STRING:      return s_to_string;
+    case SVT_DICTIONARY:  return s_to_dictionary;
+    case SVT_ARRAY:       return s_to_array;
+    default:              return s_to_generic_nil;
+    }
+}
+
+// ── variant_get_ptr_constructor / destructor ──────────────────────────────
+
+// GDExtensionPtrConstructor: void f(void *p_base, const void *const *p_args)
+
+static void s_string_ctor_default(void *p_base, const void *const *) {
+    delete str_blob_get(p_base);
+    str_blob_set(p_base, new std::u32string());
+}
+static void s_string_ctor_copy(void *p_base, const void *const *p_args) {
+    const std::u32string *orig = str_blob_get(p_args[0]);
+    delete str_blob_get(p_base);
+    str_blob_set(p_base, orig ? new std::u32string(*orig) : new std::u32string());
+}
+static void s_string_dtor(void *p_base) {
+    delete str_blob_get(p_base);
+    str_blob_set(p_base, nullptr);
+}
+
+static void s_string_name_ctor_default(void *p_base, const void *const *) {
+    sn_blob_set(p_base, sn_intern(""));
+}
+static void s_string_name_ctor_copy(void *p_base, const void *const *p_args) {
+    sn_blob_set(p_base, sn_blob_get(p_args[0]));
+}
+static void s_string_name_dtor(void *) { /* interned; pool owns */ }
+
+static void s_dict_ctor_default(void *p_base, const void *const *) {
+    StubDict *old = dict_blob_get(p_base);
+    if (old) { StubVariant ov{SVT_DICTIONARY,0,{}}; ov.data.as_ptr=old; stub_variant_free_owned(&ov); }
+    dict_blob_set(p_base, new StubDict());
+}
+static void s_dict_ctor_copy(void *p_base, const void *const *p_args) {
+    StubVariant src{SVT_DICTIONARY,0,{}};
+    src.data.as_ptr = dict_blob_get(p_args[0]);
+    StubVariant cloned; stub_variant_clone(&cloned, &src);
+    StubDict *old = dict_blob_get(p_base);
+    if (old) { StubVariant ov{SVT_DICTIONARY,0,{}}; ov.data.as_ptr=old; stub_variant_free_owned(&ov); }
+    dict_blob_set(p_base, (StubDict *)cloned.data.as_ptr);
+}
+static void s_dict_dtor(void *p_base) {
+    StubDict *d = dict_blob_get(p_base);
+    if (!d) return;
+    for (auto &e : d->entries) { stub_variant_free_owned(&e.key); stub_variant_free_owned(&e.value); }
+    delete d;
+    dict_blob_set(p_base, nullptr);
+}
+
+static void s_array_ctor_default(void *p_base, const void *const *) {
+    StubArray *old = arr_blob_get(p_base);
+    if (old) { StubVariant ov{SVT_ARRAY,0,{}}; ov.data.as_ptr=old; stub_variant_free_owned(&ov); }
+    arr_blob_set(p_base, new StubArray());
+}
+static void s_array_ctor_copy(void *p_base, const void *const *p_args) {
+    StubVariant src{SVT_ARRAY,0,{}};
+    src.data.as_ptr = arr_blob_get(p_args[0]);
+    StubVariant cloned; stub_variant_clone(&cloned, &src);
+    StubArray *old = arr_blob_get(p_base);
+    if (old) { StubVariant ov{SVT_ARRAY,0,{}}; ov.data.as_ptr=old; stub_variant_free_owned(&ov); }
+    arr_blob_set(p_base, (StubArray *)cloned.data.as_ptr);
+}
+static void s_array_dtor(void *p_base) {
+    StubArray *a = arr_blob_get(p_base);
+    if (!a) return;
+    for (auto &elem : a->elements) stub_variant_free_owned(&elem);
+    delete a;
+    arr_blob_set(p_base, nullptr);
+}
+
+static void s_noop_ctor(void *p_base, const void *const *) { ::memset(p_base, 0, 8); }
+static void s_noop_dtor(void *) {}
+
+typedef void (*PFNCtor)(void *, const void *const *);
+typedef void (*PFNDtor)(void *);
+
+static PFNCtor s_variant_get_ptr_constructor(uint32_t p_type, int32_t p_constructor) {
+    switch (p_type) {
+    case SVT_STRING:
+        return (p_constructor == 0) ? s_string_ctor_default :
+               (p_constructor == 1) ? s_string_ctor_copy : s_noop_ctor;
+    case SVT_STRING_NAME:
+    case SVT_NODE_PATH:
+        return (p_constructor == 0) ? s_string_name_ctor_default :
+               (p_constructor == 1) ? s_string_name_ctor_copy : s_noop_ctor;
+    case SVT_DICTIONARY:
+        return (p_constructor == 0) ? s_dict_ctor_default :
+               (p_constructor == 1) ? s_dict_ctor_copy : s_noop_ctor;
+    case SVT_ARRAY:
+        return (p_constructor == 0) ? s_array_ctor_default :
+               (p_constructor == 1) ? s_array_ctor_copy : s_noop_ctor;
+    default:
+        return s_noop_ctor;
+    }
+}
+
+static PFNDtor s_variant_get_ptr_destructor(uint32_t p_type) {
+    switch (p_type) {
+    case SVT_STRING:      return s_string_dtor;
+    case SVT_STRING_NAME: return s_string_name_dtor;
+    case SVT_NODE_PATH:   return s_string_name_dtor;
+    case SVT_DICTIONARY:  return s_dict_dtor;
+    case SVT_ARRAY:       return s_array_dtor;
+    default:              return s_noop_dtor;
+    }
+}
+
+// ── variant_get_ptr_builtin_method ────────────────────────────────────────
+//
+// GDExtensionPtrBuiltInMethod signature:
+//   void f(void *p_base, const void *const *p_args, void *r_return, int32_t p_arg_count)
+
+typedef void (*PFNBuiltin)(void *, const void *const *, void *, int32_t);
+static void s_noop_builtin(void *, const void *const *, void *, int32_t) {}
+
+// ── Array built-in method stubs ───────────────────────────────────────────
+
+static void s_array_push_back(void *p_base, const void *const *p_args, void *, int32_t) {
+    StubArray *a = arr_blob_get(p_base);
+    if (!a) return;
+    StubVariant elem;
+    stub_variant_clone(&elem, vblob(p_args[0]));
+    a->elements.push_back(elem);
+}
+
+static void s_array_size(void *p_base, const void *const *, void *r_ret, int32_t) {
+    StubArray *a = arr_blob_get(p_base);
+    if (r_ret) *(int64_t *)r_ret = a ? (int64_t)a->elements.size() : 0LL;
+}
+
+static void s_array_is_empty(void *p_base, const void *const *, void *r_ret, int32_t) {
+    StubArray *a = arr_blob_get(p_base);
+    if (r_ret) *(uint8_t *)r_ret = (!a || a->elements.empty()) ? 1 : 0;
+}
+
+static void s_array_clear(void *p_base, const void *const *, void *, int32_t) {
+    StubArray *a = arr_blob_get(p_base);
+    if (!a) return;
+    for (auto &elem : a->elements) stub_variant_free_owned(&elem);
+    a->elements.clear();
+}
+
+static void s_array_get(void *p_base, const void *const *p_args, void *r_ret, int32_t) {
+    StubArray *a = arr_blob_get(p_base);
+    if (!a || !r_ret) return;
+    int64_t idx = *(const int64_t *)p_args[0];
+    if (idx < 0 || (size_t)idx >= a->elements.size()) return;
+    stub_variant_clone(vblob(r_ret), &a->elements[(size_t)idx]);
+}
+
+static void s_array_set(void *p_base, const void *const *p_args, void *, int32_t) {
+    StubArray *a = arr_blob_get(p_base);
+    if (!a) return;
+    int64_t idx = *(const int64_t *)p_args[0];
+    if (idx < 0 || (size_t)idx >= a->elements.size()) return;
+    stub_variant_free_owned(&a->elements[(size_t)idx]);
+    stub_variant_clone(&a->elements[(size_t)idx], vblob(p_args[1]));
+}
+
+// ── Dictionary built-in method stubs ─────────────────────────────────────
+
+static void s_dict_get(void *p_base, const void *const *p_args, void *r_ret, int32_t p_arg_count) {
+    StubDict *d = dict_blob_get(p_base);
+    if (!r_ret) return;
+    std::string key = stub_variant_to_key(vblob(p_args[0]));
+    StubVariant *found = d ? d->find(key) : nullptr;
+    if (found) {
+        stub_variant_clone(vblob(r_ret), found);
+    } else if (p_arg_count >= 2) {
+        stub_variant_clone(vblob(r_ret), vblob(p_args[1]));
+    } else {
+        s_variant_new_nil(r_ret);
+    }
+}
+
+static void s_dict_has(void *p_base, const void *const *p_args, void *r_ret, int32_t) {
+    StubDict *d = dict_blob_get(p_base);
+    std::string key = stub_variant_to_key(vblob(p_args[0]));
+    if (r_ret) *(uint8_t *)r_ret = (d && d->find(key)) ? 1 : 0;
+}
+
+static void s_dict_keys(void *p_base, const void *const *, void *r_ret, int32_t) {
+    StubDict *d = dict_blob_get(p_base);
+    if (!r_ret) return;
+    StubArray *a = new StubArray();
+    if (d) {
+        for (const auto &e : d->entries) {
+            StubVariant kv; stub_variant_clone(&kv, &e.key);
+            a->elements.push_back(kv);
+        }
+    }
+    arr_blob_set(r_ret, a);
+}
+
+static void s_dict_size(void *p_base, const void *const *, void *r_ret, int32_t) {
+    StubDict *d = dict_blob_get(p_base);
+    if (r_ret) *(int64_t *)r_ret = d ? (int64_t)d->entries.size() : 0LL;
+}
+
+static void s_dict_is_empty(void *p_base, const void *const *, void *r_ret, int32_t) {
+    StubDict *d = dict_blob_get(p_base);
+    if (r_ret) *(uint8_t *)r_ret = (!d || d->entries.empty()) ? 1 : 0;
+}
+
+// ── String built-in method stubs ─────────────────────────────────────────
+
+static void s_string_is_empty(void *p_base, const void *const *, void *r_ret, int32_t) {
+    std::u32string *s = str_blob_get(p_base);
+    if (r_ret) *(uint8_t *)r_ret = (!s || s->empty()) ? 1 : 0;
+}
+
+static void s_string_length(void *p_base, const void *const *, void *r_ret, int32_t) {
+    std::u32string *s = str_blob_get(p_base);
+    if (r_ret) *(int64_t *)r_ret = s ? (int64_t)s->size() : 0LL;
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────
+
+static PFNBuiltin s_variant_get_ptr_builtin_method(uint32_t p_type, const void *p_method_name, int64_t /*p_hash*/) {
+    // p_method_name is a StringName blob (points to an interned std::string*)
+    const std::string *sn = sn_blob_get(p_method_name);
+    if (!sn) return s_noop_builtin;
+    std::string_view name = *sn;
+
+    if (p_type == SVT_ARRAY) {
+        if (name == "push_back" || name == "append") return s_array_push_back;
+        if (name == "size")     return s_array_size;
+        if (name == "is_empty") return s_array_is_empty;
+        if (name == "clear")    return s_array_clear;
+        if (name == "get")      return s_array_get;
+        if (name == "set")      return s_array_set;
+    }
+    if (p_type == SVT_DICTIONARY) {
+        if (name == "get")      return s_dict_get;
+        if (name == "has")      return s_dict_has;
+        if (name == "keys")     return s_dict_keys;
+        if (name == "size")     return s_dict_size;
+        if (name == "is_empty") return s_dict_is_empty;
+    }
+    if (p_type == SVT_STRING) {
+        if (name == "is_empty") return s_string_is_empty;
+        if (name == "length")   return s_string_length;
+    }
+    return s_noop_builtin;
+}
+
+// ── Variant keyed access (forwarded to dictionary) ────────────────────────
+
+static void s_variant_get_keyed(const void *p_self, const void *p_key, void *r_value, uint8_t *r_valid) {
+    const StubVariant *v = vblob(p_self);
+    if (v->type_id != SVT_DICTIONARY) { if (r_valid) *r_valid = 0; return; }
+    StubDict *d = (StubDict *)v->data.as_ptr;
+    std::string key = stub_variant_to_key(vblob(p_key));
+    StubVariant *found = d ? d->find(key) : nullptr;
+    if (found) {
+        stub_variant_clone(vblob(r_value), found);
+        if (r_valid) *r_valid = 1;
+    } else {
+        s_variant_new_nil(r_value);
+        if (r_valid) *r_valid = 0;
+    }
+}
+
+static void s_variant_set_keyed(void *p_self, const void *p_key, const void *p_value, uint8_t *r_valid) {
+    StubVariant *v = vblob(p_self);
+    if (v->type_id != SVT_DICTIONARY) { if (r_valid) *r_valid = 0; return; }
+    StubDict *d = (StubDict *)v->data.as_ptr;
+    if (!d) { if (r_valid) *r_valid = 0; return; }
+    std::string key = stub_variant_to_key(vblob(p_key));
+    StubVariant *slot = d->insert_or_find(key, *vblob(p_key));
+    stub_variant_free_owned(slot);
+    stub_variant_clone(slot, vblob(p_value));
+    if (r_valid) *r_valid = 1;
+}
+
+static uint32_t s_variant_has_key(const void *p_self, const void *p_key, uint8_t *r_valid) {
+    const StubVariant *v = vblob(p_self);
+    if (v->type_id != SVT_DICTIONARY) { if (r_valid) *r_valid = 0; return 0; }
+    StubDict *d = (StubDict *)v->data.as_ptr;
+    std::string key = stub_variant_to_key(vblob(p_key));
+    uint32_t found = (d && d->find(key)) ? 1 : 0;
+    if (r_valid) *r_valid = 1;
+    return found;
+}
+
+static void s_variant_call(void *p_self, const void *p_method, const void *const *p_args, int32_t p_arg_count, void *r_return, void *r_error) {
+    (void)p_self; (void)p_method; (void)p_args; (void)p_arg_count; (void)r_error;
+    if (r_return) s_variant_new_nil(r_return);
+}
+
+static void s_variant_call_static(uint32_t p_type, const void *p_method, const void *const *p_args, int32_t p_arg_count, void *r_return, void *r_error) {
+    (void)p_type; (void)p_method; (void)p_args; (void)p_arg_count; (void)r_error;
+    if (r_return) s_variant_new_nil(r_return);
+}
+
+static void s_variant_construct(uint32_t p_type, void *r_base, const void *const *p_args, int32_t p_argc, void *r_error) {
+    (void)r_error;
+    PFNCtor ctor = s_variant_get_ptr_constructor(p_type, p_argc > 0 ? 1 : 0);
+    ctor(r_base, p_args);
+}
+
+static void s_variant_duplicate(const void *p_self, void *r_ret, uint8_t /*deep*/) {
+    stub_variant_clone(vblob(r_ret), vblob(p_self));
+}
+
+static void s_variant_get(const void *p_self, const void *p_key, void *r_ret, uint8_t *r_valid) {
+    s_variant_get_keyed(p_self, p_key, r_ret, r_valid);
+}
+static void s_variant_set(void *p_self, const void *p_key, const void *p_value, uint8_t *r_valid) {
+    s_variant_set_keyed(p_self, p_key, p_value, r_valid);
+}
+static void s_variant_get_named(const void *p_self, const void *p_name, void *r_ret, uint8_t *r_valid) {
+    s_variant_get_keyed(p_self, p_name, r_ret, r_valid);
+}
+static void s_variant_set_named(void *p_self, const void *p_name, const void *p_value, uint8_t *r_valid) {
+    s_variant_set_keyed(p_self, p_name, p_value, r_valid);
+}
+static void s_variant_get_indexed(const void *p_self, int64_t p_index, void *r_ret, uint8_t *r_oob) {
+    // For Array access by index
+    const StubVariant *v = vblob(p_self);
+    if (v->type_id == SVT_ARRAY) {
+        StubArray *a = (StubArray *)v->data.as_ptr;
+        if (a && p_index >= 0 && (size_t)p_index < a->elements.size()) {
+            stub_variant_clone(vblob(r_ret), &a->elements[(size_t)p_index]);
+            if (r_oob) *r_oob = 0;
+            return;
+        }
+    }
+    s_variant_new_nil(r_ret);
+    if (r_oob) *r_oob = 1;
+}
+static void s_variant_set_indexed(void *p_self, int64_t p_index, const void *p_value, uint8_t *r_valid, uint8_t *r_oob) {
+    StubVariant *v = vblob(p_self);
+    if (v->type_id == SVT_ARRAY) {
+        StubArray *a = (StubArray *)v->data.as_ptr;
+        if (a && p_index >= 0 && (size_t)p_index < a->elements.size()) {
+            stub_variant_free_owned(&a->elements[(size_t)p_index]);
+            stub_variant_clone(&a->elements[(size_t)p_index], vblob(p_value));
+            if (r_valid) *r_valid = 1;
+            if (r_oob) *r_oob = 0;
+            return;
+        }
+    }
+    if (r_valid) *r_valid = 0;
+    if (r_oob) *r_oob = 1;
+}
+
+static uint8_t s_variant_can_convert(uint32_t /*p_from*/, uint32_t /*p_to*/) { return 1; }
+static uint8_t s_variant_can_convert_strict(uint32_t p_from, uint32_t p_to) { return p_from == p_to ? 1 : 0; }
+static void s_variant_evaluate(uint32_t /*op*/, const void */*a*/, const void */*b*/, void *r_ret, uint8_t *r_valid) {
+    if (r_ret) s_variant_new_nil(r_ret);
+    if (r_valid) *r_valid = 0;
+}
+static int64_t s_variant_recursive_hash(const void *p_self, int64_t /*seed*/) { return s_variant_hash(p_self); }
+static void s_variant_has_member(uint32_t /*type*/, const void */*member*/, uint8_t *r_has) { if (r_has) *r_has = 0; }
+static void s_variant_has_method(const void */*self*/, const void */*method*/, uint8_t *r_has) { if (r_has) *r_has = 0; }
+static void s_variant_get_object_instance_id(const void */*self*/, uint64_t *r_id) { if (r_id) *r_id = 0; }
+static void s_variant_get_constant_value(uint32_t /*type*/, const void */*name*/, void *r_ret) { if (r_ret) s_variant_new_nil(r_ret); }
+static void *s_variant_get_ptr_setter(uint32_t, const void *) { return nullptr; }
+static void *s_variant_get_ptr_getter(uint32_t, const void *) { return nullptr; }
+static void *s_variant_get_ptr_indexed_setter(uint32_t) { return nullptr; }
+static void *s_variant_get_ptr_indexed_getter(uint32_t) { return nullptr; }
+static void *s_variant_get_ptr_keyed_setter(uint32_t) { return nullptr; }
+static void *s_variant_get_ptr_keyed_getter(uint32_t) { return nullptr; }
+static uint32_t s_variant_get_ptr_keyed_checker(const void *, const void *) { return 0; }
+
+// Operator evaluator: void f(const void *p_left, const void *p_right, void *r_result)
+// r_result is a pre-constructed (default) blob of the same type as p_left.
+// OP_ADD=0, TYPE_STRING=4.
+static void s_noop_op_eval(const void *, const void *, void *) {}
+static void s_string_op_add(const void *p_left, const void *p_right, void *r_result) {
+    const std::u32string *L = str_blob_get(p_left);
+    const std::u32string *R = str_blob_get(p_right);
+    delete str_blob_get(r_result);
+    std::u32string *res = new std::u32string();
+    if (L) *res = *L;
+    if (R) *res += *R;
+    str_blob_set(r_result, res);
+}
+static void *s_variant_get_ptr_operator_evaluator(uint32_t p_op, uint32_t p_type_a, uint32_t p_type_b) {
+    // OP_ADD=0, TYPE_STRING=4
+    if (p_op == 0 && p_type_a == 4 && p_type_b == 4) return (void *)s_string_op_add;
+    // Return a real (but no-op) function for all other operators so callers never
+    // dereference a null function pointer.
+    return (void *)s_noop_op_eval;
+}
+
+// Utility function: void f(void *r_return, const void *const *p_args, int32_t p_arg_count)
+// Return a real noop to prevent null-pointer dereference when godot-cpp calls utility
+// functions that the fuzz targets don't exercise.
+static void s_noop_utility(void *, const void *const *, int32_t) {}
+static void *s_variant_get_ptr_utility_function(const void *, int64_t) {
+    return (void *)s_noop_utility;
+}
+
+static void *s_variant_get_ptr_internal_getter(uint32_t, uint32_t) { return nullptr; }
+static void s_variant_iter_init(const void *, void *, uint8_t *r_valid) { if (r_valid) *r_valid = 0; }
+static void s_variant_iter_next(const void *, void *, uint8_t *r_valid) { if (r_valid) *r_valid = 0; }
+static void s_variant_iter_get(const void *, void *, void *r_ret, uint8_t *r_valid) {
+    if (r_ret) s_variant_new_nil(r_ret);
+    if (r_valid) *r_valid = 0;
+}
+
+} // extern "C"
+
+// ─── Exported function pointer table ─────────────────────────────────────
+void *stub_variant_new_nil_ptr                        = (void *)s_variant_new_nil;
+void *stub_variant_new_copy_ptr                       = (void *)s_variant_new_copy;
+void *stub_variant_destroy_ptr                        = (void *)s_variant_destroy;
+void *stub_variant_get_type_ptr                       = (void *)s_variant_get_type;
+void *stub_variant_get_type_name_ptr                  = (void *)s_variant_get_type_name;
+void *stub_variant_booleanize_ptr                     = (void *)s_variant_booleanize;
+void *stub_variant_hash_ptr                           = (void *)s_variant_hash;
+void *stub_variant_hash_compare_ptr                   = (void *)s_variant_hash_compare;
+void *stub_variant_stringify_ptr                      = (void *)s_variant_stringify;
+void *stub_variant_call_ptr                           = (void *)s_variant_call;
+void *stub_variant_call_static_ptr                    = (void *)s_variant_call_static;
+void *stub_variant_construct_ptr                      = (void *)s_variant_construct;
+void *stub_variant_duplicate_ptr                      = (void *)s_variant_duplicate;
+void *stub_variant_get_ptr                            = (void *)s_variant_get;
+void *stub_variant_set_ptr                            = (void *)s_variant_set;
+void *stub_variant_get_named_ptr                      = (void *)s_variant_get_named;
+void *stub_variant_set_named_ptr                      = (void *)s_variant_set_named;
+void *stub_variant_get_indexed_ptr                    = (void *)s_variant_get_indexed;
+void *stub_variant_set_indexed_ptr                    = (void *)s_variant_set_indexed;
+void *stub_variant_get_keyed_ptr                      = (void *)s_variant_get_keyed;
+void *stub_variant_set_keyed_ptr                      = (void *)s_variant_set_keyed;
+void *stub_variant_has_key_ptr                        = (void *)s_variant_has_key;
+void *stub_variant_can_convert_ptr                    = (void *)s_variant_can_convert;
+void *stub_variant_can_convert_strict_ptr             = (void *)s_variant_can_convert_strict;
+void *stub_variant_evaluate_ptr                       = (void *)s_variant_evaluate;
+void *stub_variant_recursive_hash_ptr                 = (void *)s_variant_recursive_hash;
+void *stub_variant_has_member_ptr                     = (void *)s_variant_has_member;
+void *stub_variant_has_method_ptr                     = (void *)s_variant_has_method;
+void *stub_variant_get_object_instance_id_ptr         = (void *)s_variant_get_object_instance_id;
+void *stub_variant_get_constant_value_ptr             = (void *)s_variant_get_constant_value;
+void *stub_variant_iter_init_ptr                      = (void *)s_variant_iter_init;
+void *stub_variant_iter_next_ptr                      = (void *)s_variant_iter_next;
+void *stub_variant_iter_get_ptr                       = (void *)s_variant_iter_get;
+void *stub_variant_get_ptr_setter_ptr                 = (void *)s_variant_get_ptr_setter;
+void *stub_variant_get_ptr_getter_ptr                 = (void *)s_variant_get_ptr_getter;
+void *stub_variant_get_ptr_indexed_setter_ptr         = (void *)s_variant_get_ptr_indexed_setter;
+void *stub_variant_get_ptr_indexed_getter_ptr         = (void *)s_variant_get_ptr_indexed_getter;
+void *stub_variant_get_ptr_keyed_setter_ptr           = (void *)s_variant_get_ptr_keyed_setter;
+void *stub_variant_get_ptr_keyed_getter_ptr           = (void *)s_variant_get_ptr_keyed_getter;
+void *stub_variant_get_ptr_keyed_checker_ptr          = (void *)s_variant_get_ptr_keyed_checker;
+void *stub_variant_get_ptr_operator_evaluator_ptr     = (void *)s_variant_get_ptr_operator_evaluator;
+void *stub_variant_get_ptr_utility_function_ptr       = (void *)s_variant_get_ptr_utility_function;
+void *stub_variant_get_ptr_internal_getter_ptr        = (void *)s_variant_get_ptr_internal_getter;
+void *stub_variant_get_ptr_constructor_ptr            = (void *)s_variant_get_ptr_constructor;
+void *stub_variant_get_ptr_destructor_ptr             = (void *)s_variant_get_ptr_destructor;
+void *stub_variant_get_ptr_builtin_method_ptr         = (void *)s_variant_get_ptr_builtin_method;
+void *stub_get_variant_from_type_constructor_ptr      = (void *)s_get_variant_from_type_constructor;
+void *stub_get_variant_to_type_constructor_ptr        = (void *)s_get_variant_to_type_constructor;

--- a/tests/cpp/fuzz_harness/stub_variant.cpp
+++ b/tests/cpp/fuzz_harness/stub_variant.cpp
@@ -480,6 +480,21 @@ static void s_array_dtor(void *p_base) {
     arr_blob_set(p_base, nullptr);
 }
 
+// ── PackedByteArray ctor / copy / dtor ────────────────────────────────────
+static void s_pba_ctor_default(void *p_base, const void *const *) {
+    delete pba_blob_get(p_base);
+    pba_blob_set(p_base, new std::vector<uint8_t>());
+}
+static void s_pba_ctor_copy(void *p_base, const void *const *p_args) {
+    const std::vector<uint8_t> *orig = pba_blob_get(p_args[0]);
+    delete pba_blob_get(p_base);
+    pba_blob_set(p_base, orig ? new std::vector<uint8_t>(*orig) : new std::vector<uint8_t>());
+}
+static void s_pba_dtor(void *p_base) {
+    delete pba_blob_get(p_base);
+    pba_blob_set(p_base, nullptr);
+}
+
 static void s_noop_ctor(void *p_base, const void *const *) { ::memset(p_base, 0, 8); }
 static void s_noop_dtor(void *) {}
 
@@ -501,6 +516,9 @@ static PFNCtor s_variant_get_ptr_constructor(uint32_t p_type, int32_t p_construc
     case SVT_ARRAY:
         return (p_constructor == 0) ? s_array_ctor_default :
                (p_constructor == 1) ? s_array_ctor_copy : s_noop_ctor;
+    case SVT_PACKED_BYTE_ARRAY:
+        return (p_constructor == 0) ? s_pba_ctor_default :
+               (p_constructor == 1) ? s_pba_ctor_copy : s_noop_ctor;
     default:
         return s_noop_ctor;
     }
@@ -513,6 +531,7 @@ static PFNDtor s_variant_get_ptr_destructor(uint32_t p_type) {
     case SVT_NODE_PATH:   return s_string_name_dtor;
     case SVT_DICTIONARY:  return s_dict_dtor;
     case SVT_ARRAY:       return s_array_dtor;
+    case SVT_PACKED_BYTE_ARRAY: return s_pba_dtor;
     default:              return s_noop_dtor;
     }
 }
@@ -626,6 +645,56 @@ static void s_string_length(void *p_base, const void *const *, void *r_ret, int3
     if (r_ret) *(int64_t *)r_ret = s ? (int64_t)s->size() : 0LL;
 }
 
+// ── PackedByteArray built-in method stubs ────────────────────────────────
+// Builtin-method ABI: void f(void *p_base, const void *const *p_args,
+//                            void *r_return, int32_t p_arg_count)
+// int parameters are PtrToArg<int64_t>-encoded (8-byte little-endian); the
+// PackedByteArray methods set/push_back/get treat the value as a byte.
+
+static void s_pba_resize(void *p_base, const void *const *p_args, void *r_ret, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    int64_t new_size = p_args ? *(const int64_t *)p_args[0] : 0;
+    if (v && new_size >= 0) v->resize((size_t)new_size, 0);
+    if (r_ret) *(int64_t *)r_ret = 0; // Error::OK
+}
+
+static void s_pba_size(void *p_base, const void *const *, void *r_ret, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    if (r_ret) *(int64_t *)r_ret = v ? (int64_t)v->size() : 0LL;
+}
+
+static void s_pba_is_empty(void *p_base, const void *const *, void *r_ret, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    if (r_ret) *(uint8_t *)r_ret = (!v || v->empty()) ? 1 : 0;
+}
+
+static void s_pba_set(void *p_base, const void *const *p_args, void *, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    if (!v || !p_args) return;
+    int64_t idx = *(const int64_t *)p_args[0];
+    int64_t val = *(const int64_t *)p_args[1];
+    if (idx < 0 || (size_t)idx >= v->size()) return;
+    (*v)[(size_t)idx] = (uint8_t)val;
+}
+
+static void s_pba_push_back(void *p_base, const void *const *p_args, void *r_ret, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    if (v && p_args) v->push_back((uint8_t)*(const int64_t *)p_args[0]);
+    if (r_ret) *(uint8_t *)r_ret = 1; // success
+}
+
+static void s_pba_get(void *p_base, const void *const *p_args, void *r_ret, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    if (!r_ret) return;
+    int64_t idx = (v && p_args) ? *(const int64_t *)p_args[0] : -1;
+    *(int64_t *)r_ret = (v && idx >= 0 && (size_t)idx < v->size()) ? (int64_t)(*v)[(size_t)idx] : 0LL;
+}
+
+static void s_pba_clear(void *p_base, const void *const *, void *, int32_t) {
+    std::vector<uint8_t> *v = pba_blob_get(p_base);
+    if (v) v->clear();
+}
+
 // ── Dispatch ──────────────────────────────────────────────────────────────
 
 static PFNBuiltin s_variant_get_ptr_builtin_method(uint32_t p_type, const void *p_method_name, int64_t /*p_hash*/) {
@@ -652,6 +721,15 @@ static PFNBuiltin s_variant_get_ptr_builtin_method(uint32_t p_type, const void *
     if (p_type == SVT_STRING) {
         if (name == "is_empty") return s_string_is_empty;
         if (name == "length")   return s_string_length;
+    }
+    if (p_type == SVT_PACKED_BYTE_ARRAY) {
+        if (name == "resize")    return s_pba_resize;
+        if (name == "size")      return s_pba_size;
+        if (name == "is_empty")  return s_pba_is_empty;
+        if (name == "set")       return s_pba_set;
+        if (name == "push_back" || name == "append") return s_pba_push_back;
+        if (name == "get")       return s_pba_get;
+        if (name == "clear")     return s_pba_clear;
     }
     return s_noop_builtin;
 }

--- a/tests/cpp/fuzz_harness/stub_variant.cpp
+++ b/tests/cpp/fuzz_harness/stub_variant.cpp
@@ -187,9 +187,10 @@ static void s_variant_get_type_name(uint32_t p_type, void *r_name) {
         "PackedColorArray","PackedVector4Array",
     };
     const char *name = (p_type < 39) ? names[p_type] : "Unknown";
-    // r_name is an uninitialized StringName blob; intern it
-    auto *interned = new std::string(name);
-    sn_blob_set(r_name, interned);
+    // r_name is a StringName blob; point it at the shared intern pool so the
+    // pointer is stable and pool-owned (allocating a fresh std::string here and
+    // relying on the no-op StringName destructor would leak on every call).
+    sn_blob_set(r_name, sn_intern(name));
 }
 
 static void s_variant_stringify(const void *p_self, void *r_str) {
@@ -613,6 +614,11 @@ static void s_dict_has(void *p_base, const void *const *p_args, void *r_ret, int
 static void s_dict_keys(void *p_base, const void *const *, void *r_ret, int32_t) {
     StubDict *d = dict_blob_get(p_base);
     if (!r_ret) return;
+    // godot-cpp default-constructs the Array return value before invoking this
+    // method, so r_ret already owns a StubArray. Free it before reassigning to
+    // avoid leaking one array per call (mirrors s_array_ctor_default).
+    StubArray *old = arr_blob_get(r_ret);
+    if (old) { StubVariant ov{SVT_ARRAY, 0, {}}; ov.data.as_ptr = old; stub_variant_free_owned(&ov); }
     StubArray *a = new StubArray();
     if (d) {
         for (const auto &e : d->entries) {

--- a/tests/cpp/request_key/test_playfab_request_key.cpp
+++ b/tests/cpp/request_key/test_playfab_request_key.cpp
@@ -1,0 +1,119 @@
+// Doctest coverage for playfab_internal::match_request_key.
+//
+// This helper is extracted from the get_request_value key-selection logic in
+// playfab_api_helpers.cpp. The pure form uses strcmp on a flat key array and
+// has no Godot or GDK dependencies; production code uses godot::StringName
+// hash lookups for O(1) performance (see the comment in playfab_api_helpers.cpp).
+//
+// Test matrix covers the documented return contract:
+//   0  — primary matched
+//   1  — fallback matched
+//  -1  — neither matched (or degenerate input)
+
+#include "doctest.h"
+
+#include "playfab_request_key.h"
+
+using playfab_internal::match_request_key;
+
+TEST_CASE("match_request_key: degenerate inputs return -1") {
+    SUBCASE("null keys pointer") {
+        CHECK(match_request_key(nullptr, 3, "snake", "Pascal") == -1);
+    }
+
+    SUBCASE("zero key count") {
+        const char *keys[] = { "snake", "Pascal" };
+        CHECK(match_request_key(keys, 0, "snake", "Pascal") == -1);
+    }
+
+    SUBCASE("both primary and fallback null") {
+        const char *keys[] = { "something" };
+        CHECK(match_request_key(keys, 1, nullptr, nullptr) == -1);
+    }
+
+    SUBCASE("null primary and null fallback with populated key list") {
+        const char *keys[] = { "a", "b", "c" };
+        CHECK(match_request_key(keys, 3, nullptr, nullptr) == -1);
+    }
+}
+
+TEST_CASE("match_request_key: no matching key returns -1") {
+    const char *keys[] = { "alpha", "beta", "gamma" };
+
+    SUBCASE("neither primary nor fallback present") {
+        CHECK(match_request_key(keys, 3, "missing_snake", "MissingPascal") == -1);
+    }
+
+    SUBCASE("empty key array but non-null primary/fallback") {
+        CHECK(match_request_key(nullptr, 0, "some_key", "SomeKey") == -1);
+    }
+}
+
+TEST_CASE("match_request_key: primary (snake_case) wins when present") {
+    SUBCASE("only primary present") {
+        const char *keys[] = { "email_address" };
+        CHECK(match_request_key(keys, 1, "email_address", "EmailAddress") == 0);
+    }
+
+    SUBCASE("both primary and fallback present — primary takes precedence") {
+        const char *keys[] = { "email_address", "EmailAddress" };
+        CHECK(match_request_key(keys, 2, "email_address", "EmailAddress") == 0);
+    }
+
+    SUBCASE("primary present in multi-key array") {
+        const char *keys[] = { "unrelated", "email_address", "also_unrelated" };
+        CHECK(match_request_key(keys, 3, "email_address", "EmailAddress") == 0);
+    }
+
+    SUBCASE("null fallback — primary still matches") {
+        const char *keys[] = { "email_address" };
+        CHECK(match_request_key(keys, 1, "email_address", nullptr) == 0);
+    }
+}
+
+TEST_CASE("match_request_key: fallback (PascalCase) used when primary absent") {
+    SUBCASE("only fallback present") {
+        const char *keys[] = { "EmailAddress" };
+        CHECK(match_request_key(keys, 1, "email_address", "EmailAddress") == 1);
+    }
+
+    SUBCASE("null primary — fallback used") {
+        const char *keys[] = { "EmailAddress" };
+        CHECK(match_request_key(keys, 1, nullptr, "EmailAddress") == 1);
+    }
+
+    SUBCASE("fallback present in multi-key array") {
+        const char *keys[] = { "other_field", "EmailAddress", "yet_another" };
+        CHECK(match_request_key(keys, 3, "email_address", "EmailAddress") == 1);
+    }
+}
+
+TEST_CASE("match_request_key: identical primary and fallback strings") {
+    // When primary == fallback (same literal value), match_request_key
+    // should return 0 if that key is present (primary takes precedence).
+    const char *keys[] = { "SameKey" };
+    CHECK(match_request_key(keys, 1, "SameKey", "SameKey") == 0);
+}
+
+TEST_CASE("match_request_key: null entries in the key array are skipped") {
+    const char *keys[] = { nullptr, "email_address", nullptr };
+    CHECK(match_request_key(keys, 3, "email_address", "EmailAddress") == 0);
+}
+
+TEST_CASE("match_request_key: case-sensitive comparison") {
+    // snake_case != SNAKE_CASE
+    const char *keys[] = { "EMAIL_ADDRESS" };
+    CHECK(match_request_key(keys, 1, "email_address", "EmailAddress") == -1);
+}
+
+TEST_CASE("match_request_key: single-char key names") {
+    const char *keys[] = { "a", "B" };
+
+    SUBCASE("primary single char matches") {
+        CHECK(match_request_key(keys, 2, "a", "B") == 0);
+    }
+
+    SUBCASE("fallback single char matches") {
+        CHECK(match_request_key(keys, 2, "x", "B") == 1);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces libFuzzer-based fuzz-testing infrastructure for the Godot GDExtension addons and extends it to cover the addons' untrusted-input surfaces. The work spans the previously-built Phase 1–3 foundation plus this change's two new wrapped-API seams.

The change is **test/infrastructure-focused**. No public GDScript API was added or renamed — the production edits are SDK-free seam extractions of existing **private** C++ helpers, with behavior preserved at every call site (verified by review + doctest).

## What's included

**Foundation (Phases 1–3)**
- `Phase 1` — MSVC ASan build preset.
- `Phase 2` — clang-cl + libFuzzer preset (`fuzz` / `debug-fuzz`), the `godot_addon_fuzzer_target` helper, and the first pure-seam target (`playfab_fuzz_key_lookup`).
- `Phase 3` — a 176-function GDExtension **stub harness** (`tests/cpp/fuzz_harness/`) that lets `godot::String` / `Dictionary` / `Variant` / `Array` / `PackedByteArray` work in a standalone fuzz exe without a live Godot engine.
- Wrapped-API targets: `gdk_fuzz_result_formatting`, `gdk_fuzz_result_factories`, `playfab_fuzz_request_dictionary`.

**This change — two new untrusted-input seams + harness support**
- **PlayFab Party wire codec** (`addons/godot_playfab/src/playfab_party_codec.{h,cpp}`, namespace `pf_party_codec`): `build_*`/`parse_*`/`wrap_*`/`unwrap_*` extracted from `playfab_party.cpp`. The `parse_*`/`unwrap_*` paths decode untrusted peer bytes — the addon's primary attacker-controlled surface. New target `fuzz_playfab_party_codec` runs raw-decode + build/parse round-trip oracles.
- **GDK request-input parsing** (`addons/godot_gdk/src/gdk_request_parsing.{h,cpp}`, namespace `gdk_request_parsing`): `try_parse_xuid`, `parse_uint32`, `copy_utf8_to_buffer`, `to_packed_byte_array` / `to_byte_vector`, consumed via thin private forwarders in `gdk_title_storage.cpp`, `gdk_game_ui.cpp`, `gdk_profile.cpp`. New target `fuzz_gdk_request_parsing`.
- **Harness**: `PackedByteArray` support (heap `std::vector<uint8_t>*` backing) across `stub_packed_array.cpp` + `stub_variant.cpp`/`stub_types.h`/`godot_stub_init.cpp`; and a fixed off-by-one in `stub_str_to_utf8`/`stub_str_to_latin1` (godot-cpp `String::utf8()`/`ascii()` pass buffer size == content length and write their own NUL, so the stub must write all `out_len` content bytes).
- Docs: `spec/testing-strategy.md` fuzz-target inventory, seam list, and stub blob/source-layout tables.

## Behavior-preservation note (GDK XUID parsing)

The three GDK call sites historically diverged: `gdk_game_ui` rejected `XUID == 0`; `gdk_title_storage` and `gdk_profile` accepted it. The unified `try_parse_xuid(..., bool reject_zero)` preserves each: game-UI passes `reject_zero=true`, the other two pass `false`. An adversarial review caught an early version that added an extra post-UTF8 `'\0'` guard (changing the accept-zero callers on U+0000-prefixed input); the final seam drops that guard so all three call sites match their pre-refactor behavior exactly.

## Adversarial review

Ran a two-model (Claude + GPT family) review loop to convergence:
- **Consensus issue fixed**: the `try_parse_xuid` NUL-prefix divergence above. After the fix, both families confirmed all three call sites' behavior is restored and no new issues were introduced.
- **Disputed finding surfaced (not fixed — pre-existing, needs a product call)**: `copy_utf8_to_buffer` measures the value with `std::strlen`, so an embedded `U+0000` truncates the C-string field at the first NUL (an over-length `"prefix\0<suffix>"` passes the size check and is written as `"prefix"`). This behavior is unchanged from the original `_copy_utf8_to_buffer` (it always used `strlen`), so it is out of scope for this refactor. Decision needed: reject embedded NULs explicitly vs. keep `strlen` truncation. The new fuzz target masks `0x00→0x20`, so it does not currently exercise this path.

## Validation

- **Parse gate**: N/A — no `.gd` files touched.
- **Builds (rebased on `main`)**: `cmake --preset default` + `--build --preset debug` → all 3 addon DLLs (gdk / playfab / gameinput) clean; `cmake --preset fuzz` + `--build --preset debug-fuzz` → all 7 fuzz targets build.
- **Fuzz runs**: all 7 targets exit 0; the two new targets run 50,000 iterations clean.
- **Unit tests**: `gdk_unit_tests.exe` → 16/16 doctest cases pass.
- **Live coverage**: not applicable — this is compile/fuzz infrastructure; no live PlayFab/Xbox tests involved. The "GDK parts that need live state" are covered by extracting their SDK-free input-validation preambles, which fuzz without live state.
- Did **not** run the full `tools/run_all_tests.ps1` GUT hosts: the production change is a behavior-preserving private-helper extraction (no public API change), and the affected GDK GUT paths require live Xbox state.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
