### PR TITLE
Fix #136: drop Title Storage upload from GDK Tutorial 3 sample

### DIFF
--- a/docs/tutorials/gdk/03-storage-stats.md
+++ b/docs/tutorials/gdk/03-storage-stats.md
@@ -2,18 +2,18 @@
 
 ## What you'll build
 
-Add a GDK-only storage and progression scene. The Title Storage half uploads a binary blob with storage type `TrustedPlatform`, lists metadata, and downloads it back. The Stats half tracks two title-managed stats, stages integer values, flushes them to Xbox services, and queries them back.
+Add a GDK-only storage and progression scene. The Title Storage half lists blob metadata for storage type `TrustedPlatform` and downloads an existing blob — untrusted platforms (PC) can't upload, so it only reads. The Stats half tracks two title-managed stats, stages integer values, flushes them to Xbox services, and queries them back.
 
 ## Prerequisites
 
 - Complete [GDK Tutorial 2](02-achievement.md).
-- Configure Title Storage for your Partner Center title and sandbox.
+- Configure Title Storage for your Partner Center title and sandbox, and provision the blob at `tutorial/save.bin` from a console or Partner Center — untrusted platforms (PC) can't upload.
 - Declare title-managed statistics named `HighScore` and `LevelsCleared`, or update the constants in the script.
 - Stay in the same Xbox sandbox used by `MicrosoftGame.config`.
 
 ## Relevant addon surfaces
 
-- [`GDKTitleStorage`](../../../addons/godot_gdk/doc_classes/GDKTitleStorage.xml) — `upload_blob_async`, `list_blob_metadata_async`, `download_blob_async`.
+- [`GDKTitleStorage`](../../../addons/godot_gdk/doc_classes/GDKTitleStorage.xml) — `list_blob_metadata_async`, `download_blob_async`.
 - [`GDKStats`](../../../addons/godot_gdk/doc_classes/GDKStats.xml) — `track_stats`, `set_stat_integer`, `flush_stats_async`, `query_user_stats_async`, `stat_changed`.
 - [`GDKUser`](../../../addons/godot_gdk/doc_classes/GDKUser.xml) — `GdkAuth.xbox_user`.
 
@@ -21,7 +21,7 @@ Add a GDK-only storage and progression scene. The Title Storage half uploads a b
 
 ### Step 1 — Use the GDK-only scene script
 
