### PR TITLE
Fix #125: gate MicrosoftGame.config picker check to the editor

### DIFF
--- a/sample/tutorial_gdk/shared/tutorial_picker.gd
+++ b/sample/tutorial_gdk/shared/tutorial_picker.gd
@@ -77,9 +77,17 @@ func _detect_config_problems() -> Array:
 	var problems: Array = []
 
 	# MicrosoftGame.config — either missing entirely or still has template
-	# placeholder values. GDK initialize loads this file at startup; with
-	# FFFFFFFF / 9NXX / 00000000 placeholders, sign-in fails with an opaque
-	# GDK error.
+	# placeholder values. This is a development-time (editor) check only:
+	# in the editor / dev run the GDK runtime loads this file explicitly
+	# (XGameRuntimeInitializeWithOptions), so a missing or placeholder config
+	# makes sign-in fail with an opaque GDK error. In an exported build the
+	# config source is stripped from the PCK and the runtime instead gets
+	# identity from the package (XGameRuntimeInitialize, no options), so
+	# res://MicrosoftGame.config is expected to be absent — skip the check
+	# there to avoid a false "missing" report (issue #125).
+	if not OS.has_feature("editor"):
+		return problems
+
 	var config_path := "res://MicrosoftGame.config"
 	if not FileAccess.file_exists(config_path):
 		problems.append({

--- a/sample/tutorial_integrated/shared/tutorial_picker.gd
+++ b/sample/tutorial_integrated/shared/tutorial_picker.gd
@@ -100,9 +100,17 @@ func _detect_config_problems() -> Array:
 		})
 
 	# 2. MicrosoftGame.config — either missing entirely or still has
-	#    template placeholder values. GDK initialize loads this file at
-	#    startup; with FFFFFFFF / 9NXX / 00000000 placeholders, sign-in
-	#    fails with an opaque GDK error.
+	#    template placeholder values. This is a development-time (editor)
+	#    check only: in the editor / dev run the GDK runtime loads this file
+	#    explicitly (XGameRuntimeInitializeWithOptions), so a missing or
+	#    placeholder config makes sign-in fail with an opaque GDK error. In an
+	#    exported build the config source is stripped from the PCK and the
+	#    runtime instead gets identity from the package (XGameRuntimeInitialize,
+	#    no options), so res://MicrosoftGame.config is expected to be absent —
+	#    skip the check there to avoid a false "missing" report (issue #125).
+	if not OS.has_feature("editor"):
+		return problems
+
 	var config_path := "res://MicrosoftGame.config"
 	if not FileAccess.file_exists(config_path):
 		problems.append({


### PR DESCRIPTION
## Fixes #125

### Root cause (reproduced)
The tutorial pickers gated startup diagnostics on `FileAccess.file_exists("res://MicrosoftGame.config")`. The editortools `gdk_packaging.config_file` import plugin imports `MicrosoftGame.config` (to make `.config`/`.cfg` visible in the FileSystem dock). **Once Godot imports a file, it strips the source from exported PCKs** — only the generated `.import` + dummy `.res` ship. So in an **exported/packaged build**, `res://MicrosoftGame.config` never exists at runtime, and the picker reported *"MicrosoftGame.config is missing"* even after the developer authored the config or ran `setup_sample.ps1`.

### Why this is only a picker (diagnostic) bug — the runtime is already correct
`addons/godot_gdk/src/gdk_runtime.cpp` already implements the intended editor-vs-build split:
- **Editor / dev run:** `res://MicrosoftGame.config` resolves to a real on-disk path -> `XGameRuntimeInitializeWithOptions(File, <path>)` (the runtime loads the config explicitly).
- **Exported/packaged build:** the source is stripped, the path does not resolve -> `XGameRuntimeInitialize()` with no options; identity comes from the registered package. The runtime **never reads** the res:// config in a build.

`_resolve_game_config_path()` even uses `GetFileAttributesExW` (not `FileAccess`) *"so a config that lives inside a packed .pck is not mistaken for a real file."* So the config's absence in a build is **expected**, not an error.

### Fix
Gate the picker's `MicrosoftGame.config` missing/placeholder diagnostics behind `OS.has_feature("editor")`, so they run only where the config is actually consumed (editor / dev run). In exported builds the check is skipped, so no more false "missing". The PlayFab title-id check (a baked-in project setting, valid in builds) still runs.

```gdscript
# MicrosoftGame.config diagnostics are a development-time (editor) check only.
if not OS.has_feature("editor"):
    return problems

var config_path := "res://MicrosoftGame.config"
if not FileAccess.file_exists(config_path):
    ...  # "MicrosoftGame.config is missing." (editor only now)
```

Both tracks that ship a `MicrosoftGame.config` (`tutorial_gdk`, `tutorial_integrated`) get the same guard. **No runtime/addon code changes** — this supersedes the earlier exe-dir-probing approach, which incorrectly reintroduced a loose-file dependency the runtime intentionally does not have.

### Validation
- `tools/check_gd_scripts_headless.ps1` passed on `tutorial_gdk` + `tutorial_integrated` (24 scripts).
- **Ran a real Windows export template** of the fixed picker's `_detect_config_problems()` (no config present) and compared contexts:
  - Editor / dev run -> `editor=true  game_config_problem=true`  (still catches a genuinely missing config)
  - **Exported template build -> `editor=false game_config_problem=false`**  (the false "missing" is gone; only the unrelated PlayFab title-id item remains)
- Scope is sample picker code only, so no public addon API change and no doc_classes/spec/docs drift.

> Narrowed validation (parse gate + a focused exported-build probe of the changed function) rather than the full `run_all_tests.ps1`, since the change touches only two sample `.gd` files and no addon C++/GUT-testable surface.
