### PR TITLE
Add bug report issue template and link it from the README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a problem with one of the Godot GDK sample addons
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please fill out the sections below so we can reproduce and diagnose the issue quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen and what actually happened instead.
+      placeholder: Tell us what you saw, and what you expected to see.
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, reliable step-by-step sequence that reproduces the problem.
+      placeholder: |
+        1. Open the '...' sample project
+        2. Call '...'
+        3. Observe '...'
+    validations:
+      required: true
+  - type: input
+    id: engine-version
+    attributes:
+      label: Godot engine version
+      description: The Godot version you are running. Find it via Help > About, or run `godot --version`. This project supports Godot 4.5 and newer.
+      placeholder: "4.6.1-stable"
+    validations:
+      required: true
+  - type: input
+    id: gdk-version
+    attributes:
+      label: GDK version
+      description: The Microsoft GDK edition in use (6-digit edition, e.g. 260401). See your `vcpkg.json` `ms-gdk` override or the GDK installer.
+      placeholder: "260401"
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Design specs live in [`spec/`](spec/) — design intent that is not always refle
 
 ## Support and contributing
 
+- [**Report a bug**](https://github.com/microsoft/XBOX-Godot-Sample/issues/new?template=bug_report.yml) — file a bug report with repro steps, Godot engine version, and GDK version
+- [**Open an issue**](https://github.com/microsoft/XBOX-Godot-Sample/issues/new/choose) — pick from the available issue templates
 - [`SUPPORT.md`](SUPPORT.md) — how to file issues
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — CLA and Code of Conduct
 - [`SECURITY.md`](SECURITY.md) — security vulnerability reporting (MSRC; please do **not** file security issues via GitHub)


### PR DESCRIPTION
## Summary

`chore/issue-template`: Add a GitHub issue-forms **bug report** template and surface it from the README. The template requests reproduction steps, the Godot engine version, and the GDK version, so incoming bug reports carry the details needed to triage them.

## Public API changes

None. Docs/repo-config only.

## Spec / docs / samples updated

- [x] Not applicable — no public addon behaviour changed

Touched surfaces:
- New `.github/ISSUE_TEMPLATE/bug_report.yml` (matches the existing `JitAccess.yml` issue-forms schema; labeled `bug`).
- `README.md` "Support and contributing" section: added a direct **Report a bug** link (`issues/new?template=bug_report.yml`) and an **Open an issue** chooser link (`issues/new/choose`).

Version fields are free-text inputs (not dropdowns) on purpose, so they don't drift from the `godot-versions.json` / `gdk-versions.json` single-source-of-truth files.

## Test coverage delta

- Contract (offline) tests added/removed: none
- Live-read tests added/removed: none
- Live-write tests added/removed: none
- Live title id used (if any): none

## Validation run

No `.gd` files were touched, so the GDScript parse gate and the test orchestrator do not apply to this change. Validation was limited to confirming the issue-forms YAML parses:

```text
python -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))"  -> YAML OK
```

## Migration notes

None.
