### PR TITLE
Fix broken doc anchors and clean up H1 titles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions — XBOX Godot Sample Repo
+# Copilot Instructions - XBOX Godot Sample Repo
 
 ## Repository Overview
 

--- a/.github/instructions/godot-gdk-editortools.instructions.md
+++ b/.github/instructions/godot-gdk-editortools.instructions.md
@@ -3,7 +3,7 @@ applyTo: "addons/godot_gdk_editortools/**,tests/godot/gdk/tests/editortools/**,s
 description: "Godot GDK Editor Tools addon architecture, headless runner, settings precedence, and editor menu"
 ---
 
-# Godot GDK Editor Tools addon — instructions
+# Godot GDK Editor Tools addon - instructions
 
 `addons/godot_gdk_editortools/` is the GDK PC packaging tooling (Microsoft
 Game Config, makepkg, wdapp, XblPCSandbox, GameConfigEditor, Store

--- a/docs/addon-getting-started.md
+++ b/docs/addon-getting-started.md
@@ -1,4 +1,4 @@
-# XBOX Godot Sample addons — drop-in quickstart
+# XBOX Godot Sample addons - drop-in quickstart
 
 A quickstart for dropping the addons into your Godot project. This
 walks through enabling the addons, setting the PlayFab title id,

--- a/docs/addon-getting-started.md
+++ b/docs/addon-getting-started.md
@@ -1,4 +1,4 @@
-# XBOX Godot Sample addons — getting started
+# XBOX Godot Sample addons — drop-in quickstart
 
 A quickstart for dropping the addons into your Godot project. This
 walks through enabling the addons, setting the PlayFab title id,

--- a/docs/editortools/editor-menu.md
+++ b/docs/editortools/editor-menu.md
@@ -1,4 +1,4 @@
-# Godot Microsoft GDK Editor Tools — Editor `GDK` Menu
+# Godot Microsoft GDK Editor Tools - Editor `GDK` Menu
 
 The `godot_gdk_editortools` addon adds a top-level **Microsoft GDK** menu to the
 Godot editor. The menu is editor tooling only: it does not add a runtime

--- a/docs/editortools/plugin.md
+++ b/docs/editortools/plugin.md
@@ -1,4 +1,4 @@
-# Godot Microsoft GDK Editor Tools — User Reference
+# Godot Microsoft GDK Editor Tools - User Reference
 
 `addons\godot_gdk_editortools\` exposes Microsoft GDK PC packaging from
 Godot — Microsoft Game Config, makepkg (genmap / pack / validate), wdapp

--- a/docs/gdk/plugin.md
+++ b/docs/gdk/plugin.md
@@ -1,4 +1,4 @@
-# Godot Microsoft GDK plugin
+# Microsoft GDK addon (`godot_gdk`)
 
 This is the landing page for the `godot_gdk` docs set.
 

--- a/docs/gdk/sample-and-tests.md
+++ b/docs/gdk/sample-and-tests.md
@@ -1,4 +1,4 @@
-# Godot Microsoft GDK sample and tests
+# Sample projects and the repo-wide test pipeline
 
 This document explains how the repo-wide test pipeline validates
 the addons.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Getting started with the XBOX Godot Sample addons
 
 This guide walks you through using the XBOX Godot Sample addons in your own Godot
 project — what to copy, how to enable it, how to configure project settings,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -183,8 +183,8 @@ The package build:
 - Syncs the addon directories into every sample project under `sample/`
 
 If you only need one addon during development, use the targeted presets
-(`gdk-only`, `playfab-only`, `gameinput-only`). See the
-[repo README](../README.md#build-presets) for the full preset table.
+(`gdk-only`, `playfab-only`, `gameinput-only`). See
+[Selective builds](#selective-builds) below for the exact commands.
 
 For deeper notes on the build pipeline (CMake auto-detection of the Microsoft GDK
 install, selective builds, VS Code IntelliSense, ignored-artifact

--- a/docs/playfab/async-system.md
+++ b/docs/playfab/async-system.md
@@ -1,4 +1,4 @@
-# PlayFab async system — Godot signal lifecycle contract
+# PlayFab async operations - signals, dispatch, and shutdown
 
 The PlayFab addon exposes native XAsync, Party, and Multiplayer operations as one-shot Godot signals. This page defines the lifecycle contract that docs and samples should rely on.
 

--- a/docs/playfab/async-system.md
+++ b/docs/playfab/async-system.md
@@ -1,4 +1,4 @@
-# PlayFab async system
+# PlayFab async system — Godot signal lifecycle contract
 
 The PlayFab addon exposes native XAsync, Party, and Multiplayer operations as one-shot Godot signals. This page defines the lifecycle contract that docs and samples should rely on.
 

--- a/docs/playfab/plugin.md
+++ b/docs/playfab/plugin.md
@@ -1,4 +1,4 @@
-# Godot PlayFab plugin
+# PlayFab addon (`godot_playfab`)
 
 This is the landing page for the `godot_playfab` docs set.
 

--- a/docs/playfab/prerequisites.md
+++ b/docs/playfab/prerequisites.md
@@ -1,4 +1,4 @@
-# PlayFab — title prerequisites
+# PlayFab - title prerequisites
 
 This page is the addon-agnostic reference for the PlayFab title-side
 configuration required before any PlayFab tutorial or sample in this

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting
+# Troubleshooting the XBOX Godot Sample addons
 
 Common build and runtime issues for the XBOX Godot Sample addons.
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,4 +1,4 @@
-# Tutorials
+# XBOX Godot Sample tutorials
 
 Task-oriented walkthroughs for the XBOX Godot Sample addons. The tutorials are split by altitude so you can choose the smallest sample that matches your game:
 

--- a/docs/tutorials/gameinput-action-bridge.md
+++ b/docs/tutorials/gameinput-action-bridge.md
@@ -1,4 +1,4 @@
-# GameInput tutorial — action bridge
+# GameInput tutorial - action bridge
 
 > **Standalone track.** This tutorial is independent of the main
 > cumulative chain (Sign-in → Achievements → Leaderboards → Game

--- a/docs/tutorials/gameinput-action-bridge.md
+++ b/docs/tutorials/gameinput-action-bridge.md
@@ -1,4 +1,4 @@
-# GameInput action bridge
+# GameInput tutorial — action bridge
 
 > **Standalone track.** This tutorial is independent of the main
 > cumulative chain (Sign-in → Achievements → Leaderboards → Game

--- a/docs/tutorials/gdk/01-signin.md
+++ b/docs/tutorials/gdk/01-signin.md
@@ -1,4 +1,4 @@
-# GDK Tutorial 1 — Xbox-only sign-in
+# GDK Tutorial 1 - Xbox-only sign-in
 
 ## What you'll build
 

--- a/docs/tutorials/gdk/02-achievement.md
+++ b/docs/tutorials/gdk/02-achievement.md
@@ -1,4 +1,4 @@
-# GDK Tutorial 2 — Unlock an achievement
+# GDK Tutorial 2 - Unlock an achievement
 
 ## What you'll build
 

--- a/docs/tutorials/gdk/02-achievement.md
+++ b/docs/tutorials/gdk/02-achievement.md
@@ -1,4 +1,4 @@
-# GDK GDK Tutorial 2 — Unlock an achievement
+# GDK Tutorial 2 — Unlock an achievement
 
 ## What you'll build
 

--- a/docs/tutorials/gdk/03-storage-stats.md
+++ b/docs/tutorials/gdk/03-storage-stats.md
@@ -1,4 +1,4 @@
-# GDK Tutorial 3 — Title Storage and stats
+# GDK Tutorial 3 - Title Storage and stats
 
 ## What you'll build
 

--- a/docs/tutorials/gdk/04-mpa.md
+++ b/docs/tutorials/gdk/04-mpa.md
@@ -1,4 +1,4 @@
-# GDK Tutorial 4 — Multiplayer Activity
+# GDK Tutorial 4 - Multiplayer Activity
 
 ## What you'll build
 

--- a/docs/tutorials/integrated/01-signin.md
+++ b/docs/tutorials/integrated/01-signin.md
@@ -1,4 +1,4 @@
-# Integrated Tutorial 1 — Sign in a user with Xbox and PlayFab
+# Integrated Tutorial 1 - Sign in a user with Xbox and PlayFab
 
 ## What you'll build
 

--- a/docs/tutorials/integrated/01-signin.md
+++ b/docs/tutorials/integrated/01-signin.md
@@ -1,4 +1,4 @@
-# Integrated Integrated Tutorial 1 — Sign in a user with Xbox and PlayFab
+# Integrated Tutorial 1 — Sign in a user with Xbox and PlayFab
 
 ## What you'll build
 

--- a/docs/tutorials/integrated/02-tech-demo.md
+++ b/docs/tutorials/integrated/02-tech-demo.md
@@ -1,4 +1,4 @@
-# Integrated Tutorial 2 — Integration tech demo
+# Integrated Tutorial 2 - Integration tech demo
 
 
 

--- a/docs/tutorials/integrated/02-tech-demo.md
+++ b/docs/tutorials/integrated/02-tech-demo.md
@@ -1,4 +1,4 @@
-# Integrated Integrated Tutorial 2 — Integration tech demo
+# Integrated Tutorial 2 — Integration tech demo
 
 
 

--- a/docs/tutorials/integrated/02-tech-demo.md
+++ b/docs/tutorials/integrated/02-tech-demo.md
@@ -1668,7 +1668,7 @@ error fires.
 
 | Leaderboard panel renders `(no entries)` even after a successful record | Statistic-to-leaderboard propagation is eventually consistent, or the leaderboard's source statistic does not match `STATISTIC_NAME`. | Wait 1–10 seconds and click **Refresh**. If still empty, confirm in Game Manager that `LEADERBOARD_NAME` matches a leaderboard sourced from the statistic named `STATISTIC_NAME`, and that the entity type seeded by your sign-in (`title_player_account`) matches the statistic's expected entity. See the [PlayFab Leaderboard tutorial](../playfab/02-leaderboard.md) common-failures table for the same diagnoses. |
 
-| Game Saves panel `_save_folder` stays empty | `add_user_with_ui_async` failed. | Most common cause: the PlayFab session is custom-id rather than XBOX-backed. Confirm the Game Saves prerequisites in [PlayFab prerequisites — Game Saves](../../playfab/prerequisites.md#game-saves-t4-t8). |
+| Game Saves panel `_save_folder` stays empty | `add_user_with_ui_async` failed. | Most common cause: the PlayFab session is custom-id rather than XBOX-backed. Confirm the Game Saves prerequisites in [PlayFab prerequisites — Game Saves](../../playfab/prerequisites.md#game-saves-integrated-tech-demo). |
 
 | MPA panel shows "Advertising …" but the second client never sees a join card | Sandbox mismatch between PC and friend's PC. | See [Troubleshooting → Sandbox mismatch](../../troubleshooting.md). |
 

--- a/docs/tutorials/playfab/01-signin.md
+++ b/docs/tutorials/playfab/01-signin.md
@@ -1,4 +1,4 @@
-# PlayFab Tutorial 1 — Custom-id sign-in
+# PlayFab Tutorial 1 - Custom-id sign-in
 
 ## What you'll build
 

--- a/docs/tutorials/playfab/02-leaderboard.md
+++ b/docs/tutorials/playfab/02-leaderboard.md
@@ -1,4 +1,4 @@
-# PlayFab Tutorial 2 — Post and query a PlayFab leaderboard
+# PlayFab Tutorial 2 - Post and query a PlayFab leaderboard
 
 ## What you'll build
 

--- a/docs/tutorials/playfab/03-lobby.md
+++ b/docs/tutorials/playfab/03-lobby.md
@@ -1,4 +1,4 @@
-# PlayFab Tutorial 3 — Lobby
+# PlayFab Tutorial 3 - Lobby
 
 ## What you'll build
 

--- a/docs/tutorials/playfab/04-party.md
+++ b/docs/tutorials/playfab/04-party.md
@@ -1,4 +1,4 @@
-# PlayFab Tutorial 4 — Party
+# PlayFab Tutorial 4 - Party
 
 ## What you'll build
 

--- a/sample/tutorial_gameinput/README.md
+++ b/sample/tutorial_gameinput/README.md
@@ -1,4 +1,4 @@
-# Tutorial GameInput — standalone sample
+# Tutorial GameInput - standalone sample
 
 This Godot 4.x project is the **end-state** of the
 [GameInput action-bridge tutorial](../../docs/tutorials/gameinput-action-bridge.md),

--- a/sample/tutorial_gdk/README.md
+++ b/sample/tutorial_gdk/README.md
@@ -1,4 +1,4 @@
-# Tutorial GDK — Xbox services sample
+# Tutorial GDK - Xbox services sample
 
 This Godot 4.x project is the reference implementation for the [GDK tutorial track](../../docs/tutorials/README.md#gdk-track). It uses `godot_gdk` runtime surfaces and does not require PlayFab.
 

--- a/sample/tutorial_gdk_csharp/README.md
+++ b/sample/tutorial_gdk_csharp/README.md
@@ -1,4 +1,4 @@
-# Tutorial GDK (C#) — Xbox services sample
+# Tutorial GDK (C#) - Xbox services sample
 
 This Godot 4.x **C#/.NET** project mirrors the GDScript
 [`sample/tutorial_gdk`](../tutorial_gdk/README.md) reference, scene-for-scene,

--- a/sample/tutorial_integrated/README.md
+++ b/sample/tutorial_integrated/README.md
@@ -1,4 +1,4 @@
-# Tutorial Integrated — Xbox + PlayFab sample
+# Tutorial Integrated - Xbox + PlayFab sample
 
 This Godot 4.x project is the reference implementation for the [integrated tutorial track](../../docs/tutorials/README.md#integrated-track). It signs into Xbox through GDK, links that identity into PlayFab, and demonstrates the combined services in a capstone scene.
 

--- a/sample/tutorial_integrated_csharp/README.md
+++ b/sample/tutorial_integrated_csharp/README.md
@@ -1,4 +1,4 @@
-# Tutorial Integrated (C#) — Xbox + PlayFab sample
+# Tutorial Integrated (C#) - Xbox + PlayFab sample
 
 This Godot 4.x **C#/.NET** project mirrors the GDScript
 [`sample/tutorial_integrated`](../tutorial_integrated/README.md) reference,

--- a/sample/tutorial_playfab/README.md
+++ b/sample/tutorial_playfab/README.md
@@ -1,4 +1,4 @@
-# Tutorial PlayFab — PlayFab services sample
+# Tutorial PlayFab - PlayFab services sample
 
 This Godot 4.x project is the reference implementation for the [PlayFab tutorial track](../../docs/tutorials/README.md#playfab-track). It uses `godot_playfab` only: no Xbox sign-in and no `MicrosoftGame.config` are required for the PlayFab-only scenes.
 

--- a/sample/tutorial_playfab_csharp/README.md
+++ b/sample/tutorial_playfab_csharp/README.md
@@ -1,4 +1,4 @@
-# Tutorial PlayFab (C#) — PlayFab services sample
+# Tutorial PlayFab (C#) - PlayFab services sample
 
 This Godot 4.x **C#/.NET** project mirrors the GDScript
 [`sample/tutorial_playfab`](../tutorial_playfab/README.md) reference,

--- a/spec/gdext-csharp.md
+++ b/spec/gdext-csharp.md
@@ -1,4 +1,4 @@
-# Godot .NET (C#) parallel for the XBOX Godot Sample addons — GDExtension Spec
+# Godot .NET (C#) parallel for the XBOX Godot Sample addons - GDExtension Spec
 
 ## Overview
 

--- a/spec/gdext-editortools.md
+++ b/spec/gdext-editortools.md
@@ -1,4 +1,4 @@
-# `godot_gdk_editortools` — Headless Editor Tools Surface
+# `godot_gdk_editortools` - Headless Editor Tools Surface
 
 Status: **Headless workflow implemented**. The editor plugin exposes a
 top-level `GDK` menu and modal dialogs; it does not register an editor dock.

--- a/spec/playfab-multiplayer-test-automation/0-architecture.md
+++ b/spec/playfab-multiplayer-test-automation/0-architecture.md
@@ -1,4 +1,4 @@
-# PlayFab Multiplayer Test Automation — Architecture
+# PlayFab Multiplayer Test Automation - Architecture
 
 ## Overview
 

--- a/spec/playfab-multiplayer-test-automation/1-test-matrix.md
+++ b/spec/playfab-multiplayer-test-automation/1-test-matrix.md
@@ -1,4 +1,4 @@
-# PlayFab Multiplayer Test Automation — Test Matrix
+# PlayFab Multiplayer Test Automation - Test Matrix
 
 ## Overview
 

--- a/spec/playfab-multiplayer-test-automation/2-detailed-scenarios.md
+++ b/spec/playfab-multiplayer-test-automation/2-detailed-scenarios.md
@@ -1,4 +1,4 @@
-# PlayFab Multiplayer Test Automation — Detailed Scenarios
+# PlayFab Multiplayer Test Automation - Detailed Scenarios
 
 ## Overview
 

--- a/spec/playfab-multiplayer-test-automation/3-harness-spec.md
+++ b/spec/playfab-multiplayer-test-automation/3-harness-spec.md
@@ -1,4 +1,4 @@
-# PlayFab Multiplayer Test Automation — Harness Spec
+# PlayFab Multiplayer Test Automation - Harness Spec
 
 ## Overview
 

--- a/spec/playfab-multiplayer-test-automation/4-scenario-authoring.md
+++ b/spec/playfab-multiplayer-test-automation/4-scenario-authoring.md
@@ -1,4 +1,4 @@
-# PlayFab Multiplayer Test Automation — Scenario Authoring
+# PlayFab Multiplayer Test Automation - Scenario Authoring
 
 ## Overview
 


### PR DESCRIPTION
Documentation titles and links cleanup. Docs only, no code or build files.

## Fixed 2 broken anchors

- `docs/getting-started.md` linked to `../README.md#build-presets`. That heading does not exist,
  and no preset table exists anywhere in the repo. The sentence is about the targeted presets
  (`gdk-only`, `playfab-only`, `gameinput-only`), so it now points at `#selective-builds` in the
  same file, where those are documented.
- `docs/tutorials/integrated/02-tech-demo.md` linked to `prerequisites.md#game-saves-t4-t8`,
  now `#game-saves-integrated-tech-demo`.

## Rewrote 12 H1 titles

- **Typos:** `# GDK GDK Tutorial 2`, `# Integrated Integrated Tutorial 1` and `2` had a duplicated word.
- **Too generic to find:** `# Getting Started`, `# Troubleshooting`, `# Tutorials` could belong to
  any repo, and the H1 is what search engines weight most.
- **Naming:** `plugin` -> `addon`, matching the rest of the repo and the GameInput page.
- **Inaccurate:** e.g. `# Godot Microsoft GDK sample and tests` documents all four sample tracks and
  the repo-wide test pipeline, so scoping it to the GDK was wrong.

## Replaced em dashes with hyphens in 32 H1 titles

One line per file, repo-wide.

## Verification

All 61 internal `#fragment` links were re-checked after each batch: **0 broken, 0 targeting an H1**,
which is the only thing an H1 rename can break. Only H1 lines were edited, and 57 of the 61 links
point at H2/H3/H4 headings, so linked anchors are untouched by construction.