### PR TITLE
Fix #144: ship C# assemblies from an "XBOX on PC" export

### DIFF
--- a/addons/godot_gdk/editor/gdk_export_platform.gd
+++ b/addons/godot_gdk/editor/gdk_export_platform.gd
@@ -209,12 +209,20 @@ func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String
 	print("[GDK Export] Template copied: ", exe_path)
 
 	# Export PCK
-	var pck_err: int = _export_pck(p_preset, p_debug, pck_path, p_flags)
+	var pck_result: Dictionary = _export_pck(p_preset, p_debug, pck_path, p_flags)
+	var pck_err: int = int(pck_result.get("result", FAILED))
 	if pck_err != OK:
 		push_error("GDK Export: PCK export failed")
 		return pck_err
 
 	print("[GDK Export] PCK exported: ", pck_path)
+
+	# ── Step 2b: Stage export-plugin shared objects (C#/.NET assemblies, …) ──
+	# These never live inside the .pck; they are handed back by save_pack() and
+	# must be copied next to the .exe (or into their declared target folder).
+	var so_err: int = _stage_shared_objects(staging_dir, pck_result.get("so_files", []))
+	if so_err != OK:
+		return so_err
 
 	# ── Step 3: Copy addon GDExtension main DLLs + support runtime DLLs ──
 	# - Main DLLs (godot_*.windows.<config>.x86_64.dll) go to staging/addons/<name>/bin/
@@ -794,8 +802,150 @@ static func _missing_main_dll_message(p_config: String) -> String:
 		"      cmake --build build --preset %s\n" % build_preset +
 		"  then re-export. (In the Godot export dialog, \"Export With Debug\" unchecked selects release.)")
 
-func _export_pck(p_preset: EditorExportPreset, p_debug: bool, p_path: String, p_flags: int) -> int:
-	return export_pack(p_preset, p_debug, p_path, p_flags)
+## Writes the project PCK and returns [method EditorExportPlatform.save_pack]'s
+## raw dictionary: [code]{"result": Error, "so_files": Array}[/code].
+##
+## Using [code]save_pack()[/code] instead of [code]export_pack()[/code] is
+## deliberate and load-bearing:
+##
+## - [code]export_pack()[/code] opens a *second* [code]ExportNotifier[/code]
+##   inside the one [code]EditorExportPlatformExtension[/code] already opened
+##   around [code]_export_project()[/code], so every export plugin's
+##   [code]_export_begin[/code] / [code]_export_end[/code] runs twice (the C#
+##   plugin publishes the whole assembly set twice), and its
+##   [code]_export_end[/code] deletes the C# publish temp directory before this
+##   platform ever gets a chance to stage it.
+## - [code]export_pack()[/code] calls [code]save_pack()[/code] with a null
+##   shared-object sink, so every file an export plugin registered via
+##   [code]add_shared_object()[/code] is silently discarded.
+##
+## Godot delivers a C#/.NET project's published assemblies *exclusively* as
+## shared objects targeted at [code]data_<assembly>_windows_x86_64/[/code], so
+## the discarded set was the entire managed runtime: the packaged game shipped
+## without a single C# DLL (issue #144). [code]save_pack()[/code] hands the
+## list back so [method _stage_shared_objects] can place it.
+func _export_pck(p_preset: EditorExportPreset, p_debug: bool, p_path: String, _p_flags: int) -> Dictionary:
+	return save_pack(p_preset, p_debug, p_path)
+
+## Copies the shared objects that export plugins registered during
+## [code]_export_begin[/code] into [param staging_dir], mirroring what Godot's
+## built-in desktop exporter does with [code]save_pack()[/code]'s
+## [code]so_files[/code]: an entry with an empty [code]target_folder[/code]
+## lands next to the .exe, any other entry lands in that subfolder.
+##
+## This is the only channel through which a C#/.NET project's assemblies reach
+## the package (issue #144).
+##
+## Entries directly under [code]addons/<name>/bin/[/code] are skipped —
+## [method _copy_addon_dlls] already stages those with debug/release filtering
+## and the [code]addons/[/code] layout the .gdextension expects, so copying
+## them here would drop an unfiltered duplicate in the package root.
+func _stage_shared_objects(staging_dir: String, so_files: Variant) -> int:
+	if not (so_files is Array):
+		return OK
+	var project_dir: String = ProjectSettings.globalize_path("res://")
+	var staged: int = 0
+	for entry: Variant in (so_files as Array):
+		if not (entry is Dictionary):
+			continue
+		var shared_object: Dictionary = entry
+		var raw_path: String = str(shared_object.get("path", ""))
+		if raw_path.is_empty():
+			continue
+		var src: String = ProjectSettings.globalize_path(raw_path)
+		if _is_addon_bin_library(src, project_dir):
+			continue
+		var dest: String = _shared_object_destination(
+			staging_dir, src, str(shared_object.get("target_folder", "")))
+		if dest.is_empty():
+			push_warning("GDK Export: Skipping shared object with unusable target: %s" % src)
+			continue
+		var dest_dir: String = dest.get_base_dir()
+		var mk_err: int = DirAccess.make_dir_recursive_absolute(dest_dir)
+		if mk_err != OK:
+			push_error("GDK Export: Failed to create %s (err %d)" % [dest_dir, mk_err])
+			return mk_err
+		var copy_err: int = OK
+		if DirAccess.dir_exists_absolute(src):
+			copy_err = _copy_dir_recursive(src, dest)
+		else:
+			copy_err = DirAccess.copy_absolute(src, dest)
+		if copy_err != OK:
+			push_error("GDK Export: Failed to copy shared object %s -> %s (err %d)" % [
+				src, dest, copy_err])
+			return copy_err
+		staged += 1
+	if staged > 0:
+		print("[GDK Export] Staged %d export-plugin shared object(s)" % staged)
+	return OK
+
+# Resolves where a save_pack() shared-object entry must land inside the staging
+# directory. An empty target folder means "next to the .exe". Returns "" for any
+# entry whose target would escape the staging root (absolute, drive-qualified,
+# res://-style, or `..`-relative), so a misbehaving export plugin cannot write
+# outside the package.
+static func _shared_object_destination(staging_dir: String, src_path: String,
+		target_folder: String) -> String:
+	var file_name: String = src_path.replace("\\", "/").simplify_path().get_file()
+	if file_name.is_empty():
+		return ""
+	var target: String = target_folder.replace("\\", "/").strip_edges()
+	var dest_dir: String = staging_dir
+	if not target.is_empty():
+		if target.begins_with("/") or target.contains("://") or _has_windows_drive(target):
+			return ""
+		dest_dir = staging_dir.path_join(target)
+	var dest: String = dest_dir.path_join(file_name).replace("\\", "/").simplify_path()
+	if not _is_path_inside_dir(dest, staging_dir):
+		return ""
+	return dest
+
+# True when `src_path` is a file directly inside `<project>/addons/<name>/bin/`,
+# i.e. the set _copy_addon_dlls() already owns.
+static func _is_addon_bin_library(src_path: String, project_dir: String) -> bool:
+	var src: String = src_path.replace("\\", "/").simplify_path()
+	var root: String = project_dir.replace("\\", "/").simplify_path()
+	if not root.ends_with("/"):
+		root += "/"
+	var addons_root: String = root + "addons/"
+	if not src.to_lower().begins_with(addons_root.to_lower()):
+		return false
+	var parts: PackedStringArray = src.substr(addons_root.length()).split("/")
+	return parts.size() == 3 and parts[1] == "bin"
+
+static func _has_windows_drive(path: String) -> bool:
+	return path.length() >= 2 and path.substr(1, 1) == ":"
+
+static func _is_path_inside_dir(candidate_path: String, root_dir: String) -> bool:
+	var candidate: String = candidate_path.replace("\\", "/").simplify_path().to_lower()
+	var root: String = root_dir.replace("\\", "/").simplify_path().to_lower()
+	if not root.ends_with("/"):
+		root += "/"
+	return candidate.begins_with(root)
+
+static func _copy_dir_recursive(src_dir: String, dest_dir: String) -> int:
+	var mk_err: int = DirAccess.make_dir_recursive_absolute(dest_dir)
+	if mk_err != OK:
+		return mk_err
+	var dir: DirAccess = DirAccess.open(src_dir)
+	if dir == null:
+		return ERR_CANT_OPEN
+	dir.list_dir_begin()
+	var entry: String = dir.get_next()
+	while entry != "":
+		var src: String = src_dir.path_join(entry)
+		var dest: String = dest_dir.path_join(entry)
+		var err: int = OK
+		if dir.current_is_dir():
+			err = _copy_dir_recursive(src, dest)
+		else:
+			err = DirAccess.copy_absolute(src, dest)
+		if err != OK:
+			dir.list_dir_end()
+			return err
+		entry = dir.get_next()
+	dir.list_dir_end()
+	return OK
 
 func _rmdir_recursive(path: String) -> void:
 	var da := DirAccess.open(path)