-The complete reference script below is copy-pasteable. It waits for `GdkAuth`, uploads/lists/downloads the blob, then sets and queries stats.
+The complete reference script below is copy-pasteable. It waits for `GdkAuth`, lists metadata and downloads an existing blob, then sets and queries stats.
 
 ```gdscript
 extends Control
@@ -31,9 +31,10 @@ const AddonApi = preload("res://shared/addon_api.gd")
 ## GDK Tutorial 3 reference scene — Title Storage + user statistics.
 ##
 ## GDK-only surfaces, no PlayFab. Buttons drive each step:
-##   - Upload a small blob to Title Storage, then list + download it back
-##     (GDK.title_storage.upload_blob_async / list_blob_metadata_async /
-##     download_blob_async).
+##   - List Title Storage blob metadata, then download an existing blob
+##     (GDK.title_storage.list_blob_metadata_async / download_blob_async).
+##     Untrusted platforms (PC) can't upload to Title Storage, so writes
+##     are omitted here — provision blobs from a console or Partner Center.
 ##   - Stage and flush a couple of title-managed statistics, then query
 ##     them back (GDK.stats.set_stat_integer / flush_stats_async /
 ##     query_user_stats_async).
@@ -97,23 +98,17 @@ func _on_storage_pressed() -> void:
 	if user == null:
 		return
 
-	# 1. Upload a small blob.
-	var payload := "tutorial-payload @ %d" % int(Time.get_unix_time_from_system())
-	var bytes := payload.to_utf8_buffer()
-	var up = await AddonApi.singleton("GDK").title_storage.upload_blob_async(
-		user, STORAGE_TYPE, BLOB_PATH, bytes, "Tutorial Save")
-	if not up.ok:
-		_append("[color=orange][Storage] upload failed: %s (%s)[/color]" % [up.message, up.code])
-		return
-	_append("[Storage] Uploaded %d bytes to %s." % [bytes.size(), BLOB_PATH])
-
-	# 2. List blob metadata so the developer can see what's stored.
+	# Untrusted platforms (PC) can't write Title Storage — uploads are
+	# rejected with HTTP 403. Provision the blob from a console or Partner
+	# Center, then read it back with the list + download surfaces below.
+
+	# 1. List blob metadata so the developer can see what's stored.
 	var list = await AddonApi.singleton("GDK").title_storage.list_blob_metadata_async(
 		user, STORAGE_TYPE)
 	if list.ok and list.data != null:
 		_append("[Storage] Listed blob metadata for %s." % STORAGE_TYPE)
 
-	# 3. Download the blob back and verify the round-trip.
+	# 2. Download an existing blob.
 	var down = await AddonApi.singleton("GDK").title_storage.download_blob_async(
 		user, STORAGE_TYPE, BLOB_PATH)
 	if not down.ok:
@@ -179,14 +174,13 @@ The two buttons intentionally run separate flows. Storage failures should not pr
 
 ## Verify
 
-Run `g03_storage_stats`, click **Title Storage**, then **Stats**. Output should show an uploaded byte count, downloaded payload, flushed values, tracked changes, and queried stat data.
+Run `g03_storage_stats`, click **Storage list + download**, then **Stats flush + query**. Output should show listed blob metadata, a downloaded payload, flushed values, tracked changes, and queried stat data.
 
 ## Common failures
 
 | Output | Diagnosis | Fix |
 |---|---|---|
-| `upload failed` | Title Storage not configured, wrong storage type, or sandbox mismatch. | Verify Partner Center storage setup and `MicrosoftGame.config`. |
-| `download failed` | Blob path/type does not match the upload or upload failed. | Use the same `STORAGE_TYPE` and `BLOB_PATH`. |
+| `download failed` | No blob provisioned, or blob path/type mismatch. Untrusted platforms (PC) can't upload, so the blob must already exist. | Provision the blob from a console or Partner Center using the same `STORAGE_TYPE` and `BLOB_PATH`. |
 | `flush failed` | Statistic names are not registered for this title. | Create the stats or update the constants. |
 | No `stat_changed` output | You did not track the stat names before setting/flushing. | Call `track_stats` with the same names you set. |
 

--- a/docs/tutorials/gdk/03-storage-stats.md
+++ b/docs/tutorials/gdk/03-storage-stats.md
@@ -105,8 +105,10 @@ func _on_storage_pressed() -> void:
 	# 1. List blob metadata so the developer can see what's stored.
 	var list = await AddonApi.singleton("GDK").title_storage.list_blob_metadata_async(
 		user, STORAGE_TYPE)
-	if list.ok and list.data != null:
-		_append("[Storage] Listed blob metadata for %s." % STORAGE_TYPE)
+	if not list.ok:
+		_append("[color=orange][Storage] list failed: %s (%s)[/color]" % [list.message, list.code])
+	elif list.data != null:
+		_append("[Storage] Listed blob metadata for %s." % STORAGE_TYPE)
 
 	# 2. Download an existing blob.
 	var down = await AddonApi.singleton("GDK").title_storage.download_blob_async(

--- a/sample/tutorial_gdk/g03_storage_stats.gd
+++ b/sample/tutorial_gdk/g03_storage_stats.gd
@@ -5,9 +5,10 @@ const AddonApi = preload("res://shared/addon_api.gd")
 ## GDK Tutorial 3 reference scene — Title Storage + user statistics.
 ##
 ## GDK-only surfaces, no PlayFab. Buttons drive each step:
-##   - Upload a small blob to Title Storage, then list + download it back
-##     (GDK.title_storage.upload_blob_async / list_blob_metadata_async /
-##     download_blob_async).
+##   - List Title Storage blob metadata, then download an existing blob
+##     (GDK.title_storage.list_blob_metadata_async / download_blob_async).
+##     Untrusted platforms (PC) can't upload to Title Storage, so writes
+##     are omitted here — provision blobs from a console or Partner Center.
 ##   - Stage and flush a couple of title-managed statistics, then query
 ##     them back (GDK.stats.set_stat_integer / flush_stats_async /
 ##     query_user_stats_async).
@@ -71,23 +72,17 @@ func _on_storage_pressed() -> void:
 	if user == null:
 		return
 
-	# 1. Upload a small blob.
-	var payload := "tutorial-payload @ %d" % int(Time.get_unix_time_from_system())
-	var bytes := payload.to_utf8_buffer()
-	var up = await AddonApi.singleton("GDK").title_storage.upload_blob_async(
-		user, STORAGE_TYPE, BLOB_PATH, bytes, "Tutorial Save")
-	if not up.ok:
-		_append("[color=orange][Storage] upload failed: %s (%s)[/color]" % [up.message, up.code])
-		return
-	_append("[Storage] Uploaded %d bytes to %s." % [bytes.size(), BLOB_PATH])
+	# Untrusted platforms (PC) can't write Title Storage — uploads are
+	# rejected with HTTP 403. Provision the blob from a console or Partner
+	# Center, then read it back with the list + download surfaces below.
 
-	# 2. List blob metadata so the developer can see what's stored.
+	# 1. List blob metadata so the developer can see what's stored.
 	var list = await AddonApi.singleton("GDK").title_storage.list_blob_metadata_async(
 		user, STORAGE_TYPE)
 	if list.ok and list.data != null:
 		_append("[Storage] Listed blob metadata for %s." % STORAGE_TYPE)
 
-	# 3. Download the blob back and verify the round-trip.
+	# 2. Download an existing blob.
 	var down = await AddonApi.singleton("GDK").title_storage.download_blob_async(
 		user, STORAGE_TYPE, BLOB_PATH)
 	if not down.ok:

--- a/sample/tutorial_gdk/g03_storage_stats.gd
+++ b/sample/tutorial_gdk/g03_storage_stats.gd
@@ -79,7 +79,9 @@ func _on_storage_pressed() -> void:
 	# 1. List blob metadata so the developer can see what's stored.
 	var list = await AddonApi.singleton("GDK").title_storage.list_blob_metadata_async(
 		user, STORAGE_TYPE)
-	if list.ok and list.data != null:
+	if not list.ok:
+		_append("[color=orange][Storage] list failed: %s (%s)[/color]" % [list.message, list.code])
+	elif list.data != null:
 		_append("[Storage] Listed blob metadata for %s." % STORAGE_TYPE)
 
 	# 2. Download an existing blob.

--- a/sample/tutorial_gdk/g03_storage_stats.tscn
+++ b/sample/tutorial_gdk/g03_storage_stats.tscn
@@ -31,7 +31,7 @@ theme_override_font_sizes/font_size = 24
 
 [node name="Subtitle" type="Label" parent="Root"]
 layout_mode = 2
-text = "GDK.title_storage upload/list/download + GDK.stats stage/flush/query."
+text = "GDK.title_storage list/download + GDK.stats stage/flush/query."
 autowrap_mode = 3
 
 [node name="Buttons" type="HBoxContainer" parent="Root"]
@@ -40,7 +40,7 @@ theme_override_constants/separation = 12
 
 [node name="StorageBtn" type="Button" parent="Root/Buttons"]
 layout_mode = 2
-text = "Storage round-trip (Step 1)"
+text = "Storage list + download (Step 1)"
 
 [node name="StatsBtn" type="Button" parent="Root/Buttons"]
 layout_mode = 2

--- a/sample/tutorial_gdk_csharp/G03StorageStats.cs
+++ b/sample/tutorial_gdk_csharp/G03StorageStats.cs
@@ -78,7 +78,9 @@ public partial class G03StorageStats : Control
         // Center, then read it back with the list + download surfaces below.
 
         // 1. List blob metadata so the developer can see what's stored.
-        GdkResult list = await Gdk.TitleStorage.ListBlobMetadataAsync(user, StorageType, string.Empty, 0, 0);
+        // Pass maxItems=25 to mirror the GDScript sample's binding default
+        // (the C# facade has no default; the native list forwards it as-is).
+        GdkResult list = await Gdk.TitleStorage.ListBlobMetadataAsync(user, StorageType, string.Empty, 0, 25);
         if (!IsInsideTree()) return;
         if (list.Ok) Append($"[Storage] Listed blob metadata for {StorageType}.");
         else Append($"[color=orange][Storage] list failed: {list.Message} ({list.Code})[/color]");

--- a/sample/tutorial_gdk_csharp/G03StorageStats.cs
+++ b/sample/tutorial_gdk_csharp/G03StorageStats.cs
@@ -81,6 +81,7 @@ public partial class G03StorageStats : Control
         GdkResult list = await Gdk.TitleStorage.ListBlobMetadataAsync(user, StorageType, string.Empty, 0, 0);
         if (!IsInsideTree()) return;
         if (list.Ok) Append($"[Storage] Listed blob metadata for {StorageType}.");
+        else Append($"[color=orange][Storage] list failed: {list.Message} ({list.Code})[/color]");
 
         // 2. Download an existing blob.
         GdkResult down = await Gdk.TitleStorage.DownloadBlobAsync(user, StorageType, BlobPath);

--- a/sample/tutorial_gdk_csharp/G03StorageStats.cs
+++ b/sample/tutorial_gdk_csharp/G03StorageStats.cs
@@ -7,8 +7,9 @@ using GodotGdk.Types;
 /// GDK Tutorial 3 reference scene — Title Storage + user statistics.
 ///
 /// GDK-only surfaces, no PlayFab. Buttons drive each step:
-///   - Upload a small blob to Title Storage, then list + download it back
-///     (GDK.title_storage upload/list/download).
+///   - List Title Storage blob metadata, then download an existing blob
+///     (GDK.title_storage list/download). Untrusted platforms (PC) can't
+///     upload to Title Storage, so writes are omitted here.
 ///   - Stage and flush a couple of title-managed statistics, then query
 ///     them back (GDK.stats set/flush/query).
 /// </summary>
@@ -72,20 +73,16 @@ public partial class G03StorageStats : Control
         GdkUser user = _auth.XboxUser;
         if (user == null) return;
 
-        // 1. Upload a small blob.
-        string payload = $"tutorial-payload @ {(long)Time.GetUnixTimeFromSystem()}";
-        byte[] bytes = System.Text.Encoding.UTF8.GetBytes(payload);
-        GdkResult up = await Gdk.TitleStorage.UploadBlobAsync(user, StorageType, BlobPath, bytes, "Tutorial Save");
-        if (!IsInsideTree()) return;
-        if (!up.Ok) { Append($"[color=orange][Storage] upload failed: {up.Message} ({up.Code})[/color]"); return; }
-        Append($"[Storage] Uploaded {bytes.Length} bytes to {BlobPath}.");
+        // Untrusted platforms (PC) can't write Title Storage — uploads are
+        // rejected with HTTP 403. Provision the blob from a console or Partner
+        // Center, then read it back with the list + download surfaces below.
 
-        // 2. List blob metadata so the developer can see what's stored.
+        // 1. List blob metadata so the developer can see what's stored.
         GdkResult list = await Gdk.TitleStorage.ListBlobMetadataAsync(user, StorageType, string.Empty, 0, 0);
         if (!IsInsideTree()) return;
         if (list.Ok) Append($"[Storage] Listed blob metadata for {StorageType}.");
 
-        // 3. Download the blob back and verify the round-trip.
+        // 2. Download an existing blob.
         GdkResult down = await Gdk.TitleStorage.DownloadBlobAsync(user, StorageType, BlobPath);
         if (!IsInsideTree()) return;
         if (!down.Ok) { Append($"[color=orange][Storage] download failed: {down.Message}[/color]"); return; }

--- a/sample/tutorial_gdk_csharp/README.md
+++ b/sample/tutorial_gdk_csharp/README.md
@@ -46,7 +46,7 @@ the GDScript samples demonstrate, expressed in C#.
 
 - `Gdk.Users` — `GetPrimaryUser`, `AddDefaultUserAsync`, `AddUserWithUiAsync`
 - `Gdk.Achievements` — `QueryPlayerAchievementsAsync`, `GetCachedAchievements`, `UpdateAchievementAsync`, `AchievementUnlocked`
-- `Gdk.TitleStorage` — `UploadBlobAsync`, `ListBlobMetadataAsync`, `DownloadBlobAsync`
+- `Gdk.TitleStorage` — `ListBlobMetadataAsync`, `DownloadBlobAsync`
 - `Gdk.Stats` — `TrackStats`, `SetStatInteger`, `FlushStatsAsync`, `QueryUserStatsAsync`, `StatChanged`
 - `Gdk.Social` — `StartSocialGraph`, `GetFriendsAsync`, `GetGroupUsers`, `DestroySocialGroup`, `StopSocialGraph`
 - `Gdk.Privacy` — `BatchCheckPermissionAsync`

--- a/sample/tutorial_gdk_csharp/g03_storage_stats.tscn
+++ b/sample/tutorial_gdk_csharp/g03_storage_stats.tscn
@@ -31,7 +31,7 @@ theme_override_font_sizes/font_size = 24
 
 [node name="Subtitle" type="Label" parent="Root"]
 layout_mode = 2
-text = "GDK.title_storage upload/list/download + GDK.stats stage/flush/query."
+text = "GDK.title_storage list/download + GDK.stats stage/flush/query."
 autowrap_mode = 3
 
 [node name="Buttons" type="HBoxContainer" parent="Root"]
@@ -40,7 +40,7 @@ theme_override_constants/separation = 12
 
 [node name="StorageBtn" type="Button" parent="Root/Buttons"]
 layout_mode = 2
-text = "Storage round-trip (Step 1)"
+text = "Storage list + download (Step 1)"
 
 [node name="StatsBtn" type="Button" parent="Root/Buttons"]
 layout_mode = 2


### PR DESCRIPTION
Fixes #136.

## Problem

Running **G3 → Storage** ("Storage round-trip") in the GDK Tutorial 3 sample failed with:

> Failed to upload Title Storage blob. (HRESULT 0x80190193) (title_storage_upload_result_failed)

`0x80190193` decodes to **HTTP 403 Forbidden**. This is expected behavior: PC/desktop is an **untrusted platform** for GDK Title Storage, so client-side blob **writes** are rejected. Reads (list + download) still work.

## Change

Drop the upload step from the G3 Title Storage flow so the sample demonstrates only the read path that works on PC: list metadata + download an existing blob. The `upload_blob_async` / `UploadBlobAsync` API itself is untouched (still valid on console).

Updated together:
- `sample/tutorial_gdk/g03_storage_stats.gd` + `.tscn` (GDScript sample + scene labels)
- `sample/tutorial_gdk_csharp/G03StorageStats.cs` + `.tscn` (C# twin + scene labels)
- `sample/tutorial_gdk_csharp/README.md` (removed `UploadBlobAsync` from the surface list)
- `docs/tutorials/gdk/03-storage-stats.md` (prose, embedded script, prerequisites, verify steps, common-failures table)

Each sample keeps a short comment explaining *why* the upload is omitted, pointing developers to provision the blob from a console or Partner Center.

## Sample flow (after)

```gdscript
func _on_storage_pressed() -> void:
    var user = _auth.get("xbox_user")
    if user == null:
        return

    # Untrusted platforms (PC) can't write Title Storage — uploads are
    # rejected with HTTP 403. Provision the blob from a console or Partner
    # Center, then read it back with the list + download surfaces below.

    # 1. List blob metadata so the developer can see what's stored.
    var list = await AddonApi.singleton("GDK").title_storage.list_blob_metadata_async(
        user, STORAGE_TYPE)
    if list.ok and list.data != null:
        _append("[Storage] Listed blob metadata for %s." % STORAGE_TYPE)

    # 2. Download an existing blob.
    var down = await AddonApi.singleton("GDK").title_storage.download_blob_async(
        user, STORAGE_TYPE, BLOB_PATH)
    if not down.ok:
        _append("[color=orange][Storage] download failed: %s[/color]" % down.message)
        return
    var data: PackedByteArray = down.data.get("data", PackedByteArray())
    _append("[Storage] Downloaded %d bytes." % data.size())
```

## Validation

- `tools/check_gd_scripts_headless.ps1` — passed.
- Narrowed to the parse gate intentionally: sample/doc-only change, no addon C++, public API, or GUT test changes. Live tests not run (default). The C# twin was edited for parity but is not compiled by `run_all_tests.ps1`.
