### PR TITLE
Fix #126: compile in the GDK/PlayFab async frame-callback auto-pump

### DIFF
--- a/addons/godot_gdk/src/register_types.cpp
+++ b/addons/godot_gdk/src/register_types.cpp
@@ -5,6 +5,7 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <gdextension_interface.h>
 #include <godot_cpp/godot.hpp>
+#include <godot_cpp/core/version.hpp>
 
 #include "gdk_achievement.h"
 #include "gdk_accessibility.h"
@@ -194,7 +195,15 @@ GDExtensionBool GDE_EXPORT gdk_addon_init(
 #if GODOT_VERSION_MINOR >= 5
     init_obj.register_frame_callback(gdk_frame_callback);
 #endif
-    init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+    // The per-frame dispatch pump is registered with the engine only during
+    // CORE-level init (godot-cpp's register_main_loop_callbacks). On editor
+    // hot-reload the engine re-initializes an extension from its declared minimum
+    // level upward, so a SCENE minimum would skip CORE and silently drop the pump,
+    // leaving every await *_async() hung with no notice. Declaring CORE instead makes
+    // the engine return LOAD_STATUS_NEEDS_RESTART on reload (an explicit "restart
+    // required" prompt); cold start/export are unaffected (first load always inits
+    // from CORE regardless of this minimum).
+    init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_CORE);
 
     return init_obj.init();
 }

--- a/addons/godot_playfab/doc_classes/PlayFab.xml
+++ b/addons/godot_playfab/doc_classes/PlayFab.xml
@@ -39,6 +39,18 @@
 				Manually pumps the PlayFab async task queue. Use this when [code]playfab/runtime/embed_dispatch[/code] is disabled or when deterministic completion timing is required. Returns the number of completion work items processed during that call.
 			</description>
 		</method>
+		<method name="submit_dispatch_probe">
+			<return type="bool" />
+			<description>
+				Diagnostics hook. Enqueues a no-op callback on the internal async task queue's completion port and returns [code]true[/code] when the callback was accepted (requires the runtime to be initialized). The callback increments the counter reported by [method get_dispatch_probe_count] only when the completion port is drained, either by the per-frame auto-pump (when [code]playfab/runtime/embed_dispatch[/code] is enabled) or by an explicit [method dispatch] call. Used by the test suite to verify the auto-pump is wired without requiring a signed-in user or a network round-trip; not intended for gameplay code.
+			</description>
+		</method>
+		<method name="get_dispatch_probe_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Diagnostics hook. Returns the running total of completion-port probes submitted via [method submit_dispatch_probe] that have since been drained by a dispatch of the task queue. The count is monotonic for the lifetime of the runtime; compare deltas across frames to confirm the auto-pump is draining the completion port. Not intended for gameplay code.
+			</description>
+		</method>
 		<method name="get_users" qualifiers="const">
 			<return type="PlayFabUsers" />
 			<description>

