### PR TITLE
Skip PR gates for documentation-only changes

### DIFF
--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -40,9 +40,14 @@ name: PR Gates
 # ignored path AND anything else still runs every job. So a docs + code change is
 # gated exactly as it is today -- only pure docs/README churn is skipped.
 #
-# '**/*.md' covers Markdown at any depth, including root README.md/CONTRIBUTING.md,
-# docs/, spec/, and sample/*/README.md. 'docs/**' is redundant today (docs/ is
-# 100% Markdown) but keeps future doc assets such as screenshots out of the gates.
+# '**.md' covers Markdown at any depth, including root README.md/CONTRIBUTING.md,
+# docs/, spec/, and sample/*/README.md. GitHub's path filters are NOT minimatch:
+# '**' matches zero or more of ANY character, '/' included, so '**.md' is the
+# pattern that reaches every depth (the docs use '**.js' for "all .js files in the
+# repository"). Do not "correct" this to '**/*.md' -- that form requires a literal
+# '/' before the filename and would stop ignoring root-level README.md and
+# CONTRIBUTING.md. 'docs/**' is redundant today (docs/ is 100% Markdown) but keeps
+# future doc assets such as screenshots out of the gates.
 #
 # This is safe because no job here reads a Markdown file. The one script that does
 # consume docs -- tools/package_addons.ps1, which stages docs/addon-getting-started.md

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -33,12 +33,36 @@ name: PR Gates
 #
 # PlayFab live tests are intentionally NOT here -- they run on a schedule /
 # manual dispatch from playfab-live-nightly.yml so secrets never reach fork PRs.
+#
+# Documentation-only changes skip these gates entirely (see paths-ignore below).
+# The filter is all-or-nothing across the whole changed file set: a change that
+# touches ONLY ignored paths does not start a run, but one that touches an
+# ignored path AND anything else still runs every job. So a docs + code change is
+# gated exactly as it is today -- only pure docs/README churn is skipped.
+#
+# '**.md' covers Markdown at any depth, including root README.md/CONTRIBUTING.md,
+# docs/, spec/, and sample/*/README.md. 'docs/**' is redundant today (docs/ is
+# 100% Markdown) but keeps future doc assets such as screenshots out of the gates.
+#
+# This is safe because no job here reads a Markdown file. The one script that does
+# consume docs -- tools/package_addons.ps1, which stages docs/addon-getting-started.md
+# as GETTING_STARTED.md -- is a local/release tool that no workflow invokes. If a
+# gate ever starts depending on Markdown, narrow this list.
+#
+# workflow_dispatch is deliberately left unfiltered, so a manual run always
+# executes the full set regardless of what changed.
 
 on:
   pull_request:
     branches: [main, experimental/dotnet]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   push:
     branches: [main, experimental/dotnet]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -40,7 +40,7 @@ name: PR Gates
 # ignored path AND anything else still runs every job. So a docs + code change is
 # gated exactly as it is today -- only pure docs/README churn is skipped.
 #
-# '**.md' covers Markdown at any depth, including root README.md/CONTRIBUTING.md,
+# '**/*.md' covers Markdown at any depth, including root README.md/CONTRIBUTING.md,
 # docs/, spec/, and sample/*/README.md. 'docs/**' is redundant today (docs/ is
 # 100% Markdown) but keeps future doc assets such as screenshots out of the gates.
 #


### PR DESCRIPTION
Editing `README.md` or anything under `docs/` currently triggers the full PR gate set: the Godot
parse-gate matrix, a `windows-2022` native addon build, the offline test tier, a libFuzzer corpus
replay, and the C# parity suite. None of those jobs read a Markdown file, so a docs-only change
burns CI minutes to prove nothing.

## Change

`paths-ignore` on the `pull_request` and `push` triggers of `pr-gates.yml`:

```yaml
paths-ignore:
  - '**.md'
  - 'docs/**'
```

GitHub evaluates the filter across the **entire changed file set**, so it is all-or-nothing by
design - which is exactly the requested behavior:

| Change contains | Gates |
|---|---|
| docs / README only | **skipped** |
| docs **and** code | full run, unchanged |
| code only | full run, unchanged |

`'**.md'` matches Markdown at any depth, including root `README.md` / `CONTRIBUTING.md`, `docs/`,
`spec/`, and `sample/*/README.md`. `'docs/**'` is redundant today (`docs/` is 100% Markdown) but
keeps future doc assets such as screenshots out of the gates.

`workflow_dispatch` is deliberately left unfiltered, so a manual run always executes everything.

## Why this is safe

- **No gate job reads Markdown.** The only reference to a doc inside `.github/` is a comment in
  `build-addons/action.yml`. The one script that really does consume a doc -
  `tools/package_addons.ps1`, which stages `docs/addon-getting-started.md` as `GETTING_STARTED.md` -
  is a local/release tool that no workflow invokes.
- **No docs PR can get stuck.** There are no required status checks on `main`; the `PRs only to
  main` ruleset requires review, linear history and non-fast-forward, not checks. A skipped
  workflow therefore reports nothing and blocks nothing. This is the usual failure mode of
  `paths-ignore` and it does not apply here.
- **`doc_classes/*.xml` still gates**, so the C# facade parity suite keeps running when the
  documented native surface changes.

## Verification

The filter was replayed over real PR file lists rather than assumed:

| PR | Files | Non-Markdown | Result |
|---|---|---|---|
| #149 | 38 | 0 | skipped |
| #148 | 1 (`README.md`) | 0 | skipped |
| #147 | 29 | 27 | runs |
| synthetic docs + one `.cpp` | 3 | 1 | runs |

The workflow was also parsed with a YAML parser to confirm all 6 jobs, both trigger filters, and
the `branches` lists survive intact.

This PR touches only `.github/workflows/pr-gates.yml`, so it is itself a non-Markdown change and
the gates run on it - a live confirmation that the workflow still parses and dispatches.

No `.gd`, C++, CMake or tooling files were touched, so the parse gate and test orchestrator do not
apply and were not run.
