### PR TITLE
Add Godot 4.7.1-stable to CI test gates and make it the default

### DIFF
--- a/.github/godot-versions.json
+++ b/.github/godot-versions.json
@@ -1,12 +1,14 @@
 {
   "_comment": "Single source of truth for the Godot versions CI exercises. Policy: support Godot 4.5 and newer (latest patch of each minor line). 'default' is used by single-version jobs (PlayFab live tier, local-dev parity). 'supported' is the matrix the parse gate fans out over. To widen the range, add a version string to 'supported' AND its pinned hash to 'sha512' -- it must be a real godotengine/godot-builds release tag whose asset 'Godot_v<version>_win64.exe.zip' exists (the zip bundles the '_console.exe' the gates use). No workflow edits are required when this list changes.",
   "_sha512_comment": "Supply-chain pin: SHA-512 (lowercase hex) of each version's 'Godot_v<version>_win64.exe.zip'. setup-godot REFUSES to download a version that has no entry here, and aborts before extraction on any mismatch. To add a version: run `(Get-FileHash -Algorithm SHA512 <zip>).Hash.ToLower()` (or cross-check godotengine/godot-builds SHA512-SUMS.txt) and paste the value below.",
-  "default": "4.6.1-stable",
+  "default": "4.7.1-stable",
   "supported": [
+    "4.7.1-stable",
     "4.6.1-stable",
     "4.5.1-stable"
   ],
   "sha512": {
+    "4.7.1-stable": "a6b02c527c18ba9936e63562032701432b2dc57d98d6483ceaccb00fe14af16af5773ae8a55e7b4d614edf121c4d9e420d870f804edb1dac16362298a01ce6c4",
     "4.6.1-stable": "67c63291115c66ebe7145415b5aac235e1667e417d6cd3d1975848670a1d31cbfad111c8231cb53195bb62e6e4fde951d97aaca227736a94f93dcbf8f23b1fbb",
     "4.5.1-stable": "ab84df90ead5a888530faaabe744a27678ef7635068883900174fae37f7fc6178d033b551d88963c7dc2466580915a582bbc79aca97c19085900655761f56a27"
   }

--- a/docs/ci/pr-gates.md
+++ b/docs/ci/pr-gates.md
@@ -136,9 +136,10 @@ The set of Godot versions CI exercises is data-driven in
 
 ```json
 {
-  "default": "4.6.1-stable",
-  "supported": ["4.6.1-stable", "4.5.1-stable"],
+  "default": "4.7.1-stable",
+  "supported": ["4.7.1-stable", "4.6.1-stable", "4.5.1-stable"],
   "sha512": {
+    "4.7.1-stable": "a6b02c52…",
     "4.6.1-stable": "67c63291…",
     "4.5.1-stable": "ab84df90…"
   }


### PR DESCRIPTION
## What

Adds **Godot 4.7.1-stable** (the latest 4.7 patch) to the CI Godot test-gate matrix and promotes it to the `default` single-version edition.

- `.github/godot-versions.json`
  - `supported`: `["4.7.1-stable", "4.6.1-stable", "4.5.1-stable"]` (newest-first, matching convention)
  - `default`: `4.6.1-stable` → `4.7.1-stable`
  - `sha512`: added the pinned hash for `Godot_v4.7.1-stable_win64.exe.zip`
- `docs/ci/pr-gates.md`: synced the illustrative manifest example.

## Why

Policy is "support Godot 4.5 and newer (latest patch of each minor line)". 4.7.1-stable is the newest 4.7 release, so it joins the matrix and becomes the default the single-version jobs run against.

## Effect on gates (no workflow edits needed)

The `versions` job reads the manifest, so this is purely data-driven:
- **Parse gate** + **nightly offline tier** fan out over `supported` → now also exercise 4.7.1.
- **PR build / test-offline**, **nightly PlayFab live tier**, and the **workflow_dispatch default** use `default` → now 4.7.1.
- GUT selection only special-cases `4.5.x`, so 4.7 correctly uses the default GUT 9.6.0 mirror (which hard-requires Godot 4.6+).

## Supply-chain pin verification

Downloaded `Godot_v4.7.1-stable_win64.exe.zip`, computed its SHA-512 locally, and cross-checked it against upstream `godotengine/godot-builds` `SHA512-SUMS.txt` — exact match:

```
a6b02c527c18ba9936e63562032701432b2dc57d98d6483ceaccb00fe14af16af5773ae8a55e7b4d614edf121c4d9e420d870f804edb1dac16362298a01ce6c4  Godot_v4.7.1-stable_win64.exe.zip
```

## Validation

- Manifest validated well-formed; `default` resolves and has a matching `sha512` pin; `supported` parses to the 3-version list.
- No `.gd` files touched → parse gate not required locally. No code changed → test orchestrator not applicable. CI will exercise the new version end-to-end across all gates.