--- a/addons/godot_playfab/src/playfab.cpp
+++ b/addons/godot_playfab/src/playfab.cpp
@@ -149,6 +149,8 @@ void PlayFab::_bind_methods() {
     ClassDB::bind_method(D_METHOD("is_available"), &PlayFab::is_available);
     ClassDB::bind_method(D_METHOD("is_initialized"), &PlayFab::is_initialized);
     ClassDB::bind_method(D_METHOD("dispatch"), &PlayFab::dispatch);
+    ClassDB::bind_method(D_METHOD("submit_dispatch_probe"), &PlayFab::submit_dispatch_probe);
+    ClassDB::bind_method(D_METHOD("get_dispatch_probe_count"), &PlayFab::get_dispatch_probe_count);
     ClassDB::bind_method(D_METHOD("get_users"), &PlayFab::get_users);
     ClassDB::bind_method(D_METHOD("get_game_saves"), &PlayFab::get_game_saves);
     ClassDB::bind_method(D_METHOD("get_leaderboards"), &PlayFab::get_leaderboards);
@@ -294,6 +296,14 @@ int64_t PlayFab::dispatch() {
         dispatched += static_cast<int64_t>(m_party->dispatch());
     }
     return dispatched;
+}
+
+bool PlayFab::submit_dispatch_probe() {
+    return m_runtime != nullptr ? m_runtime->submit_dispatch_probe() : false;
+}
+
+int64_t PlayFab::get_dispatch_probe_count() const {
+    return m_runtime != nullptr ? static_cast<int64_t>(m_runtime->get_dispatch_probe_count()) : 0;
 }
 
 Ref<PlayFabUsers> PlayFab::get_users() const {

--- a/addons/godot_playfab/src/playfab.h
+++ b/addons/godot_playfab/src/playfab.h
@@ -82,6 +82,8 @@ public:
     bool is_available() const;
     bool is_initialized() const;
     int64_t dispatch();
+    bool submit_dispatch_probe();
+    int64_t get_dispatch_probe_count() const;
     Ref<PlayFabUsers> get_users() const;
     Ref<PlayFabGameSaves> get_game_saves() const;
     Ref<PlayFabLeaderboards> get_leaderboards() const;

--- a/addons/godot_playfab/src/playfab_runtime.cpp
+++ b/addons/godot_playfab/src/playfab_runtime.cpp
@@ -371,6 +371,41 @@ int PlayFabRuntime::dispatch() {
     return dispatched;
 }
 
+void CALLBACK PlayFabRuntime::_dispatch_probe_completed(void *p_context, bool p_cancelled) {
+    // Runs on the thread that dispatches the Completion port (the Godot main
+    // thread, via the frame-callback auto-pump or a manual PlayFab.dispatch()).
+    // A cancelled invocation means the queue was terminating, not that the
+    // pump drained the port, so it must not count toward the probe.
+    if (p_cancelled || p_context == nullptr) {
+        return;
+    }
+
+    PlayFabRuntime *runtime = static_cast<PlayFabRuntime *>(p_context);
+    runtime->m_dispatch_probe_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+bool PlayFabRuntime::submit_dispatch_probe() {
+    // Diagnostics/test hook: enqueue a no-op callback on the shared task queue's
+    // Completion port so callers can verify the per-frame auto-pump actually
+    // drains that port -- without a network round-trip or a signed-in user.
+    // The callback only runs when the Completion port is dispatched, i.e. by
+    // PlayFab.dispatch() (manual) or the extension frame callback (auto).
+    if (!m_initialized || m_task_queue == nullptr) {
+        return false;
+    }
+
+    HRESULT hr = XTaskQueueSubmitCallback(
+            m_task_queue,
+            XTaskQueuePort::Completion,
+            this,
+            &PlayFabRuntime::_dispatch_probe_completed);
+    return SUCCEEDED(hr);
+}
+
+uint64_t PlayFabRuntime::get_dispatch_probe_count() const {
+    return m_dispatch_probe_count.load(std::memory_order_relaxed);
+}
+
 bool PlayFabRuntime::is_initialized() const {
     return m_initialized;
 }

--- a/addons/godot_playfab/src/playfab_runtime.h
+++ b/addons/godot_playfab/src/playfab_runtime.h
@@ -6,6 +6,7 @@
 #endif
 #include <windows.h>
 
+#include <atomic>
 #include <vector>
 
 #include <godot_cpp/classes/ref.hpp>
@@ -33,8 +34,10 @@ class PlayFabRuntime {
     String m_title_id;
     String m_endpoint;
     std::vector<Ref<PlayFabPendingSignal>> m_active_pending_signals;
+    std::atomic<uint64_t> m_dispatch_probe_count{0};
 
     static void CALLBACK _queue_terminated(void *p_context);
+    static void CALLBACK _dispatch_probe_completed(void *p_context, bool p_cancelled);
 
 public:
     PlayFabRuntime();
@@ -43,6 +46,8 @@ public:
     Ref<PlayFabResult> initialize();
     void shutdown();
     int dispatch();
+    bool submit_dispatch_probe();
+    uint64_t get_dispatch_probe_count() const;
 
     bool is_initialized() const;
     bool is_shutting_down() const;

--- a/addons/godot_playfab/src/register_types.cpp
+++ b/addons/godot_playfab/src/register_types.cpp
@@ -4,6 +4,7 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/core/version.hpp>
 #include <godot_cpp/godot.hpp>
 
 #include "playfab.h"
@@ -227,7 +228,15 @@ GDExtensionBool GDE_EXPORT playfab_addon_init(
 #if GODOT_VERSION_MINOR >= 5
     init_obj.register_frame_callback(playfab_frame_callback);
 #endif
-    init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+    // The per-frame dispatch pump is registered with the engine only during
+    // CORE-level init (godot-cpp's register_main_loop_callbacks). On editor
+    // hot-reload the engine re-initializes an extension from its declared minimum
+    // level upward, so a SCENE minimum would skip CORE and silently drop the pump,
+    // leaving every await *_async() hung with no notice. Declaring CORE instead makes
+    // the engine return LOAD_STATUS_NEEDS_RESTART on reload (an explicit "restart
+    // required" prompt); cold start/export are unaffected (first load always inits
+    // from CORE regardless of this minimum).
+    init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_CORE);
 
     return init_obj.init();
 }

--- a/spec/gdext-playfab.md
+++ b/spec/gdext-playfab.md
@@ -97,6 +97,7 @@ Rules:
 6. When embed dispatch is disabled, callers must pump the queue manually with `PlayFab.dispatch()`.
 7. `PlayFab.dispatch()` pumps the shared PlayFab runtime queue, PlayFab Multiplayer lobby/matchmaking state changes, and PlayFab Party state changes, then returns the number of completion work items processed.
 8. Shutdown cancels outstanding Party and Multiplayer completion signals before native SDK teardown, rejects new Party/Multiplayer work while shutdown is in progress, defers native teardown until any active SDK state-change batch has been finished, and only frees native async context storage after `PartyManager::Cleanup()` / `PFMultiplayerUninitialize()` has returned.
+9. `PlayFab.submit_dispatch_probe()` and `PlayFab.get_dispatch_probe_count()` are offline, identity-free diagnostics hooks (test-only, not for gameplay code). `submit_dispatch_probe()` enqueues a no-op callback on the runtime's completion port; `get_dispatch_probe_count()` reports how many such probes have since been drained. The GUT suite uses them to assert the rule 5 frame-callback auto-pump actually drains the completion port in the offline PR gate — the coverage gap that let issue #126 (a silently compiled-out auto-pump, from a missing `GODOT_VERSION_MINOR` include) ship.
 
 For Multiplayer lobbies, successful local `PlayFabLobby.set_member_properties_async()` writes update the local member snapshot eagerly before the completion signal settles; remote member-property changes continue to arrive through SDK-driven `MEMBER_UPDATED` state changes.
 

--- a/tests/godot/gdk/tests/test_core.gd
+++ b/tests/godot/gdk/tests/test_core.gd
@@ -222,36 +222,14 @@ func test_embed_dispatch_behavior() -> void:
 	var gdk = get_gdk()
 	var original_embed_dispatch: bool = get_embed_dispatch_enabled()
 
-	set_embed_dispatch_enabled(true)
-	var auto_init_result = initialize_runtime()
-	assert_not_null(auto_init_result, "initialize() returns GDKResult for auto-dispatch coverage")
-	if auto_init_result == null:
-		set_embed_dispatch_enabled(original_embed_dispatch)
-		return
-	if not auto_init_result.ok:
-		pending("Auto-dispatch behavior: %s" % auto_init_result.message)
-		set_embed_dispatch_enabled(original_embed_dispatch)
-		return
-
-	var auto_signal = gdk.users.add_default_user_async()
-	assert_true(typeof(auto_signal) == TYPE_SIGNAL, "add_default_user_async() returns Signal for auto-dispatch coverage")
-	if typeof(auto_signal) != TYPE_SIGNAL:
-		reset_runtime()
-		set_embed_dispatch_enabled(original_embed_dispatch)
-		return
-
-	var auto_state = track_signal(auto_signal)
-	if auto_state["completed"]:
-		pending("Auto-dispatch behavior: The default-user op completed synchronously before frame-based coverage could run.")
-	else:
-		var auto_result = await await_completion_state_no_dispatch(auto_state, 8000)
-		if auto_result == null:
-			pending("Auto-dispatch behavior: Timed out waiting for add_default_user_async() without manual GDK.dispatch().")
-		else:
-			assert_true(true, "Auto-dispatch behavior — completed without manual GDK.dispatch()")
-
-	reset_runtime()
-
+	# ── Manual-dispatch control (embed_dispatch=false) ───────────────────────
+	# First establish whether add_default_user_async() resolves at all on this
+	# host when GDK.dispatch() is pumped by hand. A signed-in Xbox identity is
+	# NOT required — the op completes with a failure result on identity-less
+	# machines — but if it does not resolve even under a manual pump we cannot
+	# make any claim about the frame-callback auto-pump and must report pending
+	# rather than fail (e.g. a hosted CI runner where the silent add never
+	# posts a completion).
 	set_embed_dispatch_enabled(false)
 	var manual_init_result = initialize_runtime()
 	assert_not_null(manual_init_result, "initialize() returns GDKResult for manual-dispatch coverage")
@@ -271,19 +249,66 @@ func test_embed_dispatch_behavior() -> void:
 		return
 
 	var manual_state = track_signal(manual_signal)
+	var manual_resolved: Variant = null
 	if manual_state["completed"]:
-		pending("Manual-dispatch fallback: The default-user op completed synchronously before disabled-mode coverage could run.")
+		manual_resolved = manual_state["result"]
 	else:
 		var advanced_frames = await advance_process_frames(5)
 		if not advanced_frames:
 			pending("Manual-dispatch fallback: The headless runner could not access process_frame for disabled-mode coverage.")
-		else:
-			assert_eq(manual_state["completed"], false, "embed_dispatch disabled keeps async completion pending")
+			reset_runtime()
+			set_embed_dispatch_enabled(original_embed_dispatch)
+			return
+		# With embed_dispatch=false and no manual pump yet, the completion must
+		# still be pending — proving the disabled path does not auto-pump.
+		assert_eq(manual_state["completed"], false, "embed_dispatch=false keeps async completion pending until GDK.dispatch() is pumped")
+		manual_resolved = await await_completion_state(manual_state, 8000)
 
-			var manual_result = await await_completion_state(manual_state, 8000)
-			if manual_result == null:
-				pending("Manual-dispatch fallback completion: Timed out waiting for completion after manual GDK.dispatch().")
-			else:
-				assert_true(true, "Manual-dispatch fallback completion — completed after manual GDK.dispatch()")
+	reset_runtime()
 
+	if manual_resolved == null:
+		# The op never resolved even under a manual pump (e.g. no Xbox identity
+		# and the silent add stays pending on this host). We cannot assess the
+		# auto-pump, so do not fail CI on an environment limitation.
+		pending("Auto-pump regression guard: add_default_user_async() did not resolve under manual GDK.dispatch() on this host; cannot assess the frame-callback pump.")
+		set_embed_dispatch_enabled(original_embed_dispatch)
+		return
+
+	# ── Auto-dispatch subject (embed_dispatch=true) ──────────────────────────
+	# The control above proved the op resolves on this host. Now verify the
+	# frame-callback auto-pump drains the SAME completion with NO manual
+	# GDK.dispatch(). A timeout here is a real regression (issue #126: the
+	# per-frame pump was silently compiled out via a missing GODOT_VERSION_MINOR
+	# include), so it is a hard failure — not a pending — because we have
+	# positive evidence the op resolves.
+	set_embed_dispatch_enabled(true)
+	var auto_init_result = initialize_runtime()
+	assert_not_null(auto_init_result, "initialize() returns GDKResult for auto-dispatch coverage")
+	if auto_init_result == null:
+		set_embed_dispatch_enabled(original_embed_dispatch)
+		return
+	if not auto_init_result.ok:
+		pending("Auto-dispatch behavior: %s" % auto_init_result.message)
+		set_embed_dispatch_enabled(original_embed_dispatch)
+		return
+
+	var auto_signal = gdk.users.add_default_user_async()
+	assert_true(typeof(auto_signal) == TYPE_SIGNAL, "add_default_user_async() returns Signal for auto-dispatch coverage")
+	if typeof(auto_signal) != TYPE_SIGNAL:
+		reset_runtime()
+		set_embed_dispatch_enabled(original_embed_dispatch)
+		return
+
+	var auto_state = track_signal(auto_signal)
+	var auto_resolved: Variant = null
+	if auto_state["completed"]:
+		auto_resolved = auto_state["result"]
+	else:
+		auto_resolved = await await_completion_state_no_dispatch(auto_state, 8000)
+	assert_true(
+		auto_resolved != null,
+		"Auto-pump regression (issue #126): add_default_user_async() resolves under manual GDK.dispatch() but the frame-callback auto-pump did not drain it with embed_dispatch=true — the per-frame GDK.dispatch() pump is not running.")
+
+	reset_runtime()
 	set_embed_dispatch_enabled(original_embed_dispatch)
+

--- a/tests/godot/playfab/tests/test_core.gd
+++ b/tests/godot/playfab/tests/test_core.gd
@@ -11,6 +11,8 @@ const PLAYFAB_ROOT_METHODS := [
 	"is_available",
 	"is_initialized",
 	"dispatch",
+	"submit_dispatch_probe",
+	"get_dispatch_probe_count",
 	"get_users",
 	"get_game_saves",
 	"get_leaderboards",
@@ -297,3 +299,103 @@ func test_initialize_shutdown_rearms_runtime_lifecycle() -> void:
 	_restore_playfab_runtime_settings(original_title_id, original_endpoint)
 	reset_playfab_runtime()
 	_disconnect_playfab_lifecycle_handlers(playfab, initialized_handler, shutdown_handler)
+
+
+func _restore_embed_dispatch_settings(original_title_id, original_endpoint, original_embed_dispatch) -> void:
+	ProjectSettings.set_setting(PLAYFAB_EMBED_DISPATCH_SETTING, original_embed_dispatch)
+	_restore_playfab_runtime_settings(original_title_id, original_endpoint)
+	reset_playfab_runtime()
+
+
+# Regression guard for issue #126 (GDK/PlayFab async completions never fired
+# because the per-frame auto-pump was silently compiled out of the DLL). Rather
+# than a real async op — which needs a title id and a network round-trip — this
+# uses the offline, identity-free diagnostics probe: submit_dispatch_probe()
+# enqueues a no-op callback on the runtime's Manual XTaskQueue completion port,
+# and get_dispatch_probe_count() reports how many probes have since been drained.
+# The completion port is only dispatched by PlayFab.dispatch() (manual) or the
+# extension frame callback (auto), so the probe deterministically detects whether
+# the auto-pump is wired — in the offline PR gate, exactly where #126 slipped
+# through.
+func test_embed_dispatch_auto_pump() -> void:
+	if pending_unless_playfab_available():
+		return
+
+	var playfab = get_playfab()
+
+	var original_title_id = ProjectSettings.get_setting(PLAYFAB_TITLE_ID_SETTING, "")
+	var original_endpoint = ProjectSettings.get_setting(PLAYFAB_ENDPOINT_SETTING, "")
+	var original_embed_dispatch = ProjectSettings.get_setting(PLAYFAB_EMBED_DISPATCH_SETTING, true)
+
+	ProjectSettings.set_setting(PLAYFAB_TITLE_ID_SETTING, REARM_TEST_TITLE_ID)
+	ProjectSettings.set_setting(PLAYFAB_ENDPOINT_SETTING, "")
+
+	var main_loop: MainLoop = Engine.get_main_loop()
+	if main_loop == null or not main_loop.has_signal("process_frame"):
+		pending("Auto-pump guard: the headless runner could not access process_frame.")
+		_restore_embed_dispatch_settings(original_title_id, original_endpoint, original_embed_dispatch)
+		return
+
+	# ── Manual-dispatch control (embed_dispatch=false) ───────────────────────
+	# Prove the probe mechanism is sound before using it to police the auto-pump:
+	# a completion-port probe must NOT drain on its own (no spurious increment)
+	# and MUST drain when PlayFab.dispatch() is pumped by hand. This makes an
+	# auto-phase failure unambiguously a frame-callback regression rather than a
+	# broken probe.
+	ProjectSettings.set_setting(PLAYFAB_EMBED_DISPATCH_SETTING, false)
+	reset_playfab_runtime()
+	var manual_init = playfab.initialize()
+	assert_not_null(manual_init, "initialize() returns PlayFabResult for manual-dispatch coverage")
+	if manual_init == null or not manual_init.ok:
+		pending("Auto-pump guard (manual control): %s" % (manual_init.message if manual_init != null else "initialize() returned null"))
+		_restore_embed_dispatch_settings(original_title_id, original_endpoint, original_embed_dispatch)
+		return
+
+	var manual_baseline: int = playfab.get_dispatch_probe_count()
+	assert_true(playfab.submit_dispatch_probe(), "submit_dispatch_probe() is accepted when the runtime is initialized")
+
+	# With embed_dispatch=false and no manual pump, advancing frames must NOT
+	# drain the probe — the frame callback skips PlayFab.dispatch() in this mode.
+	await advance_process_frames(5)
+	assert_eq(playfab.get_dispatch_probe_count(), manual_baseline,
+		"embed_dispatch=false: the completion-port probe stays undrained until PlayFab.dispatch() is pumped")
+
+	# A manual dispatch drains it — proving the probe + counter actually work.
+	playfab.dispatch()
+	assert_true(playfab.get_dispatch_probe_count() > manual_baseline,
+		"PlayFab.dispatch() drains the submitted completion-port probe")
+
+	reset_playfab_runtime()
+
+	# ── Auto-dispatch subject (embed_dispatch=true) ──────────────────────────
+	# The control proved the probe drains only on a real completion-port dispatch.
+	# Now verify the per-frame auto-pump drains a probe with NO manual dispatch.
+	# A timeout here is issue #126: the frame-callback auto-pump was silently
+	# compiled out (missing GODOT_VERSION_MINOR include via <godot_cpp/core/version.hpp>),
+	# so nothing drained the Manual XTaskQueue completion port and every
+	# await *_async() hung.
+	ProjectSettings.set_setting(PLAYFAB_EMBED_DISPATCH_SETTING, true)
+	reset_playfab_runtime()
+	var auto_init = playfab.initialize()
+	assert_not_null(auto_init, "initialize() returns PlayFabResult for auto-dispatch coverage")
+	if auto_init == null or not auto_init.ok:
+		pending("Auto-pump guard (auto subject): %s" % (auto_init.message if auto_init != null else "initialize() returned null"))
+		_restore_embed_dispatch_settings(original_title_id, original_endpoint, original_embed_dispatch)
+		return
+
+	var auto_baseline: int = playfab.get_dispatch_probe_count()
+	assert_true(playfab.submit_dispatch_probe(), "submit_dispatch_probe() is accepted for auto-dispatch coverage")
+
+	var drained := false
+	var started_msec := Time.get_ticks_msec()
+	while Time.get_ticks_msec() - started_msec < 8000:
+		await main_loop.process_frame
+		if playfab.get_dispatch_probe_count() > auto_baseline:
+			drained = true
+			break
+
+	assert_true(drained,
+		"Auto-pump regression (issue #126): a completion-port probe submitted with embed_dispatch=true was not drained by the per-frame auto-pump — PlayFab's frame-callback PlayFab.dispatch() is not running.")
+
+	reset_playfab_runtime()
+	_restore_embed_dispatch_settings(original_title_id, original_endpoint, original_embed_dispatch)


### PR DESCRIPTION
## Summary

Fixes #126. GDK/PlayFab async completion callbacks (`await *_async()`) never fired because the frame-callback **auto-pump** that drains the Manual `XTaskQueue` completion port was **silently compiled out** of both service-addon DLLs. To the developer everything just appears broken, with no error or warning.

## Root cause

The auto-pump was guarded by `#if GODOT_VERSION_MINOR >= 5` in each addon's `register_types.cpp`, but `GODOT_VERSION_MINOR` is defined **only** in `<godot_cpp/core/version.hpp>` — which neither file included, and which no other godot-cpp header pulls in transitively. An undefined identifier in an `#if` expression evaluates to `0`, so `0 >= 5` was false and the entire auto-pump (`register_frame_callback` / `gdk_frame_callback`) was compiled out. Nothing drained completions, so every `await *_async()` hung forever.

This affected **both** `godot_gdk` and `godot_playfab` (identical missing include). `godot_gameinput` is unaffected (no frame callback — different threading model).

## Fix

Both `addons/godot_gdk/src/register_types.cpp` and `addons/godot_playfab/src/register_types.cpp`:

1. **Add `#include <godot_cpp/core/version.hpp>`** so `GODOT_VERSION_MINOR` is defined and the per-frame auto-pump is actually compiled in.
2. **Declare the extension's minimum initialization level as `CORE`** (was `SCENE`). godot-cpp registers the frame callback only at CORE-level init; with a `SCENE` minimum, editor in-place hot-reload (`reloadable = true`) reloads starting at SCENE and skips CORE, silently dropping the pump until an engine restart. `CORE` makes the engine emit an explicit `NEEDS_RESTART` prompt instead of leaving a silently dead pump.

## Regression guard

`tests/godot/gdk/tests/test_core.gd::test_embed_dispatch_behavior()` is rewritten into a CI-safe **A/B guard**:

- **Manual control** (`embed_dispatch = false`): prove `add_default_user_async()` resolves under a hand-pumped `GDK.dispatch()`.
- **Auto subject** (`embed_dispatch = true`): drain the *same* op via the frame callback with **no** manual dispatch.
- It **FAILS** the suite iff the op resolves manually but the auto-pump times out — the exact #126 signature. Where the op cannot resolve at all (e.g. identity-less hosted runners), it degrades to `pending()`, so it never false-fails.

Previously the auto path called `pending()` (not `fail()`) on timeout, so a dead pump degraded to **PENDING** and never failed CI — which is why #126 shipped undetected.

## Validation

### GDK guard
- Godot 4.6.1 headless GUT — `tests/godot/gdk/tests/test_core.gd` **5/5 pass** with the fix (auto-pump drains with no manual dispatch, 0.57s).
- **Guard has teeth:** reverting *only* the `version.hpp` include and rebuilding makes the guard **FAIL** (exit 1, 8.5s = the auto timeout); restoring it returns to 5/5 pass.

### PlayFab guard
- Godot 4.6.1 headless GUT — `tests/godot/playfab/tests/test_core.gd` **10/10 pass** with the fix (auto-pump drains the probe, 0.59s); full PlayFab host **54 pass / 20 live-pending / 0 fail**.
- Also **10/10 on Godot 4.7.1**.
- **Guard has teeth:** reverting *only* the `godot_playfab` `version.hpp` include and rebuilding makes `test_embed_dispatch_auto_pump` **FAIL** (exit 1, 8.6s auto timeout) while the manual-control asserts still pass; restoring it returns to 10/10.

### Shared
- `tools/check_gd_scripts_headless.ps1` parse gate clean.
- Both addons build clean. `doc_classes/PlayFab.xml` and `spec/gdext-playfab.md` updated for the two new diagnostics methods.

Live tiers were **not** run (no live PR-gate coverage on hosted runners; no sandbox title on the dev box).

## PlayFab regression guard (offline, identity-free)

Rather than leave `godot_playfab` protected only by the source fix, this adds an **offline** guard that runs in the same PR gate where #126 slipped through. Because no PlayFab async op resolves without a `title_id` + network, the guard does **not** use a real async op — instead it adds a tiny, identity-free **diagnostics probe** on the runtime and asserts the auto-pump drains it:

- `PlayFab.submit_dispatch_probe()` — enqueues a no-op callback on the runtime's Manual `XTaskQueue` **completion port** (the same port the auto-pump drains). Test-only; not for gameplay.
- `PlayFab.get_dispatch_probe_count()` — running total of probes that have since been drained.

`tests/godot/playfab/tests/test_core.gd::test_embed_dispatch_auto_pump()` then runs an A/B check (`initialize()` succeeds offline with a dummy `title_id` `"00000"`, no network):

- **Manual control** (`embed_dispatch = false`): a submitted probe stays **undrained** across 5 frames (no auto-pump), then a hand-pumped `PlayFab.dispatch()` **drains** it — proving the probe + counter are sound.
- **Auto subject** (`embed_dispatch = true`): a submitted probe is drained by the per-frame frame callback with **no** manual dispatch. A timeout here is the exact #126 signature and **FAILS** the suite.

This is strictly better than a deferred live-only guard: it is deterministic, needs no signed-in user or network, and exercises the failure in the offline gate.

### New diagnostics API (usage)

```gdscript
# Verify the per-frame auto-pump is draining PlayFab's completion port.
var before := PlayFab.get_dispatch_probe_count()
PlayFab.submit_dispatch_probe()
await get_tree().process_frame          # with embed_dispatch = true (the default)
assert(PlayFab.get_dispatch_probe_count() > before)
```
