### PR TITLE
Fix GDK export "unexpected error code 47" (#123)

### DIFF
--- a/addons/godot_gdk/editor/gdk_export_platform.gd
+++ b/addons/godot_gdk/editor/gdk_export_platform.gd
@@ -322,13 +322,11 @@ func _stage_logos(staging_dir: String) -> void:
 func _wdapp_register(staging_dir: String) -> int:
 	print("[GDK Export] Registering loose folder via wdapp...")
 	var global_path: String = ProjectSettings.globalize_path(staging_dir)
-	var output: Array = []
-	var exit_code: int = OS.execute(_wdapp, ["register", global_path], output, true)
-	for line: Variant in output:
-		print("[wdapp] ", line)
-	if exit_code != 0:
-		push_error("GDK Export: wdapp register failed (exit code %d)" % exit_code)
-		return ERR_BUG
+	var result: Dictionary = _run_tool_capture(_wdapp, PackedStringArray(["register", global_path]))
+	_print_tool_output("wdapp", result)
+	if int(result.get("exit_code", -1)) != 0:
+		push_error(_summarize_tool_failure("wdapp register", result))
+		return FAILED
 	print("[GDK Export] Registered successfully! Launch from Xbox app or Start menu.")
 	return OK
 
@@ -339,37 +337,164 @@ func _makepkg_pack(staging_dir: String, output_path: String, p_preset: EditorExp
 	# Step 1: genmap
 	print("[GDK Export] Generating file map...")
 	var layout_path: String = global_staging + "\\layout.xml"
-	var output1: Array = []
-	var exit1: int = OS.execute(_makepkg, [
+	var genmap_result: Dictionary = _run_tool_capture(_makepkg, PackedStringArray([
 		"genmap", "/f", layout_path, "/d", global_staging
-	], output1, true)
-	for line: Variant in output1:
-		print("[makepkg] ", line)
-	if exit1 != 0:
-		push_error("GDK Export: makepkg genmap failed")
-		return ERR_BUG
+	]))
+	_print_tool_output("makepkg", genmap_result)
+	if int(genmap_result.get("exit_code", -1)) != 0:
+		push_error(_summarize_tool_failure("makepkg genmap", genmap_result))
+		return FAILED
 
 	# Step 2: pack
 	print("[GDK Export] Packing MSIXVC...")
-	var output2: Array = []
-	var pack_args: Array = [
+	var pack_args: PackedStringArray = PackedStringArray([
 		"pack", "/f", layout_path, "/d", global_staging, "/pd", global_output.get_base_dir()
-	]
+	])
 
 	# Add EKB file if provided
 	var ekb: Variant = p_preset.get("packaging/ekb_file") if p_preset.has("packaging/ekb_file") else ""
 	if ekb != "":
-		pack_args.append_array(["/lk", ProjectSettings.globalize_path(ekb)])
+		pack_args.append("/lk")
+		pack_args.append(ProjectSettings.globalize_path(ekb))
 
-	var exit2 := OS.execute(_makepkg, pack_args, output2, true)
-	for line: Variant in output2:
-		print("[makepkg] ", line)
-	if exit2 != 0:
-		push_error("GDK Export: makepkg pack failed")
-		return ERR_BUG
+	var pack_result: Dictionary = _run_tool_capture(_makepkg, pack_args)
+	_print_tool_output("makepkg", pack_result)
+	if int(pack_result.get("exit_code", -1)) != 0:
+		push_error(_summarize_tool_failure("makepkg pack", pack_result))
+		return FAILED
 
 	print("[GDK Export] Package created: ", global_output)
 	return OK
+
+# ── GDK tool invocation + failure diagnostics ───────────────────
+
+# Runs a GDK CLI tool (makepkg / wdapp) capturing stdout and stderr on
+# SEPARATE pipes. These tools split their failure diagnostics across both
+# streams (e.g. makepkg `pack` prints "Failed with error (0x...)" to stdout
+# but "Mapfile ... does not exist." to stderr; `genmap` prints the
+# "error = 0x8007xxxx" line to stderr), so both must be captured to explain a
+# failure. Returns { "exit_code": int, "stdout": String, "stderr": String }.
+#
+# NOTE: the process exit code from these tools is NOT diagnostic — it is a
+# small value (often 2 or 3) that never corresponds to the real cause. The
+# actionable signal is the HRESULT embedded in the captured text; see
+# `_summarize_tool_failure` / `_extract_hresult`.
+func _run_tool_capture(exe_path: String, args: PackedStringArray) -> Dictionary:
+	if not FileAccess.file_exists(exe_path):
+		return {"exit_code": -1, "stdout": "", "stderr": "Tool not found: " + exe_path}
+
+	var pipes: Dictionary = OS.execute_with_pipe(exe_path, args, false)
+	if pipes.is_empty():
+		return {"exit_code": -1, "stdout": "", "stderr": "Failed to launch: " + exe_path}
+
+	var pid: int = int(pipes.get("pid", -1))
+	var stdout_pipe: FileAccess = pipes.get("stdio", null) as FileAccess
+	var stderr_pipe: FileAccess = pipes.get("stderr", null) as FileAccess
+	var stdout_text: String = ""
+	var stderr_text: String = ""
+
+	while pid >= 0 and OS.is_process_running(pid):
+		stdout_text += _drain_pipe_text(stdout_pipe)
+		stderr_text += _drain_pipe_text(stderr_pipe)
+		OS.delay_msec(10)
+	stdout_text += _drain_pipe_text(stdout_pipe)
+	stderr_text += _drain_pipe_text(stderr_pipe)
+
+	var exit_code: int = OS.get_process_exit_code(pid) if pid >= 0 else -1
+	if stdout_pipe != null:
+		stdout_pipe.close()
+	if stderr_pipe != null:
+		stderr_pipe.close()
+
+	return {"exit_code": exit_code, "stdout": stdout_text, "stderr": stderr_text}
+
+static func _drain_pipe_text(pipe: FileAccess) -> String:
+	if pipe == null or not pipe.is_open():
+		return ""
+	var bytes: PackedByteArray = PackedByteArray()
+	while true:
+		var chunk: PackedByteArray = pipe.get_buffer(4096)
+		if chunk.is_empty():
+			break
+		bytes.append_array(chunk)
+	return bytes.get_string_from_utf8()
+
+# Echoes a captured tool result to the editor console, tagging the stream so a
+# reader can tell stdout diagnostics from the stderr error line.
+static func _print_tool_output(tool_name: String, result: Dictionary) -> void:
+	for line: String in str(result.get("stdout", "")).split("\n"):
+		if line.strip_edges() != "":
+			print("[%s] %s" % [tool_name, line])
+	for line: String in str(result.get("stderr", "")).split("\n"):
+		if line.strip_edges() != "":
+			print("[%s:err] %s" % [tool_name, line])
+
+# Builds a human-readable failure summary from a captured tool result so the
+# editor's export dialog explains WHY the step failed instead of surfacing an
+# opaque engine error code. Extracts the HRESULT (the real signal) and echoes
+# the captured stdout+stderr tail.
+static func _summarize_tool_failure(step_label: String, result: Dictionary) -> String:
+	var stdout_text: String = str(result.get("stdout", ""))
+	var stderr_text: String = str(result.get("stderr", ""))
+	var combined: String = stdout_text
+	if stderr_text.strip_edges() != "":
+		combined += "\n" + stderr_text
+
+	var lines: Array[String] = []
+	lines.append("GDK Export: %s failed." % step_label)
+
+	var hresult: String = _extract_hresult(combined)
+	if hresult != "":
+		lines.append("  Error %s%s" % [hresult, _describe_hresult(hresult)])
+
+	var detail: String = combined.strip_edges()
+	if detail != "":
+		lines.append("  Tool output:")
+		for line: String in detail.split("\n"):
+			var trimmed: String = line.strip_edges()
+			if trimmed != "":
+				lines.append("    " + trimmed)
+	else:
+		lines.append("  (no output captured; process exit code %d)" % int(result.get("exit_code", -1)))
+
+	return "\n".join(lines)
+
+# Finds the first failure HRESULT (high-bit-set 8-hex value such as
+# 0x8007xxxx) in captured tool output. makepkg/wdapp print this as
+# "error = 0x8007xxxx" or "Failed with error (0x8007xxxx)". Returns "" when no
+# failure HRESULT is present. A successful 0x00000000 token is intentionally
+# ignored so it never masks a real failure code appearing later in the text.
+static func _extract_hresult(text: String) -> String:
+	var re: RegEx = RegEx.new()
+	re.compile("0[xX][0-9A-Fa-f]{8}")
+	for m: RegExMatch in re.search_all(text):
+		var token: String = m.get_string(0)
+		var normalized: String = "0x" + token.substr(2).to_upper()
+		if normalized.begins_with("0x8") or normalized.begins_with("0xC"):
+			return normalized
+	return ""
+
+# Decodes the most common FACILITY_WIN32 HRESULTs makepkg/wdapp surface into a
+# short actionable hint. Unknown codes return "" (the raw HRESULT + tool output
+# already carry the detail).
+static func _describe_hresult(hresult: String) -> String:
+	# Normalize to a lowercase "0x" prefix + upper-case hex digits so the match
+	# labels below are hit regardless of the caller's casing. (`to_upper()` on
+	# the whole string would uppercase the "x" and never match.)
+	var key: String = hresult.strip_edges()
+	if key.length() > 2:
+		key = "0x" + key.substr(2).to_upper()
+	match key:
+		"0x80070002":
+			return " (ERROR_FILE_NOT_FOUND — a referenced file is missing from the staging folder)"
+		"0x80070003":
+			return " (ERROR_PATH_NOT_FOUND — a referenced path is missing)"
+		"0x80070005":
+			return " (ERROR_ACCESS_DENIED — a file is locked or the tool needs elevation)"
+		"0x80070057":
+			return " (E_INVALIDARG — check MicrosoftGame.config, e.g. TargetDeviceFamily)"
+		_:
+			return ""
 
 # ── Helpers ─────────────────────────────────────────────────────
 

--- a/addons/godot_gdk/editor/gdk_export_platform.gd
+++ b/addons/godot_gdk/editor/gdk_export_platform.gd
@@ -5,6 +5,10 @@ extends EditorExportPlatformExtension
 const PLATFORM_NAME := "XBOX on PC"
 const OS_NAME := "Windows"
 
+# Max number of captured tool-output lines to embed in the export dialog error
+# summary. The full output is still printed to the editor Output panel.
+const _MAX_SUMMARY_OUTPUT_LINES := 12
+
 # GDK tool paths (resolved on init)
 var _gdk_root := ""
 var _makepkg := ""
@@ -420,19 +424,25 @@ static func _drain_pipe_text(pipe: FileAccess) -> String:
 	return bytes.get_string_from_utf8()
 
 # Echoes a captured tool result to the editor console, tagging the stream so a
-# reader can tell stdout diagnostics from the stderr error line.
+# reader can tell stdout diagnostics from the stderr error line. Lines are
+# trimmed because the tools emit CRLF and `split("\n")` would otherwise leave a
+# stray `\r` on every line.
 static func _print_tool_output(tool_name: String, result: Dictionary) -> void:
 	for line: String in str(result.get("stdout", "")).split("\n"):
-		if line.strip_edges() != "":
-			print("[%s] %s" % [tool_name, line])
+		var trimmed: String = line.strip_edges()
+		if trimmed != "":
+			print("[%s] %s" % [tool_name, trimmed])
 	for line: String in str(result.get("stderr", "")).split("\n"):
-		if line.strip_edges() != "":
-			print("[%s:err] %s" % [tool_name, line])
+		var trimmed: String = line.strip_edges()
+		if trimmed != "":
+			print("[%s:err] %s" % [tool_name, trimmed])
 
 # Builds a human-readable failure summary from a captured tool result so the
 # editor's export dialog explains WHY the step failed instead of surfacing an
 # opaque engine error code. Extracts the HRESULT (the real signal) and echoes
-# the captured stdout+stderr tail.
+# the TAIL of the captured stdout+stderr (last `_MAX_SUMMARY_OUTPUT_LINES`
+# non-empty lines) so the dialog stays readable — the full, untruncated output
+# is already sent to the editor Output panel by `_print_tool_output`.
 static func _summarize_tool_failure(step_label: String, result: Dictionary) -> String:
 	var stdout_text: String = str(result.get("stdout", ""))
 	var stderr_text: String = str(result.get("stderr", ""))
@@ -447,15 +457,24 @@ static func _summarize_tool_failure(step_label: String, result: Dictionary) -> S
 	if hresult != "":
 		lines.append("  Error %s%s" % [hresult, _describe_hresult(hresult)])
 
-	var detail: String = combined.strip_edges()
-	if detail != "":
-		lines.append("  Tool output:")
-		for line: String in detail.split("\n"):
-			var trimmed: String = line.strip_edges()
-			if trimmed != "":
-				lines.append("    " + trimmed)
-	else:
+	var detail_lines: Array[String] = []
+	for line: String in combined.split("\n"):
+		var trimmed: String = line.strip_edges()
+		if trimmed != "":
+			detail_lines.append(trimmed)
+
+	if detail_lines.is_empty():
 		lines.append("  (no output captured; process exit code %d)" % int(result.get("exit_code", -1)))
+		return "\n".join(lines)
+
+	var total: int = detail_lines.size()
+	if total > _MAX_SUMMARY_OUTPUT_LINES:
+		detail_lines = detail_lines.slice(total - _MAX_SUMMARY_OUTPUT_LINES)
+		lines.append("  Tool output (last %d of %d lines; see Output panel for full log):" % [_MAX_SUMMARY_OUTPUT_LINES, total])
+	else:
+		lines.append("  Tool output:")
+	for line: String in detail_lines:
+		lines.append("    " + line)
 
 	return "\n".join(lines)
 

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -69,6 +69,28 @@ automation. The export platform exists for editor-driven workflows; the
 headless runner exists for CI and scripted automation. Keep both paths
 working when the underlying packaging primitives change.
 
+### Export failure diagnostics
+
+The final export step shells out to a GDK tool — `wdapp register` when
+**Dev Iteration ▸ Register Loose** is enabled, otherwise `makepkg genmap`
++ `makepkg pack`. These tools do **not** report a meaningful process exit
+code (it is usually a small value such as `2` or `3`); the real cause is an
+HRESULT (`error = 0x8007xxxx`, a `FACILITY_WIN32` code) that they print
+across **both** stdout and stderr, depending on the sub-command.
+
+`gdk_export_platform.gd` captures both streams (via `OS.execute_with_pipe`),
+echoes them to the editor Output panel tagged by stream, extracts the
+HRESULT, and includes it — with a short hint for the common codes
+(`0x80070002` file not found, `0x80070003` path not found, `0x80070005`
+access denied, `0x80070057` invalid config) — in the error surfaced by the
+export dialog.
+
+A failed tool step returns `FAILED`, **not** `ERR_BUG`. Returning `ERR_BUG`
+(Godot `Error` value `47`) is what produced the opaque *"unexpected error
+code 47"* reported in issue #123; the packaging step never actually
+"hit a bug" — the underlying tool failed for a reportable reason, so the
+diagnostic must carry that reason instead of an internal error code.
+
 ## `godot_gdk_editortools`
 
 The active editor tooling for Microsoft GDK packaging now lives in

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -79,11 +79,13 @@ HRESULT (`error = 0x8007xxxx`, a `FACILITY_WIN32` code) that they print
 across **both** stdout and stderr, depending on the sub-command.
 
 `gdk_export_platform.gd` captures both streams (via `OS.execute_with_pipe`),
-echoes them to the editor Output panel tagged by stream, extracts the
-HRESULT, and includes it — with a short hint for the common codes
-(`0x80070002` file not found, `0x80070003` path not found, `0x80070005`
-access denied, `0x80070057` invalid config) — in the error surfaced by the
-export dialog.
+echoes the **full** output to the editor Output panel tagged by stream,
+extracts the HRESULT, and surfaces it — with a short hint for the common
+codes (`0x80070002` file not found, `0x80070003` path not found,
+`0x80070005` access denied, `0x80070057` invalid config) plus the **tail**
+of the captured output — in the error shown by the export dialog. The dialog
+text is capped to the last handful of lines so a large tool log stays
+readable; the full log remains in the Output panel.
 
 A failed tool step returns `FAILED`, **not** `ERR_BUG`. Returning `ERR_BUG`
 (Godot `Error` value `47`) is what produced the opaque *"unexpected error

--- a/tests/godot/gdk/tests/test_export_platform_errors.gd
+++ b/tests/godot/gdk/tests/test_export_platform_errors.gd
@@ -1,0 +1,106 @@
+extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
+## GUT coverage for the GDK export platform's tool-failure diagnostics
+## (`addons/godot_gdk/editor/gdk_export_platform.gd`).
+##
+## Regression pin for issue #123 ("Export error code 47"): when a Register
+## Loose / MSIXVC export step fails, the platform used to return `ERR_BUG`
+## (Godot Error value 47), which the export dialog surfaced as an opaque
+## "unexpected error code 47" while the real cause stayed buried in the
+## console. It now captures both stdout and stderr and surfaces the real
+## makepkg/wdapp HRESULT.
+##
+## The platform script `extends EditorExportPlatformExtension`, which cannot be
+## instantiated outside the editor process, so the diagnostic logic lives in
+## static functions we exercise directly, and the return-code regression is
+## pinned by source inspection.
+
+const ExportPlatform := preload("res://addons/godot_gdk/editor/gdk_export_platform.gd")
+const SCRIPT_PATH := "res://addons/godot_gdk/editor/gdk_export_platform.gd"
+
+# Real strings captured from GDK 260400 makepkg.exe on failure.
+const GENMAP_STDERR := "'C:\\out\\layout.xml' map file was not created, error = 0x80070003"
+const GENMAP_STDOUT := "Failed to traverse path 'C:\\out\\does_not_exist'."
+const PACK_STDOUT := "Failed with error (0x80070002): The system cannot find the file specified.\nPackage was not created, error = 0x80070002. See the full output for additional information."
+const PACK_STDERR := "Mapfile 'C:\\out\\nope_layout.xml' does not exist."
+
+
+# ── HRESULT extraction ────────────────────────────────────────────────────
+
+func test_extract_hresult_from_genmap_stderr() -> void:
+	assert_eq(ExportPlatform._extract_hresult(GENMAP_STDERR), "0x80070003",
+		"genmap stderr HRESULT extracted")
+
+
+func test_extract_hresult_from_pack_stdout() -> void:
+	assert_eq(ExportPlatform._extract_hresult(PACK_STDOUT), "0x80070002",
+		"pack stdout HRESULT extracted")
+
+
+func test_extract_hresult_ignores_success_zero() -> void:
+	# 0x00000000 is a success token and must never be reported as the failure.
+	assert_eq(ExportPlatform._extract_hresult("done, error = 0x00000000"), "",
+		"success HRESULT (0x00000000) is not treated as a failure code")
+
+
+func test_extract_hresult_prefers_failure_code_after_success() -> void:
+	var text := "first 0x00000000 then error = 0x80070005"
+	assert_eq(ExportPlatform._extract_hresult(text), "0x80070005",
+		"a trailing failure HRESULT wins over a leading success token")
+
+
+func test_extract_hresult_none_present() -> void:
+	assert_eq(ExportPlatform._extract_hresult("everything is fine"), "",
+		"plain text yields no HRESULT")
+
+
+# ── HRESULT descriptions ──────────────────────────────────────────────────
+
+func test_describe_known_hresults() -> void:
+	assert_string_contains(ExportPlatform._describe_hresult("0x80070002"), "ERROR_FILE_NOT_FOUND")
+	assert_string_contains(ExportPlatform._describe_hresult("0x80070003"), "ERROR_PATH_NOT_FOUND")
+	assert_string_contains(ExportPlatform._describe_hresult("0x80070005"), "ERROR_ACCESS_DENIED")
+	assert_string_contains(ExportPlatform._describe_hresult("0x80070057"), "E_INVALIDARG")
+
+
+func test_describe_unknown_hresult_is_empty() -> void:
+	assert_eq(ExportPlatform._describe_hresult("0x8000FFFF"), "",
+		"unknown HRESULT returns no description")
+
+
+# ── Failure summary ───────────────────────────────────────────────────────
+
+func test_summary_surfaces_hresult_and_output() -> void:
+	var result := {"exit_code": 3, "stdout": GENMAP_STDOUT, "stderr": GENMAP_STDERR}
+	var summary: String = ExportPlatform._summarize_tool_failure("makepkg genmap", result)
+	assert_string_contains(summary, "makepkg genmap failed")
+	assert_string_contains(summary, "0x80070003")
+	assert_string_contains(summary, "ERROR_PATH_NOT_FOUND")
+	# Both stream contents must be echoed so the real cause is visible.
+	assert_string_contains(summary, "Failed to traverse path")
+	assert_string_contains(summary, "map file was not created")
+
+
+func test_summary_handles_pack_split_streams() -> void:
+	var result := {"exit_code": 3, "stdout": PACK_STDOUT, "stderr": PACK_STDERR}
+	var summary: String = ExportPlatform._summarize_tool_failure("makepkg pack", result)
+	assert_string_contains(summary, "0x80070002")
+	assert_string_contains(summary, "Mapfile")
+	assert_string_contains(summary, "The system cannot find the file specified")
+
+
+func test_summary_without_output_reports_exit_code() -> void:
+	var result := {"exit_code": 9, "stdout": "", "stderr": ""}
+	var summary: String = ExportPlatform._summarize_tool_failure("wdapp register", result)
+	assert_string_contains(summary, "wdapp register failed")
+	assert_string_contains(summary, "9")
+
+
+# ── Return-code regression (issue #123) ───────────────────────────────────
+
+func test_tool_steps_no_longer_return_err_bug() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	assert_ne(src, "", "export platform source is readable")
+	assert_false(src.contains("return ERR_BUG"),
+		"tool-failure paths must not return ERR_BUG (Godot error 47) — issue #123")
+	assert_true(src.contains("return FAILED"),
+		"tool-failure paths return FAILED so the dialog shows a real error")

--- a/tests/godot/gdk/tests/test_export_platform_errors.gd
+++ b/tests/godot/gdk/tests/test_export_platform_errors.gd
@@ -95,6 +95,27 @@ func test_summary_without_output_reports_exit_code() -> void:
 	assert_string_contains(summary, "9")
 
 
+func test_summary_caps_long_output_to_tail() -> void:
+	# 40 lines of stdout should be truncated to the tail in the dialog summary,
+	# with the HRESULT (on the last line) and a truncation notice preserved.
+	var many: Array[String] = []
+	for i in range(39):
+		many.append("noise line %d" % i)
+	many.append("Package was not created, error = 0x80070002.")
+	var result := {"exit_code": 3, "stdout": "\n".join(many), "stderr": ""}
+	var summary: String = ExportPlatform._summarize_tool_failure("makepkg pack", result)
+
+	# The HRESULT must survive truncation.
+	assert_string_contains(summary, "0x80070002")
+	# A truncation notice referencing the full line count is shown.
+	assert_string_contains(summary, "last 12 of 40 lines")
+	# Early noise lines are dropped; the final line is retained.
+	assert_false(summary.contains("noise line 0"), "leading lines are truncated")
+	assert_string_contains(summary, "Package was not created")
+	# The embedded output is bounded (well under the 40 source lines).
+	assert_true(summary.split("\n").size() <= 16, "summary stays compact")
+
+
 # ── Return-code regression (issue #123) ───────────────────────────────────
 
 func test_tool_steps_no_longer_return_err_bug() -> void:


### PR DESCRIPTION
## Summary

Fixes #123 — exporting with **Register Loose** enabled (and MSIXVC export) failed with an opaque *"unexpected error code 47"*.

**47 is Godot's `ERR_BUG`.** `gdk_export_platform.gd` returned `ERR_BUG` from `_wdapp_register` / `_makepkg_pack` whenever the underlying GDK tool failed, so the export dialog showed the raw `47` while the real cause stayed buried in the console.

## Root cause

`makepkg` / `wdapp` do **not** report a meaningful process exit code (usually a small value like `2` or `3`). The actionable signal is an HRESULT (`error = 0x8007xxxx`, a `FACILITY_WIN32` code) that these tools print across **both** stdout and stderr depending on the sub-command. Verified locally against GDK 260400:

| Case | exit | where the HRESULT lands |
|---|---|---|
| `makepkg genmap` missing dir | 3 | **stderr**: `... map file was not created, error = 0x80070003` |
| `makepkg pack` missing map | 3 | **stdout**: `Failed with error (0x80070002): The system cannot find the file specified.` |

The old code used merged `OS.execute(..., output, true)` and collapsed all failures to `ERR_BUG`.

## Changes

- **`addons/godot_gdk/editor/gdk_export_platform.gd`**
  - Capture stdout and stderr on **separate pipes** via `OS.execute_with_pipe` (new `_run_tool_capture`).
  - Extract the failure HRESULT (`_extract_hresult`) and add a short hint for common codes (`_describe_hresult`: `0x80070002/3/5`, `0x80070057`); echo the captured output tail.
  - Return **`FAILED`** instead of `ERR_BUG` so the export dialog shows a real, reportable error.
- **`tests/godot/gdk/tests/test_export_platform_errors.gd`** (new) — 11 GUT tests over the diagnostic helpers using real makepkg output strings, plus a regression pin that `ERR_BUG` is no longer returned.
- **`docs/gdk/editor-tools.md`** — new "Export failure diagnostics" note.

## Validation

- Parse gate (`tools/check_gd_scripts_headless.ps1`): **clean**.
- `cmake --build build --preset debug`: succeeded (re-syncs addon into the GDK test host).
- New suite: **11/11 pass**. Full GDK GUT host (`tests/godot/gdk`): **270 tests, 237 passing, 0 failing**, 33 pending (expected no-signed-in-user skips).
- Live tests: **not run** (offline tier; no live/sandbox state touched).

No public GDScript API changed (editor-only diagnostics), so no `doc_classes` / usage-snippet updates were required.
