### PR TITLE
fix(mp-orchestrator): accept optional reason in ClientProxy.disconnect_client

### DIFF
--- a/tests/godot/mp_orchestrator/scripts/client_proxy.gd
+++ b/tests/godot/mp_orchestrator/scripts/client_proxy.gd
@@ -182,12 +182,12 @@ func send_shutdown(reason: String) -> void:
 	_send_frame({ "kind": "shutdown", "reason": reason })
 
 
-func disconnect_client() -> void:
+func disconnect_client(reason: String = "orchestrator_initiated") -> void:
 	if _state == STATE_CLOSED:
 		return
 	if _peer != null and _peer.get_status() == StreamPeerTCP.STATUS_CONNECTED:
 		_peer.disconnect_from_host()
-	_close("orchestrator_initiated")
+	_close(reason)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a pre-existing runtime bug in the multiplayer test orchestrator: four chaos
scenarios call `ClientProxy.disconnect_client(<label>)` with a reason string, but the
method was declared with **zero parameters**. GDScript raised an arity error at runtime,
the scenario aborted before the client was actually killed, and the subsequent
`await _wait_*` calls timed out — failing the host-kill, guest-kill, party-host-kill, and
party-guest-kill scenarios.

This is orthogonal to the PR-gates / GDK-edition-matrix work (#120); it was surfaced by
a full-matrix live CI probe but exists on `main` independently.

## Change

`tests/godot/mp_orchestrator/scripts/client_proxy.gd`:

```gdscript
# before
func disconnect_client() -> void:
	...
	_close("orchestrator_initiated")

# after
func disconnect_client(reason: String = "orchestrator_initiated") -> void:
	...
	_close(reason)
```

`reason` is optional, so the six zero-arg callers in `test_orchestrator.gd` keep the
previous default. The four labeled callers in `scenarios/_base/lobby_flows.gd` and
`scenarios/_base/party_flows.gd` now thread their intended label into `_close(reason)`,
which records it as `_close_reason`.

## Validation

- Parse gate clean: `tools/check_gd_scripts_headless.ps1` (76 mp_orchestrator scripts checked, 0 errors).
- Full orchestrator validation requires the live PlayFab multiplayer tier (hosted runner); the arity
  error is a runtime call error that the headless parse gate does not catch, which is why it slipped
  through originally. The live nightly will exercise the four affected scenarios.

> Note: a separate `party_match.descriptor_via_arranged_lobby_property` failure observed in the same
> probe appears matchmaking-related and is **not** addressed here.