--- a/addons/godot_gdk/editor/gdk_export_platform.gd
+++ b/addons/godot_gdk/editor/gdk_export_platform.gd
@@ -93,21 +93,86 @@ func _get_export_option_visibility(p_preset: EditorExportPreset, p_option: Strin
 func _get_export_option_warning(p_preset: EditorExportPreset, p_option: StringName) -> String:
 	return ""
 
+# ── Validation messages ─────────────────────────────────────────
+#
+# Validation must never fail silently: Godot greys out "Export Project…" /
+# "Export All…" purely on the boolean the callbacks below return, and shows
+# nothing at all unless the platform reports *why* through set_config_error().
+# Every `return false` therefore records an actionable reason first, so the
+# dialog never presents a dead "Export Project" button with no explanation.
+
+static func _gdk_missing_message() -> String:
+	return ("Microsoft GDK was not found on this machine. " +
+		"Install it with `winget install Microsoft.Gaming.GDK`, then restart the Godot editor.")
+
+static func _missing_game_config_message(config_path: String) -> String:
+	return ("MicrosoftGame.config was not found at %s. " % config_path +
+		"Run GDK \u25b8 Create Game Config\u2026 from the editor menu, or copy " +
+		"MicrosoftGame.config.template next to it and fill in your Partner Center values. " +
+		"Set the gdk/packaging/game_config_dir Project Setting to look elsewhere.")
+
+static func _missing_template_message(p_debug: bool, p_dotnet: bool = false) -> String:
+	var config_label: String = "debug" if p_debug else "release"
+	var godot_ver: String = str(Engine.get_version_info().get("string", ""))
+	var flavor: String = ".NET/Mono " if p_dotnet else ""
+	return ("No Windows %s %sexport template was found for Godot %s. " % [config_label, flavor, godot_ver] +
+		"Install it via Editor \u25b8 Manage Export Templates\u2026 (matching your exact Godot " +
+		"version%s), " % (" \u2014 the .NET template package, not the standard one" if p_dotnet else "") +
+		"or enable Dev \u25b8 Register Loose to skip packaging for local iteration.")
+
+# A C# project cannot be staged from the editor binary at all: the game starts
+# up looking for `<exe_dir>/GodotSharp/Api/Debug` and dies with ".NET assemblies
+# not found". So unlike a GDScript project, loose dev-register does NOT get to
+# fall back — a real .NET template is mandatory.
+static func _dotnet_requires_template_message(p_debug: bool) -> String:
+	return (_missing_template_message(p_debug, true) + "\n" +
+		"This project contains C# code (dotnet/project/assembly_name is set), so the Godot " +
+		"editor binary cannot be used as a stand-in even for a loose dev-register build \u2014 " +
+		"the game would fail at launch with \".NET assemblies not found\".")
+
 func _has_valid_export_configuration(p_preset: EditorExportPreset, p_debug: bool) -> bool:
 	_ensure_detected()
+	set_config_missing_templates(false)
+	var errors: PackedStringArray = PackedStringArray()
+
 	if not _gdk_found:
-		return false
+		errors.append(_gdk_missing_message())
+
 	# MicrosoftGame.config is the source of truth for identity / shell visuals
 	# and is authored via the godot_gdk_editortools addon's "Create Game Config".
 	# If it's missing the export pipeline cannot proceed. Its directory is
 	# configurable via the gdk/packaging/game_config_dir Project Setting.
 	if not FileAccess.file_exists(_game_config_src()):
-		return false
-	return true
+		errors.append(_missing_game_config_message(_game_config_src()))
+
+	# A packaged (non-loose) export refuses to substitute the editor binary for
+	# a real export template (issue #134), so a missing template is a hard
+	# blocker. Report it as a missing-templates condition so the dialog offers
+	# the "Manage Export Templates" shortcut. Loose dev-register on a pure
+	# GDScript project still works without templates, so it stays exempt — but a
+	# C# project never can, because the editor binary resolves .NET assemblies
+	# from `GodotSharp/Api/` instead of the exported `data_*` directory.
+	var use_loose: bool = false
+	if p_preset != null and p_preset.has("dev/register_loose"):
+		use_loose = bool(p_preset.get("dev/register_loose"))
+	if _find_windows_template(p_debug) == "":
+		if _is_dotnet_project():
+			set_config_missing_templates(true)
+			errors.append(_dotnet_requires_template_message(p_debug))
+		elif not use_loose:
+			set_config_missing_templates(true)
+			errors.append(_missing_template_message(p_debug))
+
+	set_config_error("\n".join(errors))
+	return errors.is_empty()
 
 func _has_valid_project_configuration(p_preset: EditorExportPreset) -> bool:
 	_ensure_detected()
-	return _gdk_found
+	if not _gdk_found:
+		set_config_error(_gdk_missing_message())
+		return false
+	set_config_error("")
+	return true
 
 func _can_export(p_preset: EditorExportPreset, p_debug: bool) -> bool:
 	return _has_valid_export_configuration(p_preset, p_debug)
@@ -183,6 +248,15 @@ func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String
 	var template_path: String = _find_windows_template(p_debug)
 	if template_path == "":
 		var godot_ver: String = str(Engine.get_version_info().get("string", ""))
+		if _is_dotnet_project():
+			push_error(
+				"GDK Export: No Windows %s .NET/Mono export template found for Godot %s.\n" % [config_label, godot_ver] +
+				"  This project contains C# code, so the Godot editor binary cannot stand in\n" +
+				"  even for a loose dev-register build — the game aborts at launch with\n" +
+				"  \".NET assemblies not found\" (it looks for GodotSharp/Api/Debug next to\n" +
+				"  the .exe). Install the .NET export template package via\n" +
+				"  Editor \u25b8 Manage Export Templates\u2026 (match your exact Godot version) and re-export.")
+			return ERR_FILE_NOT_FOUND
 		if not use_loose:
 			push_error(
 				"GDK Export: No Windows %s export template found for Godot %s.\n" % [config_label, godot_ver] +
@@ -683,7 +757,7 @@ func _detect_gdk() -> void:
 # Godot editor binary as a stand-in template — producing a package that fails
 # at launch with "GDExtension dynamic library not found" (issue #134).
 # Most-specific name first so the real template wins.
-static func _template_version_dirs(p_version: Dictionary) -> PackedStringArray:
+static func _template_version_dirs(p_version: Dictionary, p_dotnet: bool = false) -> PackedStringArray:
 	var major: int = int(p_version.get("major", 0))
 	var minor: int = int(p_version.get("minor", 0))
 	var patch: int = int(p_version.get("patch", 0))
@@ -694,13 +768,36 @@ static func _template_version_dirs(p_version: Dictionary) -> PackedStringArray:
 		dirs.append("%d.%d.%s" % [major, minor, status])
 	dirs.append("%d.%d.%d" % [major, minor, patch])
 	dirs.append("%d.%d" % [major, minor])
+	if p_dotnet:
+		# A .NET editor build resolves templates from "<version>.mono" only
+		# (Godot appends the module config to VERSION_FULL_CONFIG). A non-.NET
+		# template cannot host a C# game — it has no assembly loader — so the
+		# plain names are dropped rather than offered as a silent fallback.
+		var mono_dirs: PackedStringArray = PackedStringArray()
+		for dir_name: String in dirs:
+			mono_dirs.append(dir_name + ".mono")
+		return mono_dirs
 	return dirs
+
+# True when the running editor is a Godot .NET (Mono) build. Only these builds
+# expose CSharpScript, and only they can export a project containing C# code.
+static func _is_dotnet_editor() -> bool:
+	return ClassDB.class_exists("CSharpScript")
+
+# True when this project actually ships C# code, i.e. Godot resolved a .NET
+# assembly for it. Such a project must be staged from a .NET export template:
+# the editor binary sends the game looking for `GodotSharp/Api/Debug` next to
+# the .exe and aborts with ".NET assemblies not found".
+static func _is_dotnet_project() -> bool:
+	if not _is_dotnet_editor():
+		return false
+	return str(ProjectSettings.get_setting("dotnet/project/assembly_name", "")) != ""
 
 func _find_windows_template(p_debug: bool) -> String:
 	var app_data: String = OS.get_environment("APPDATA")
 	var templates_dir: String = app_data.path_join("Godot").path_join("export_templates")
 	var file_name: String = "windows_%s_x86_64.exe" % ("debug" if p_debug else "release")
-	for ver_dir: String in _template_version_dirs(Engine.get_version_info()):
+	for ver_dir: String in _template_version_dirs(Engine.get_version_info(), _is_dotnet_editor()):
 		var template: String = templates_dir.path_join(ver_dir).path_join(file_name)
 		if FileAccess.file_exists(template):
 			return template

--- a/docs/gameinput/csharp.md
+++ b/docs/gameinput/csharp.md
@@ -18,7 +18,15 @@ bridge.
    </ItemGroup>
    ```
 
-3. (Optional) C# bootstrap autoload — initializes on startup, polls each frame,
+3. Add a solution file next to `project.godot`. Godot's .NET export plugin
+   **requires** `<assembly_name>.sln` in the project root — without it every
+   export fails with *"This project contains C# files but no solution file was
+   found"*. Include the facade project(s) so solution builds use the same
+   `Debug` / `ExportDebug` / `ExportRelease` configuration. See
+   [`../gdk/csharp.md`](../gdk/csharp.md#setup) and the `.sln` files in
+   `sample/tutorial_gameinput_csharp/` for the expected shape.
+
+4. (Optional) C# bootstrap autoload — initializes on startup, polls each frame,
    and (when `game_input/mapper/default_action_map` points at a
    `GameInputActionMap`) spawns a default `GameInputMapper` child, driven by the
    same `game_input/*` project settings the GDScript bootstrap reads:

--- a/docs/gdk/csharp.md
+++ b/docs/gdk/csharp.md
@@ -22,7 +22,22 @@ underlying Signal/Result model that the C# bridge wraps.
    </ItemGroup>
    ```
 
-3. (Optional) Register the C# bootstrap autoload instead of the GDScript one.
+3. Add a solution file next to `project.godot`. Godot's .NET export plugin
+   **requires** `<assembly_name>.sln` in the project root — without it every
+   export fails with *"This project contains C# files but no solution file was
+   found"*. Include the facade project so solution builds pick up the same
+   `Debug` / `ExportDebug` / `ExportRelease` configuration:
+
+   ```powershell
+   dotnet new sln --name MyGame
+   dotnet sln MyGame.sln add MyGame.csproj addons/godot_gdk_csharp/GodotGdkCSharp.csproj
+   ```
+
+   Then add the `ExportDebug` and `ExportRelease` solution configurations (the
+   tutorial samples' `.sln` files show the expected shape). `MyGame` must match
+   `dotnet/project/assembly_name` in `project.godot`.
+
+4. (Optional) Register the C# bootstrap autoload instead of the GDScript one.
    Create a project-local subclass so Godot can resolve it by script path:
 
    ```csharp

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -117,6 +117,49 @@ launch with *"GDExtension dynamic library not found"* are now hard errors:
   (`cmake --build build --preset release`) instead of shipping a DLL-less
   package. In the export dialog, **Export With Debug** unchecked selects release.
 
+### Export-plugin shared objects / C# assemblies (issue #144)
+
+A third silent failure mode was that an `XBOX on PC` export produced a package
+containing **no C# assemblies at all** — the `data_<assembly>_windows_x86_64`
+folder that a Godot .NET build normally places next to the `.exe` was simply
+absent, so a C# project failed at launch.
+
+Godot hands an export platform two separate things: the resource `.pck`, and a
+list of **shared objects** that export plugins registered via
+`add_shared_object()` during `_export_begin`. The C# export plugin publishes the
+managed assemblies to a temp directory and registers **every published file** as
+a shared object targeted at `data_<assembly>_windows_x86_64/`. That list is the
+*only* channel through which those assemblies reach a package.
+
+The platform used to build the `.pck` with `EditorExportPlatform.export_pack()`,
+which is the wrong primitive for a custom platform:
+
+- it calls `save_pack()` with a **null shared-object sink**, discarding every
+  registered shared object, and
+- it opens a **second** `ExportNotifier` inside the one
+  `EditorExportPlatformExtension` already opens around `_export_project()`, so
+  each export plugin's `_export_begin` / `_export_end` runs **twice** (the C#
+  publish ran twice) and the inner `_export_end` deleted the C# publish temp
+  directory before the platform could copy anything out of it.
+
+`_export_pck()` now calls `EditorExportPlatform.save_pack()` — available since
+Godot 4.4 — which returns `{"result": Error, "so_files": Array}`. Each entry is
+`{path, tags, target_folder}`; `_stage_shared_objects()` copies it into the
+staging directory, placing an entry with an empty `target_folder` next to the
+`.exe` and everything else inside that folder, exactly as Godot's built-in
+desktop exporter does. Targets that would escape the staging root are rejected.
+
+Shared objects living directly in `addons/<name>/bin/` are skipped, because
+`_copy_addon_dlls()` already stages those with debug/release filtering and the
+`addons/` layout the `.gdextension` expects; staging them twice would also leave
+an unfiltered duplicate in the package root. Shared objects from anywhere else
+(the C# publish temp dir, a GDExtension that does not use the `bin/` layout) are
+staged by `_stage_shared_objects()`.
+
+Projects that enable **Embed Build Outputs** are unaffected either way: in that
+mode the C# plugin writes the assemblies into the `.pck` via `add_file()`
+instead of registering shared objects.
+
 ### GDK detection lifecycle
 
 The platform locates the Microsoft GDK (install root + `makepkg.exe` /

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -160,6 +160,66 @@ Projects that enable **Embed Build Outputs** are unaffected either way: in that
 mode the C# plugin writes the assemblies into the `.pck` via `add_file()`
 instead of registering shared objects.
 
+### Why "Export Project…" is greyed out
+
+Godot enables the export dialog's **Export Project…** / **Export All…** buttons
+purely from what the platform's validation callbacks return, and displays *no*
+explanation unless the platform supplies one via `set_config_error()`. A bare
+`return false` therefore left the user staring at a dead button.
+
+`_has_valid_export_configuration()` now collects **every** blocker in one pass
+and reports them together:
+
+| Blocker | What the dialog says |
+| --- | --- |
+| Microsoft GDK not installed / no `makepkg.exe` + `wdapp.exe` | install command (`winget install Microsoft.Gaming.GDK`) and "restart the editor" |
+| `MicrosoftGame.config` missing from the configured game-config directory | the exact path probed, the **GDK ▸ Create Game Config…** menu entry, the `.template` fallback, and the `gdk/packaging/game_config_dir` Project Setting |
+| No Windows export template for the running Godot version (packaged export only) | the failing config (`debug`/`release`), the Godot version, and **Editor ▸ Manage Export Templates…** |
+| No Windows **.NET/Mono** export template, on a project containing C# | the same, plus that the .NET template package is required and that loose dev-register cannot substitute for it |
+
+The template check also calls `set_config_missing_templates(true)` so Godot
+shows its built-in **Manage Export Templates** shortcut. It is skipped when
+**Dev ▸ Register Loose** is on, because a loose dev-register build does not
+need a template — *except* on a C# project, which always needs a real .NET
+template (see below). `_has_valid_project_configuration()` reports the
+missing-GDK reason through the same message helper.
+
+Each blocker is reported independently, so a project missing both the GDK and
+`MicrosoftGame.config` sees both lines instead of only the first.
+
+### .NET export templates for C# projects (".NET assemblies not found")
+
+`_find_windows_template()` probes
+`%APPDATA%\Godot\export_templates\<version>\windows_<config>_x86_64.exe`. Godot
+appends its module config to that directory name, so a **.NET editor build**
+installs its templates under `4.7.1.stable.mono`, not `4.7.1.stable`. Probing
+only the plain name found nothing on a .NET editor, and the export silently fell
+back to `OS.get_executable_path()` — the Godot **editor** binary.
+
+That fallback is fatal for a C# game. The editor binary is built with
+`TOOLS_ENABLED`, so it resolves .NET assemblies from `<exe_dir>/GodotSharp/Api/`
+instead of the exported `data_<assembly>_windows_x86_64/` directory, and the
+game dies on startup with:
+
+> Unable to find the .NET assemblies directory. Make sure the
+> `…/GodotSharp/Api/Debug` directory exists and contains the .NET assemblies.
+
+Two changes close this:
+
+- `_template_version_dirs()` takes a `p_dotnet` flag. When the running editor is
+  a .NET build (`_is_dotnet_editor()`, i.e. `ClassDB.class_exists("CSharpScript")`)
+  every candidate directory gets a `.mono` suffix, and the plain names are
+  **dropped** rather than offered as a fallback — a non-.NET template has no
+  assembly loader and could never host a C# game.
+- `_is_dotnet_project()` (a .NET editor *and* a non-empty
+  `dotnet/project/assembly_name`) makes a real template mandatory. Unlike a
+  GDScript project, a C# project does **not** get the loose dev-register
+  editor-binary fallback; both `_has_valid_export_configuration()` and
+  `_export_project()` hard-fail with a message naming the .NET template package.
+
+A GDScript project on a standard (non-.NET) editor build is unaffected: the
+candidate list and the loose fallback behave exactly as before.
+
 ### GDK detection lifecycle
 
 The platform locates the Microsoft GDK (install root + `makepkg.exe` /

--- a/docs/playfab/csharp.md
+++ b/docs/playfab/csharp.md
@@ -20,7 +20,15 @@ native DLL is unchanged.
    </ItemGroup>
    ```
 
-3. (Optional) C# bootstrap autoload:
+3. Add a solution file next to `project.godot`. Godot's .NET export plugin
+   **requires** `<assembly_name>.sln` in the project root — without it every
+   export fails with *"This project contains C# files but no solution file was
+   found"*. Include both facade projects so solution builds use the same
+   `Debug` / `ExportDebug` / `ExportRelease` configuration. See
+   [`../gdk/csharp.md`](../gdk/csharp.md#setup) and the `.sln` files in
+   `sample/tutorial_playfab_csharp/` for the expected shape.
+
+4. (Optional) C# bootstrap autoload:
 
    ```csharp
    // Autoload/PlayFabBootstrap.cs

--- a/sample/tutorial_gameinput_csharp/TutorialGameInputCSharp.sln
+++ b/sample/tutorial_gameinput_csharp/TutorialGameInputCSharp.sln
@@ -1,0 +1,30 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialGameInputCSharp", "TutorialGameInputCSharp.csproj", "{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotGameInputCSharp", "..\..\addons\godot_gameinput_csharp\GodotGameInputCSharp.csproj", "{5A3014B0-1417-4EB0-8370-79ACE9D04F04}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{7913DE1C-AADF-4ABA-8FC9-FC78A9FA7AC5}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{5A3014B0-1417-4EB0-8370-79ACE9D04F04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A3014B0-1417-4EB0-8370-79ACE9D04F04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A3014B0-1417-4EB0-8370-79ACE9D04F04}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{5A3014B0-1417-4EB0-8370-79ACE9D04F04}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{5A3014B0-1417-4EB0-8370-79ACE9D04F04}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{5A3014B0-1417-4EB0-8370-79ACE9D04F04}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/sample/tutorial_gdk_csharp/TutorialGdkCSharp.sln
+++ b/sample/tutorial_gdk_csharp/TutorialGdkCSharp.sln
@@ -1,0 +1,30 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialGdkCSharp", "TutorialGdkCSharp.csproj", "{C2BB6F0C-2018-4143-9B24-FADD36EF111A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotGdkCSharp", "..\..\addons\godot_gdk_csharp\GodotGdkCSharp.csproj", "{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C2BB6F0C-2018-4143-9B24-FADD36EF111A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2BB6F0C-2018-4143-9B24-FADD36EF111A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2BB6F0C-2018-4143-9B24-FADD36EF111A}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{C2BB6F0C-2018-4143-9B24-FADD36EF111A}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{C2BB6F0C-2018-4143-9B24-FADD36EF111A}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{C2BB6F0C-2018-4143-9B24-FADD36EF111A}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{1D36CDC9-D4BF-4CFE-8D59-462FE1D6126F}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/sample/tutorial_integrated_csharp/TutorialIntegratedCSharp.sln
+++ b/sample/tutorial_integrated_csharp/TutorialIntegratedCSharp.sln
@@ -1,0 +1,38 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialIntegratedCSharp", "TutorialIntegratedCSharp.csproj", "{5ED3E0F9-1648-4733-AB32-430833A7777C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotGdkCSharp", "..\..\addons\godot_gdk_csharp\GodotGdkCSharp.csproj", "{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotPlayFabCSharp", "..\..\addons\godot_playfab_csharp\GodotPlayFabCSharp.csproj", "{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5ED3E0F9-1648-4733-AB32-430833A7777C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED3E0F9-1648-4733-AB32-430833A7777C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED3E0F9-1648-4733-AB32-430833A7777C}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{5ED3E0F9-1648-4733-AB32-430833A7777C}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{5ED3E0F9-1648-4733-AB32-430833A7777C}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{5ED3E0F9-1648-4733-AB32-430833A7777C}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{C34EE5FA-2ADE-4F6F-A62B-A9966B2AE318}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{5B11253E-CF9A-414E-BF4C-8AC65981E2B8}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/sample/tutorial_playfab_csharp/TutorialPlayFabCSharp.sln
+++ b/sample/tutorial_playfab_csharp/TutorialPlayFabCSharp.sln
@@ -1,0 +1,38 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialPlayFabCSharp", "TutorialPlayFabCSharp.csproj", "{1C777E4A-09E8-4076-830D-663BC24DCA82}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotPlayFabCSharp", "..\..\addons\godot_playfab_csharp\GodotPlayFabCSharp.csproj", "{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GodotGdkCSharp", "..\..\addons\godot_gdk_csharp\GodotGdkCSharp.csproj", "{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1C777E4A-09E8-4076-830D-663BC24DCA82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C777E4A-09E8-4076-830D-663BC24DCA82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C777E4A-09E8-4076-830D-663BC24DCA82}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{1C777E4A-09E8-4076-830D-663BC24DCA82}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{1C777E4A-09E8-4076-830D-663BC24DCA82}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{1C777E4A-09E8-4076-830D-663BC24DCA82}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{4CBB1E58-7DAB-4AD2-A10B-19E04CA6083F}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{C1E7C605-F776-4DCC-8835-0CAC1E7E1729}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/godot/gdk/tests/test_export_platform_errors.gd
+++ b/tests/godot/gdk/tests/test_export_platform_errors.gd
@@ -223,6 +223,76 @@ func test_find_windows_template_uses_version_dir_helper() -> void:
 		"_find_windows_template resolves candidates via _template_version_dirs")
 
 
+# ── .NET template resolution (".NET assemblies not found") ────────────────
+#
+# Godot resolves export templates from `<version>.mono` when the editor is a
+# .NET build. Looking only at the plain `<version>` dir found nothing, so a C#
+# project silently fell back to the Godot editor binary — which starts up
+# looking for `<exe_dir>/GodotSharp/Api/Debug` and aborts with ".NET assemblies
+# not found" instead of loading the exported `data_*` assemblies.
+
+func test_template_version_dirs_uses_mono_suffix_for_dotnet() -> void:
+	var dirs := ExportPlatform._template_version_dirs(
+		{"major": 4, "minor": 7, "patch": 1, "status": "stable"}, true)
+	assert_eq(dirs[0], "4.7.1.stable.mono",
+		"a .NET editor resolves the patch-qualified .mono template dir first")
+	for dir_name: String in dirs:
+		assert_true(dir_name.ends_with(".mono"),
+			"a non-.NET template cannot host a C# game, so plain dirs are not offered")
+
+
+func test_template_version_dirs_default_is_non_mono() -> void:
+	var dirs := ExportPlatform._template_version_dirs(
+		{"major": 4, "minor": 7, "patch": 1, "status": "stable"})
+	assert_eq(dirs[0], "4.7.1.stable",
+		"a standard editor build keeps resolving the plain template dir")
+
+
+func test_find_windows_template_asks_whether_editor_is_dotnet() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	assert_string_contains(_func_body(src, "_find_windows_template"),
+		"_is_dotnet_editor()",
+		"_find_windows_template selects .mono candidates on a .NET editor build")
+
+
+func test_dotnet_project_detection_requires_assembly_name() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_is_dotnet_project")
+	assert_string_contains(body, "_is_dotnet_editor()",
+		"a C# project is only possible on a .NET editor build")
+	assert_string_contains(body, "dotnet/project/assembly_name",
+		"C# projects are detected via the assembly name Godot resolves for them")
+	assert_string_contains(_func_body(src, "_is_dotnet_editor"), "CSharpScript",
+		"only .NET editor builds expose CSharpScript")
+
+
+func test_dotnet_missing_template_message_is_actionable() -> void:
+	var msg: String = ExportPlatform._dotnet_requires_template_message(false)
+	assert_string_contains(msg, ".NET",
+		"the message names the .NET template package the user must install")
+	assert_string_contains(msg, "Manage Export Templates",
+		"the message points at the editor's template manager")
+	assert_string_contains(msg, "assemblies not found",
+		"the message ties the failure to the runtime symptom the user sees")
+	assert_string_contains(ExportPlatform._missing_template_message(false, true), ".NET",
+		"the shared template message can name the .NET flavor")
+
+
+func test_export_refuses_editor_binary_for_dotnet_even_when_loose() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_export_project")
+	assert_string_contains(body, "_is_dotnet_project()",
+		"a C# project is checked before the loose editor-binary fallback")
+	var dotnet_idx: int = body.find("_is_dotnet_project()")
+	var loose_idx: int = body.find("OS.get_executable_path()")
+	assert_true(dotnet_idx != -1 and loose_idx != -1 and dotnet_idx < loose_idx,
+		"the C# hard error precedes the loose editor-binary fallback")
+
+	var validation := _func_body(src, "_has_valid_export_configuration")
+	assert_string_contains(validation, "_dotnet_requires_template_message",
+		"export validation blocks a template-less C# export up front")
+
+
 # ── Zero-GDExtension-DLL guard (issue #134) ───────────────────────────────
 #
 # A build that stages no GDExtension main DLL loads with "GDExtension dynamic
@@ -356,3 +426,53 @@ func test_non_addon_bin_shared_objects_are_staged() -> void:
 		"C:/proj/addons/godot_gdk/bin/sub/nested.dll", project),
 		"only files directly in addons/<name>/bin/ are owned by _copy_addon_dlls")
 
+
+# ── Silent disabled Export button ─────────────────────────────────────────
+#
+# Godot greys out "Export Project…" / "Export All…" purely on the boolean the
+# validation callbacks return, and shows no explanation unless the platform
+# reports one through set_config_error(). Returning a bare `false` therefore
+# leaves the user with a dead button and no diagnosis.
+
+func test_validation_messages_are_actionable() -> void:
+	assert_string_contains(ExportPlatform._gdk_missing_message(), "winget install Microsoft.Gaming.GDK",
+		"the GDK-missing message names the install command")
+
+	var config_msg: String = ExportPlatform._missing_game_config_message("C:/proj/MicrosoftGame.config")
+	assert_string_contains(config_msg, "C:/proj/MicrosoftGame.config",
+		"the game-config message names the exact path that was probed")
+	assert_string_contains(config_msg, "Create Game Config",
+		"the game-config message points at the editor menu that authors it")
+	assert_string_contains(config_msg, "gdk/packaging/game_config_dir",
+		"the game-config message names the Project Setting that relocates it")
+
+	assert_string_contains(ExportPlatform._missing_template_message(false), "release",
+		"the template message names the failing configuration")
+	assert_string_contains(ExportPlatform._missing_template_message(true), "debug",
+		"the debug variant names the debug configuration")
+	assert_string_contains(ExportPlatform._missing_template_message(false), "Manage Export Templates",
+		"the template message points at the editor's template manager")
+
+
+func test_has_valid_export_configuration_reports_every_blocker() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_has_valid_export_configuration")
+	assert_ne(body, "", "_has_valid_export_configuration() is defined")
+	assert_string_contains(body, "set_config_error(",
+		"validation surfaces its reason via set_config_error()")
+	for message_fn: String in ["_gdk_missing_message", "_missing_game_config_message", "_missing_template_message"]:
+		assert_string_contains(body, message_fn,
+			"%s() feeds the export-dialog error text" % message_fn)
+	assert_string_contains(body, "set_config_missing_templates(true)",
+		"a missing export template is flagged so the dialog offers the template manager")
+	assert_string_contains(body, "dev/register_loose",
+		"loose dev-register stays exempt from the export-template requirement")
+
+
+func test_has_valid_project_configuration_reports_missing_gdk() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_has_valid_project_configuration")
+	assert_string_contains(body, "set_config_error(",
+		"project validation surfaces its reason via set_config_error()")
+	assert_string_contains(body, "_gdk_missing_message",
+		"the missing-GDK reason is shared with export validation")

--- a/tests/godot/gdk/tests/test_export_platform_errors.gd
+++ b/tests/godot/gdk/tests/test_export_platform_errors.gd
@@ -269,3 +269,90 @@ func test_export_refuses_editor_binary_when_packaging() -> void:
 		"a non-loose (packaged) export refuses to continue without a real template")
 	assert_string_contains(body, "OS.get_executable_path()",
 		"the editor-binary fallback remains reachable for loose dev-register")
+
+
+# ── Export-plugin shared objects / C# assemblies (issue #144) ─────────────
+#
+# `export_pack()` calls `save_pack()` with a null shared-object sink and opens a
+# second ExportNotifier inside the one EditorExportPlatformExtension already
+# opened around `_export_project()`. That ran every export plugin's
+# `_export_begin`/`_export_end` twice AND discarded everything the plugins
+# registered via `add_shared_object()`. Godot ships a C#/.NET project's
+# published assemblies exclusively as shared objects targeted at
+# `data_<assembly>_windows_x86_64/`, so an `XBOX on PC` export produced a
+# package with zero managed DLLs. `save_pack()` returns those entries so the
+# platform can stage them itself.
+
+func test_export_pck_uses_save_pack_to_capture_shared_objects() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_export_pck")
+	assert_string_contains(body, "save_pack(",
+		"_export_pck() uses save_pack() so so_files come back to the platform")
+	assert_false(body.contains("export_pack("),
+		"export_pack() drops add_shared_object() entries and double-fires " +
+		"every export plugin's _export_begin/_export_end — issue #144")
+
+
+func test_export_project_stages_shared_objects_before_addon_dlls() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_export_project")
+	assert_string_contains(body, "_stage_shared_objects(",
+		"the export stages the shared objects save_pack() reported")
+	assert_string_contains(body, "so_files",
+		"the export reads save_pack()'s so_files list")
+	var so_at := body.find("_stage_shared_objects(")
+	var dll_at := body.find("_copy_addon_dlls(")
+	assert_true(so_at != -1 and dll_at != -1 and so_at < dll_at,
+		"shared objects are staged before _copy_addon_dlls() so its " +
+		"already-present guard keeps addon DLLs authoritative")
+
+
+func test_shared_object_without_target_lands_next_to_the_exe() -> void:
+	var dest: String = ExportPlatform._shared_object_destination(
+		"C:/out/_gdk_staging", "C:/tmp/publish/Game.dll", "")
+	assert_eq(dest, "C:/out/_gdk_staging/Game.dll",
+		"an empty target folder means the package root")
+
+
+func test_shared_object_target_folder_is_preserved() -> void:
+	var dest: String = ExportPlatform._shared_object_destination(
+		"C:/out/_gdk_staging", "C:/tmp/publish/Game.dll", "data_Game_windows_x86_64")
+	assert_eq(dest, "C:/out/_gdk_staging/data_Game_windows_x86_64/Game.dll",
+		"the C# data_<assembly>_windows_x86_64 target folder is honoured")
+
+
+func test_shared_object_nested_target_folder_is_preserved() -> void:
+	var dest: String = ExportPlatform._shared_object_destination(
+		"C:/out/_gdk_staging", "C:/tmp/publish/sub/dep.dll",
+		"data_Game_windows_x86_64/sub")
+	assert_eq(dest, "C:/out/_gdk_staging/data_Game_windows_x86_64/sub/dep.dll",
+		"nested publish subdirectories keep their relative layout")
+
+
+func test_shared_object_target_cannot_escape_the_staging_dir() -> void:
+	for target: String in ["..", "../../elsewhere", "/abs/path", "C:/abs", "res://x"]:
+		var dest: String = ExportPlatform._shared_object_destination(
+			"C:/out/_gdk_staging", "C:/tmp/publish/Game.dll", target)
+		assert_eq(dest, "",
+			"target %s must be rejected instead of writing outside the package" % target)
+
+
+func test_addon_bin_libraries_are_left_to_copy_addon_dlls() -> void:
+	var project := "C:/proj/"
+	assert_true(ExportPlatform._is_addon_bin_library(
+		"C:/proj/addons/godot_gdk/bin/godot_gdk.windows.debug.x86_64.dll", project),
+		"addons/<name>/bin/ DLLs are staged by _copy_addon_dlls with config filtering")
+
+
+func test_non_addon_bin_shared_objects_are_staged() -> void:
+	var project := "C:/proj/"
+	assert_false(ExportPlatform._is_addon_bin_library(
+		"C:/tmp/godot-publish-dotnet/1234-ExportRelease-win-x64/Game.dll", project),
+		"C# publish output is outside the project and must be staged")
+	assert_false(ExportPlatform._is_addon_bin_library(
+		"C:/proj/addons/other/lib/native.dll", project),
+		"a GDExtension outside addons/<name>/bin/ still needs staging")
+	assert_false(ExportPlatform._is_addon_bin_library(
+		"C:/proj/addons/godot_gdk/bin/sub/nested.dll", project),
+		"only files directly in addons/<name>/bin/ are owned by _copy_addon_dlls")
+


### PR DESCRIPTION
## Summary

Exporting a C# project with the **XBOX on PC** platform was broken in two independent ways. The first had to be fixed before the second became visible, so this PR carries both.

A C# export now produces a package that launches, with a populated `data_<assembly>_windows_x86_64/` next to the `.exe`.

Fixes #144.

## 1. Export-plugin shared objects were discarded (#144)

An `XBOX on PC` export produced a package containing **no C# assemblies at all** — the `data_<assembly>_windows_x86_64` folder that a Godot .NET build normally places next to the `.exe` was simply absent, so the game failed at launch.

Godot hands an export platform two separate things: the resource `.pck`, and a list of **shared objects** that export plugins registered via `add_shared_object()` during `_export_begin`. The C# export plugin publishes managed assemblies to a temp directory and registers every published file as a shared object targeted at `data_<assembly>_windows_x86_64/`. **That list is the only channel through which those assemblies reach a package.**

`_export_pck()` built the `.pck` with `EditorExportPlatform.export_pack()`, which is the wrong primitive for a custom platform:

- it calls `save_pack()` with a **null shared-object sink**, discarding every registered shared object, and
- it opens a **second** `ExportNotifier` inside the one `EditorExportPlatformExtension` already opens around `_export_project()`, so each export plugin's `_export_begin`/`_export_end` runs **twice** — the C# publish ran twice, and the inner `_export_end` deleted the publish temp directory before the platform could copy anything out of it.

`_export_pck()` now uses `EditorExportPlatform.save_pack()` (Godot 4.4+), which returns `{"result": Error, "so_files": Array}`. The new `_stage_shared_objects()` copies each entry into the staging directory — empty `target_folder` next to the `.exe`, everything else inside that folder — exactly as Godot's built-in desktop exporter does. Targets that would escape the staging root are rejected.

Shared objects living directly in `addons/<name>/bin/` are skipped, since `_copy_addon_dlls()` already stages those with debug/release filtering and the `addons/` layout the `.gdextension` expects. Projects using **Embed Build Outputs** are unaffected — that mode writes assemblies into the `.pck` via `add_file()` instead.

## 2. Solution files the C# samples were always missing

With the export actually running, it failed before it started — once per source file:

```
[Export .NET Project]: This project contains C# files but no solution file
was found at the following path: <project>/<AssemblyName>.sln
```

Godot resolves that path from `dotnet/project/assembly_name` and requires the solution to exist for **every** export. All four C# tutorial samples landed with a hand-authored `.csproj` but no `.sln` — the editor only emits a solution when it generates the `.csproj` itself, so nothing ever created one, and no export of these samples had been attempted since. **These files should have shipped alongside the `.csproj` they accompany.**

Each solution matches the shape Godot's own generator produces (UTF-8 with BOM; `Debug` / `ExportDebug` / `ExportRelease`), with one deliberate deviation: they also list the facade projects the game references, **transitively**. A referenced project absent from the solution gets no configuration mapping, so MSBuild silently falls back to `Debug` — an `ExportRelease` build would otherwise ship a Debug-built facade.

```console
# before — facade built in Debug during an ExportRelease solution build
$ dotnet build TutorialGdkCSharp.sln -c ExportRelease
  GodotGdkCSharp -> .../bin/Debug/GodotGdkCSharp.dll

# after — every project lands in ExportRelease
  GodotGdkCSharp -> .../bin/ExportRelease/GodotGdkCSharp.dll
```

The requirement is documented as a setup step in `docs/gdk/csharp.md`, `docs/playfab/csharp.md` and `docs/gameinput/csharp.md`, since it applies to any game project using these facades:

```console
dotnet new sln -n MyGame
dotnet sln MyGame.sln add MyGame.csproj
```

## Also: validation never explained itself

Godot enables the export dialog's buttons purely from what the validation callbacks return, and shows nothing unless the platform supplies a reason via `set_config_error()`. The bare `return false`s left a dead **Export Project…** button with no diagnosis.

`_has_valid_export_configuration()` now collects **every** blocker in one pass — missing GDK, missing `MicrosoftGame.config`, missing export template — and reports them together, so a project missing two things sees two lines instead of only the first. Missing templates also call `set_config_missing_templates(true)` so Godot offers its built-in **Manage Export Templates** shortcut.

## Public API

No public GDScript API changed — every affected method is internal to the export platform.

## Validation

- `tools/check_gd_scripts_headless.ps1` — passed
- `cmake --build build --preset debug` — succeeded (addon mirrors re-synced)
- `dotnet build <sln> -c ExportRelease` — succeeded for all four solutions, every project in `bin/ExportRelease/`
- GUT `test_export_platform_errors.gd` — **39/39**, including new tests for `save_pack()` usage, shared-object staging and staging-root escape rejection, template resolution, and validation error-ordering
- Full `tests/godot/gdk` GUT host — **293 passed**, 1 pre-existing unrelated failure (`test_game_chat.gd` live loopback, present on `main`)
- **End-to-end**, headless `--export-release "XBOX on PC"` on `sample/tutorial_gdk_csharp`: 189 export-plugin shared objects staged, and `data_TutorialGdkCSharp_windows_x86_64/` contains `TutorialGdkCSharp.dll`, `GodotGdkCSharp.dll`, `GodotSharp.dll`
- Live tests: **skipped** (default; no `-Live`)
