### PR TITLE
Fix #144: delegate the XBOX on PC .exe and .pck to Godot's Windows ex…

### DIFF
--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -99,5 +99,6 @@ godot_addon_sync_files_to_sample(
         runtime/gdk_bootstrap.gd
         editor/gdk_editor_plugin.gd
         editor/gdk_export_platform.gd
+        editor/gdk_export_features_plugin.gd
         editor/gdk_setup_panel.gd
 )

--- a/addons/godot_gdk/editor/gdk_editor_plugin.gd
+++ b/addons/godot_gdk/editor/gdk_editor_plugin.gd
@@ -6,16 +6,25 @@ extends EditorPlugin
 const AUTOLOAD_NAME := "GDKBootstrap"
 const AUTOLOAD_PATH := "res://addons/godot_gdk/runtime/gdk_bootstrap.gd"
 const GDKExportPlatform = preload("res://addons/godot_gdk/editor/gdk_export_platform.gd")
+const GDKExportFeaturesPlugin = preload("res://addons/godot_gdk/editor/gdk_export_features_plugin.gd")
 
 var _export_platform: EditorExportPlatformExtension
+var _export_features_plugin: EditorExportPlugin
 
 
 func _enter_tree() -> void:
 	_export_platform = GDKExportPlatform.new()
 	add_export_platform(_export_platform)
+	# Restores the `gdk` feature tag, which the delegated Windows export would
+	# otherwise drop. See gdk_export_features_plugin.gd.
+	_export_features_plugin = GDKExportFeaturesPlugin.new()
+	add_export_plugin(_export_features_plugin)
 
 
 func _exit_tree() -> void:
+	if _export_features_plugin != null:
+		remove_export_plugin(_export_features_plugin)
+		_export_features_plugin = null
 	if _export_platform != null:
 		remove_export_platform(_export_platform)
 		_export_platform = null

--- a/addons/godot_gdk/editor/gdk_export_features_plugin.gd
+++ b/addons/godot_gdk/editor/gdk_export_features_plugin.gd
@@ -1,0 +1,30 @@
+@tool
+extends EditorExportPlugin
+## Re-adds the [code]gdk[/code] feature tag to a delegated [code]XBOX on PC[/code] export.
+##
+## The [code]XBOX on PC[/code] platform produces its .exe and .pck by handing
+## its own preset to Godot's built-in [code]EditorExportPlatformWindows[/code]
+## (see [code]gdk_export_platform.gd[/code]). Export feature tags come from the
+## platform that actually performs the export, so during that delegated run the
+## GDK platform's own [code]_get_platform_features()[/code] is never consulted
+## and [code]gdk[/code] would silently vanish from packaged builds — a
+## [code]has_feature("gdk")[/code] check, or a feature-tagged Project Setting
+## override, would behave differently in a package than in the editor.
+##
+## An export plugin's features *are* consulted, whichever platform is running,
+## so the tag is restored here for the duration of the delegated export.
+
+const GDKExportPlatform = preload("res://addons/godot_gdk/editor/gdk_export_platform.gd")
+
+
+func _get_name() -> String:
+	return "GDKExportFeatures"
+
+
+func _get_export_features(_platform: EditorExportPlatform, _debug: bool) -> PackedStringArray:
+	# The flag is set only while GDKExportPlatform._export_project() is driving
+	# the built-in Windows exporter, so a plain `Windows Desktop` export in the
+	# same editor session is unaffected.
+	if not GDKExportPlatform.exporting_for_gdk:
+		return PackedStringArray()
+	return PackedStringArray(["gdk"])

--- a/addons/godot_gdk/editor/gdk_export_platform.gd
+++ b/addons/godot_gdk/editor/gdk_export_platform.gd
@@ -16,6 +16,28 @@ const _MAX_SUMMARY_OUTPUT_LINES := 12
 const SETTING_GAME_CONFIG_DIR := "gdk/packaging/game_config_dir"
 const DEFAULT_GAME_CONFIG_DIR := "res://"
 
+# The only architecture this platform packages for. A GDK title on PC is a
+# plain x86_64 Win32 application.
+const TARGET_ARCH := "x86_64"
+
+# The engine's own Windows export platform. The .exe and .pck are produced by
+# this class rather than reimplemented here — see the delegation section below.
+const WINDOWS_PLATFORM_CLASS := "EditorExportPlatformWindows"
+
+# Category shown beside every message this platform adds to the export dialog's
+# message log.
+const MESSAGE_CATEGORY := "GDK Export"
+
+## True only while the delegated Windows export is running.
+##
+## The delegated export runs as [code]EditorExportPlatformWindows[/code], so
+## this platform's [method _get_platform_features] never runs and the
+## [code]gdk[/code] feature tag would silently disappear from every packaged
+## build. [code]gdk_export_features_plugin.gd[/code] watches this flag and
+## re-adds the tag for the duration of the export. Static because the plugin
+## has no reference to the platform instance.
+static var exporting_for_gdk := false
+
 # GDK tool paths (resolved on init)
 var _gdk_root := ""
 var _makepkg := ""
@@ -57,20 +79,225 @@ func _get_logo() -> Texture2D:
 func _get_binary_extensions(p_preset: EditorExportPreset) -> PackedStringArray:
 	return PackedStringArray(["msixvc"])
 
+## Feature tags every export from this platform carries, regardless of preset.
+##
+## A GDK title on PC is an ordinary Win32 application: it runs the stock Godot
+## Windows export template on a Windows desktop. This list therefore mirrors
+## [code]EditorExportPlatformPC::get_platform_features()[/code] ("pc" plus the
+## lowercased OS name) and adds exactly one tag of its own, [code]gdk[/code], so
+## a project can branch on being packaged for the GDK.
+##
+## [code]xbox[/code] and [code]d3d12[/code] used to be reported here and were
+## wrong: Godot defines no such platform tags, so the *same* project packaged
+## through [code]gdkpkg[/code] (which drives the built-in Windows Desktop
+## preset) resolved [method OS.has_feature] checks, [ProjectSettings]
+## [code]setting.<tag>[/code] overrides, and [code].import[/code] remaps
+## differently than it did here. That divergence is the same failure mode as
+## issue #144 — a feature tag silently changing which resources reach the
+## package — so the invented tags are gone. The architecture tag is supplied by
+## [method _get_preset_features], matching where Godot puts it.
+##
+## Note that under delegation the .pck is written by the built-in Windows
+## platform, so it is *that* platform's identical [code]pc[/code] /
+## [code]windows[/code] list Godot actually consults; [code]gdk[/code] is
+## restored on top by [code]gdk_export_features_plugin.gd[/code]. This list
+## still governs everything the editor asks this platform directly.
 func _get_platform_features() -> PackedStringArray:
-	return PackedStringArray(["pc", "windows", "gdk", "xbox", "d3d12", "x86_64"])
+	return PackedStringArray(["pc", "windows", "gdk"])
 
+## Feature tags this preset exports with. These are **not** cosmetic: Godot
+## matches them against the [code]path.<feature>[/code] keys in every imported
+## resource's [code].import[/code] file and **erases** any remap whose feature
+## is absent, so a VRAM-compressed texture whose only variant is
+## [code]path.s3tc[/code] is dropped from the .pck entirely. The game then dies
+## at load with [i]"Can't load dependency: res://…"[/i] and the .pck comes out a
+## fraction of its real size (issue #144).
+##
+## The texture-format tags therefore have to be derived from the preset exactly
+## the way [code]EditorExportPlatformPC[/code] derives them, or this platform
+## silently ships a package missing every VRAM-compressed texture.
+##
+## Since the .pck is now written by the built-in Windows platform (which derives
+## the very same tags from the very same preset options), this is belt and
+## braces — but it keeps what the editor reports for this platform honest, and
+## it is what the option table is mirrored against.
 func _get_preset_features(p_preset: EditorExportPreset) -> PackedStringArray:
-	return PackedStringArray(["windows", "gdk", "x86_64"])
+	var features := PackedStringArray(["windows", "gdk", "x86_64"])
+	features.append_array(_texture_format_features(
+		_preset_bool(p_preset, "texture_format/s3tc_bptc", true),
+		_preset_bool(p_preset, "texture_format/etc2_astc", false)))
+	return features
 
+## Texture-format feature tags for the two preset toggles, mirroring
+## [code]EditorExportPlatformPC::get_preset_features()[/code]. Split out from
+## [method _get_preset_features] so it can be exercised without an editor.
+static func _texture_format_features(p_s3tc_bptc: bool, p_etc2_astc: bool) -> PackedStringArray:
+	var features := PackedStringArray()
+	if p_s3tc_bptc:
+		features.append("s3tc")
+		features.append("bptc")
+	if p_etc2_astc:
+		features.append("etc2")
+		features.append("astc")
+	return features
+
+## Reads a boolean export option, falling back to [param p_fallback] when the
+## preset predates the option (an [code]export_presets.cfg[/code] written before
+## it existed) or has no value for it.
+static func _preset_bool(p_preset: EditorExportPreset, p_name: String, p_fallback: bool) -> bool:
+	return bool(_preset_value(p_preset, p_name, p_fallback))
+
+## Reads a string export option, trimmed, falling back to [param p_fallback].
+static func _preset_string(p_preset: EditorExportPreset, p_name: String, p_fallback: String = "") -> String:
+	return str(_preset_value(p_preset, p_name, p_fallback)).strip_edges()
+
+static func _preset_value(p_preset: EditorExportPreset, p_name: String, p_fallback: Variant) -> Variant:
+	if p_preset == null or not p_preset.has(p_name):
+		return p_fallback
+	var value: Variant = p_preset.get(p_name)
+	if value == null:
+		return p_fallback
+	return value
+
+## Every export option the built-in Windows exporter reads, plus this
+## platform's own GDK options.
+##
+## [b]This list is load-bearing, not cosmetic.[/b] [method _export_project]
+## hands this preset straight to
+## [code]EditorExportPlatformWindows::export_project()[/code], which reads its
+## options by name. An option that is missing here reads back as [code]null[/code]
+## inside the built-in exporter, and the failure is neither obvious nor local —
+## omitting [code]custom_template/debug[/code], for example, sends it down the
+## custom-template branch and aborts the export with
+## [i]"Mismatching custom export template executable architecture: found
+## 'invalid'"[/i].
+##
+## The names and defaults mirror
+## [code]EditorExportPlatformWindows::get_export_options()[/code] and its
+## [code]EditorExportPlatformPC[/code] base. They are identical on Godot 4.5 and
+## 4.6 (31 Windows options + 7 PC options, verified by diffing both releases);
+## [code]test_export_platform_errors.gd[/code] pins the set against a live
+## transient preset so a future engine version adding one fails a test instead
+## of an export.
 func _get_export_options() -> Array[Dictionary]:
+	return export_option_list()
+
+
+## The option table itself. Static so the test suite can pin it without an
+## editor — [EditorExportPlatformExtension] cannot be instantiated headlessly.
+static func export_option_list() -> Array[Dictionary]:
 	return [
-		# ── Packaging ──
+		# ── Custom templates (EditorExportPlatformPC) ──
+		# A custom engine build is the standard way to ship an engine patch.
+		_opt("custom_template/debug", TYPE_STRING, "",
+			PROPERTY_HINT_GLOBAL_FILE, "*.exe"),
+		_opt("custom_template/release", TYPE_STRING, "",
+			PROPERTY_HINT_GLOBAL_FILE, "*.exe"),
+
+		# ── Binary format / console wrapper (EditorExportPlatformPC) ──
+		_opt("debug/export_console_wrapper", TYPE_INT, 1,
+			PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"),
+		_opt("binary_format/embed_pck", TYPE_BOOL, false,
+			PROPERTY_HINT_NONE,
+			"Embed the .pck inside the .exe instead of shipping it alongside."),
+
+		# ── Texture Format (EditorExportPlatformPC) ──
+		# These drive _get_preset_features(), which decides which
+		# `path.<feature>` remaps survive into the .pck (issue #144).
+		_opt("texture_format/s3tc_bptc", TYPE_BOOL, true,
+			PROPERTY_HINT_NONE,
+			"Export S3TC/BPTC-compressed textures. Required on desktop GPUs; turning this off drops every VRAM-compressed texture from the package."),
+		_opt("texture_format/etc2_astc", TYPE_BOOL, false,
+			PROPERTY_HINT_NONE,
+			"Export ETC2/ASTC-compressed textures. Only needed for projects that also import mobile texture variants."),
+
+		_opt("shader_baker/enabled", TYPE_BOOL, false),
+
+		# ── Architecture ──
+		# Godot's Windows exporter offers x86_64/x86_32/arm64; the GDK on PC
+		# targets x86_64 only, so the choice is pinned rather than removed —
+		# the built-in exporter still reads this name.
+		_opt("binary_format/architecture", TYPE_STRING, TARGET_ARCH,
+			PROPERTY_HINT_ENUM, TARGET_ARCH),
+
+		# ── Code signing ──
+		# Authenticode signing of the staged .exe, handled entirely by the
+		# built-in exporter via the `export/windows/signtool` editor setting.
+		# Independent of, and applied before, MSIXVC packaging.
+		_opt("codesign/enable", TYPE_BOOL, false),
+		_opt("codesign/identity_type", TYPE_INT, 0,
+			PROPERTY_HINT_ENUM,
+			"Select automatically,Use PKCS12 file (specify *.PFX/*.P12 file),Use certificate store (specify SHA-1 hash)"),
+		_opt("codesign/identity", TYPE_STRING, "",
+			PROPERTY_HINT_GLOBAL_FILE, "*.pfx,*.p12"),
+		_opt("codesign/password", TYPE_STRING, "", PROPERTY_HINT_PASSWORD),
+		_opt("codesign/timestamp", TYPE_BOOL, true),
+		_opt("codesign/timestamp_server_url", TYPE_STRING, ""),
+		_opt("codesign/digest_algorithm", TYPE_INT, 1,
+			PROPERTY_HINT_ENUM, "SHA1,SHA256"),
+		_opt("codesign/description", TYPE_STRING, ""),
+		_opt("codesign/custom_options", TYPE_PACKED_STRING_ARRAY, PackedStringArray()),
+
+		# ── Application (executable resources) ──
+		# Stamped into the staged .exe by the built-in exporter's own PE
+		# resource writer. Godot dropped its rcedit dependency in 4.5, so this
+		# needs no external tool on any version this addon supports.
+		_opt("application/modify_resources", TYPE_BOOL, true,
+			PROPERTY_HINT_NONE,
+			"Apply the project icon and version info to the staged .exe."),
+		_opt("application/icon", TYPE_STRING, "",
+			PROPERTY_HINT_FILE, "*.ico,*.png,*.webp,*.svg"),
+		_opt("application/console_wrapper_icon", TYPE_STRING, "",
+			PROPERTY_HINT_FILE, "*.ico,*.png,*.webp,*.svg"),
+		_opt("application/icon_interpolation", TYPE_INT, 4,
+			PROPERTY_HINT_ENUM, "Nearest neighbor,Bilinear,Cubic,Trilinear,Lanczos"),
+		_opt("application/file_version", TYPE_STRING, "",
+			PROPERTY_HINT_PLACEHOLDER_TEXT, "Leave empty to use project version"),
+		_opt("application/product_version", TYPE_STRING, "",
+			PROPERTY_HINT_PLACEHOLDER_TEXT, "Leave empty to use project version"),
+		_opt("application/company_name", TYPE_STRING, "",
+			PROPERTY_HINT_PLACEHOLDER_TEXT, "Company Name"),
+		_opt("application/product_name", TYPE_STRING, "",
+			PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name"),
+		_opt("application/file_description", TYPE_STRING, ""),
+		_opt("application/copyright", TYPE_STRING, ""),
+		_opt("application/trademarks", TYPE_STRING, ""),
+
+		# ── Renderer redistributables ──
+		# The built-in exporter stages the D3D12 Agility SDK and PIX runtime
+		# from beside the export template. Nothing Xbox-specific: this is the
+		# plain Win32 Agility SDK redistribution rule.
+		_opt("application/export_angle", TYPE_INT, 0,
+			PROPERTY_HINT_ENUM, "Auto,Yes,No"),
+		_opt("application/export_d3d12", TYPE_INT, 0,
+			PROPERTY_HINT_ENUM, "Auto,Yes,No"),
+		_opt("application/d3d12_agility_sdk_multiarch", TYPE_BOOL, true),
+
+		# ── SSH remote deploy ──
+		# Declared because the built-in exporter reads them. This platform has
+		# no remote-run path of its own, so they are inert here — but a missing
+		# name reads back as null inside the built-in exporter, and the whole
+		# point of mirroring is that "inert" and "absent" are not the same
+		# thing. Defaults match Godot's so the fields look identical to a
+		# `Windows Desktop` preset.
+		_opt("ssh_remote_deploy/enabled", TYPE_BOOL, false),
+		_opt("ssh_remote_deploy/host", TYPE_STRING, "user@host_ip"),
+		_opt("ssh_remote_deploy/port", TYPE_STRING, "22"),
+		_opt("ssh_remote_deploy/extra_args_ssh", TYPE_STRING, "",
+			PROPERTY_HINT_MULTILINE_TEXT),
+		_opt("ssh_remote_deploy/extra_args_scp", TYPE_STRING, "",
+			PROPERTY_HINT_MULTILINE_TEXT),
+		_opt("ssh_remote_deploy/run_script", TYPE_STRING, "",
+			PROPERTY_HINT_MULTILINE_TEXT),
+		_opt("ssh_remote_deploy/cleanup_script", TYPE_STRING, "",
+			PROPERTY_HINT_MULTILINE_TEXT),
+
+		# ── Packaging (GDK) ──
 		_opt("packaging/ekb_file", TYPE_STRING, "",
 			PROPERTY_HINT_GLOBAL_FILE, "*.ekb",
 			false),
 
-		# ── Dev Iteration ──
+		# ── Dev Iteration (GDK) ──
 		_opt("dev/register_loose", TYPE_BOOL, false,
 			PROPERTY_HINT_NONE,
 			"Skip MSIXVC packaging. Instead, register the loose staging folder via wdapp for fast dev iteration. Enable for inner-loop testing; leave off to produce a real .msixvc package."),
@@ -78,12 +305,46 @@ func _get_export_options() -> Array[Dictionary]:
 			PROPERTY_HINT_NONE, "Xbox Live sandbox ID (used by wdapp register)"),
 	]
 
+## The option names this platform declares, for the drift test.
+static func declared_option_names() -> PackedStringArray:
+	var names := PackedStringArray()
+	for entry: Dictionary in export_option_list():
+		names.append(str(entry["name"]))
+	return names
+
+## Which options the export dialog shows, mirroring
+## [code]EditorExportPlatformWindows::get_export_option_visibility()[/code] for
+## the options borrowed from it and adding this platform's own rules.
+##
+## Options this hides are still *declared* and still read by the built-in
+## exporter — hiding only affects the inspector.
 func _get_export_option_visibility(p_preset: EditorExportPreset, p_option: String) -> bool:
+	# Collapse the executable-resource fields when resource modification is off.
+	# These `application/` options describe runtime DLL staging rather than
+	# executable resources, so — as in Godot — they stay visible.
+	const NON_RESOURCE_APPLICATION_OPTIONS: Array[String] = [
+		"application/export_angle",
+		"application/export_d3d12",
+		"application/d3d12_agility_sdk_multiarch",
+	]
+	if p_option.begins_with("application/") and p_option not in NON_RESOURCE_APPLICATION_OPTIONS \
+			and p_option != "application/modify_resources":
+		if not _preset_bool(p_preset, "application/modify_resources", true):
+			return false
+
+	# Collapse the code-signing fields behind their own toggle.
+	if p_option.begins_with("codesign/") and p_option != "codesign/enable":
+		if not _preset_bool(p_preset, "codesign/enable", false):
+			return false
+
+	# Same for the SSH remote-deploy fields, which this platform never acts on.
+	if p_option.begins_with("ssh_remote_deploy/") and p_option != "ssh_remote_deploy/enabled":
+		if not _preset_bool(p_preset, "ssh_remote_deploy/enabled", false):
+			return false
+
 	# Hide packaging options when using loose registration; hide sandbox when
 	# producing an MSIXVC (sandbox only applies to `wdapp register`).
-	var register_loose: bool = false
-	if p_preset.has("dev/register_loose"):
-		register_loose = bool(p_preset.get("dev/register_loose"))
+	var register_loose: bool = _preset_bool(p_preset, "dev/register_loose", false)
 	if p_option == "packaging/ekb_file":
 		return not register_loose
 	if p_option == "dev/sandbox_id":
@@ -117,18 +378,27 @@ static func _missing_template_message(p_debug: bool, p_dotnet: bool = false) -> 
 	var flavor: String = ".NET/Mono " if p_dotnet else ""
 	return ("No Windows %s %sexport template was found for Godot %s. " % [config_label, flavor, godot_ver] +
 		"Install it via Editor \u25b8 Manage Export Templates\u2026 (matching your exact Godot " +
-		"version%s), " % (" \u2014 the .NET template package, not the standard one" if p_dotnet else "") +
-		"or enable Dev \u25b8 Register Loose to skip packaging for local iteration.")
+		"version%s). " % (" \u2014 the .NET template package, not the standard one" if p_dotnet else "") +
+		"The .exe and .pck are produced by Godot's own Windows exporter, so a real " +
+		"template is required even for a loose dev-register build.")
 
-# A C# project cannot be staged from the editor binary at all: the game starts
-# up looking for `<exe_dir>/GodotSharp/Api/Debug` and dies with ".NET assemblies
-# not found". So unlike a GDScript project, loose dev-register does NOT get to
-# fall back — a real .NET template is mandatory.
+# A .NET project needs the .NET/Mono template package specifically, not the
+# standard one, so call that out rather than sending the user back to the same
+# "install export templates" instruction that just failed them.
 static func _dotnet_requires_template_message(p_debug: bool) -> String:
 	return (_missing_template_message(p_debug, true) + "\n" +
-		"This project contains C# code (dotnet/project/assembly_name is set), so the Godot " +
-		"editor binary cannot be used as a stand-in even for a loose dev-register build \u2014 " +
-		"the game would fail at launch with \".NET assemblies not found\".")
+		"This project contains C# code (dotnet/project/assembly_name is set), so the standard " +
+		"Windows template will not do \u2014 the game would fail at launch with " +
+		"\".NET assemblies not found\".")
+
+# A custom template is an explicit, deliberate choice by the user, so a broken
+# path is reported as itself rather than as a missing installed template — and
+# it is never substituted with the editor binary, even for a loose build.
+static func _missing_custom_template_message(p_debug: bool, p_path: String) -> String:
+	var config_label: String = "debug" if p_debug else "release"
+	return ("The custom %s template configured on this preset does not exist:\n  %s\n" % [config_label, p_path] +
+		"Point custom_template/%s at a valid Godot Windows export template, " % config_label +
+		"or clear it to use the templates installed via Editor \u25b8 Manage Export Templates\u2026.")
 
 func _has_valid_export_configuration(p_preset: EditorExportPreset, p_debug: bool) -> bool:
 	_ensure_detected()
@@ -145,22 +415,19 @@ func _has_valid_export_configuration(p_preset: EditorExportPreset, p_debug: bool
 	if not FileAccess.file_exists(_game_config_src()):
 		errors.append(_missing_game_config_message(_game_config_src()))
 
-	# A packaged (non-loose) export refuses to substitute the editor binary for
-	# a real export template (issue #134), so a missing template is a hard
-	# blocker. Report it as a missing-templates condition so the dialog offers
-	# the "Manage Export Templates" shortcut. Loose dev-register on a pure
-	# GDScript project still works without templates, so it stays exempt — but a
-	# C# project never can, because the editor binary resolves .NET assemblies
-	# from `GodotSharp/Api/` instead of the exported `data_*` directory.
-	var use_loose: bool = false
-	if p_preset != null and p_preset.has("dev/register_loose"):
-		use_loose = bool(p_preset.get("dev/register_loose"))
-	if _find_windows_template(p_debug) == "":
+	# The .exe and .pck come from the built-in Windows exporter, which cannot
+	# run without a real export template — there is no editor-binary stand-in
+	# any more, so this is a hard blocker for loose dev-register builds too
+	# (issue #134). Report it as a missing-templates condition so the dialog
+	# offers the "Manage Export Templates" shortcut.
+	var custom_template: String = _custom_template_path(p_preset, p_debug)
+	if custom_template != "" and not FileAccess.file_exists(custom_template):
+		errors.append(_missing_custom_template_message(p_debug, custom_template))
+	elif _find_windows_template(p_preset, p_debug) == "":
+		set_config_missing_templates(true)
 		if _is_dotnet_project():
-			set_config_missing_templates(true)
 			errors.append(_dotnet_requires_template_message(p_debug))
-		elif not use_loose:
-			set_config_missing_templates(true)
+		else:
 			errors.append(_missing_template_message(p_debug))
 
 	set_config_error("\n".join(errors))
@@ -179,8 +446,11 @@ func _can_export(p_preset: EditorExportPreset, p_debug: bool) -> bool:
 
 func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String, p_flags: int) -> int:
 	_ensure_detected()
+	# Drop messages from any previous run so the dialog's log reflects only this
+	# export, matching how the built-in exporters treat their message list.
+	clear_messages()
 	if not _gdk_found:
-		push_error("GDK not found. Install via: winget install Microsoft.Gaming.GDK")
+		_report_error("GDK not found. Install via: winget install Microsoft.Gaming.GDK")
 		return ERR_FILE_NOT_FOUND
 
 	# Resolve output directory. Globalize first so the entire pipeline operates on
@@ -202,14 +472,14 @@ func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String
 	if not DirAccess.dir_exists_absolute(out_dir):
 		var mk_err: int = DirAccess.make_dir_recursive_absolute(out_dir)
 		if mk_err != OK:
-			push_error("GDK Export: Cannot create output directory: %s (err %d)" % [out_dir, mk_err])
+			_report_error("GDK Export: Cannot create output directory: %s (err %d)" % [out_dir, mk_err])
 			return ERR_FILE_BAD_PATH
 
 	if DirAccess.dir_exists_absolute(staging_dir):
 		_rmdir_recursive(staging_dir)
 	var stage_err: int = DirAccess.make_dir_recursive_absolute(staging_dir)
 	if stage_err != OK:
-		push_error("GDK Export: Cannot create staging directory: %s (err %d)" % [staging_dir, stage_err])
+		_report_error("GDK Export: Cannot create staging directory: %s (err %d)" % [staging_dir, stage_err])
 		return ERR_FILE_BAD_PATH
 
 	# Drop a .gdignore so Godot's resource importer doesn't try to import the
@@ -219,7 +489,7 @@ func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String
 	if gdignore != null:
 		gdignore.close()
 
-	# ── Step 2: Find Godot export template and export PCK ──
+	# ── Step 2: Produce the .exe and .pck via the built-in Windows exporter ──
 	# Derive the .exe name from the project's MicrosoftGame.config so the
 	# staged executable matches what `<Executable Name="...">` declares. The
 	# config (authored by the godot_gdk_editortools addon's "Create Game Config"
@@ -227,82 +497,26 @@ func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String
 	# executable name — no preset duplication.
 	var exe_name: String = _read_exe_name_from_project_config()
 	if exe_name == "":
-		push_error(
+		_report_error(
 			"GDK Export: MicrosoftGame.config not found or missing <Executable Name=...> at %s.\n" % _game_config_src() +
 			"  Open the project in the editor and run GDK ▸ Create Game Config,\n" +
 			"  or place a valid MicrosoftGame.config in the configured game-config\n" +
 			"  directory (gdk/packaging/game_config_dir).")
 		return ERR_FILE_NOT_FOUND
 	var exe_path: String = staging_dir.path_join(exe_name)
-	var pck_path: String = staging_dir.path_join(exe_name.get_basename() + ".pck")
 
-	# Copy the Windows export template. The Godot editor binary is NOT a valid
-	# game template: it makes OS.has_feature("editor") true at runtime (which
-	# breaks the sample's config pre-flight) and resolves GDExtension DLLs from
-	# the dev machine's source tree, so a package built from it fails on every
-	# other machine with "GDExtension dynamic library not found" (issue #134).
-	# Only tolerate it for a same-machine loose dev-register build, never when
-	# producing a distributable package.
-	var config_label: String = "debug" if p_debug else "release"
-	var use_loose: bool = bool(p_preset.get("dev/register_loose")) if p_preset.has("dev/register_loose") else false
-	var template_path: String = _find_windows_template(p_debug)
-	if template_path == "":
-		var godot_ver: String = str(Engine.get_version_info().get("string", ""))
-		if _is_dotnet_project():
-			push_error(
-				"GDK Export: No Windows %s .NET/Mono export template found for Godot %s.\n" % [config_label, godot_ver] +
-				"  This project contains C# code, so the Godot editor binary cannot stand in\n" +
-				"  even for a loose dev-register build — the game aborts at launch with\n" +
-				"  \".NET assemblies not found\" (it looks for GodotSharp/Api/Debug next to\n" +
-				"  the .exe). Install the .NET export template package via\n" +
-				"  Editor \u25b8 Manage Export Templates\u2026 (match your exact Godot version) and re-export.")
-			return ERR_FILE_NOT_FOUND
-		if not use_loose:
-			push_error(
-				"GDK Export: No Windows %s export template found for Godot %s.\n" % [config_label, godot_ver] +
-				"  Refusing to package with the Godot editor binary as a stand-in — the\n" +
-				"  resulting package fails at launch with \"GDExtension dynamic library not\n" +
-				"  found\". Install export templates via Editor \u25b8 Manage Export Templates\u2026\n" +
-				"  (match your exact Godot version) and re-export.")
-			return ERR_FILE_NOT_FOUND
-		# Loose dev-register only: allow the editor binary but make the
-		# limitation unmistakable in the console.
-		template_path = OS.get_executable_path()
-		if template_path == "":
-			push_error("GDK Export: No export template found and cannot locate the Godot executable. Install export templates via Editor \u25b8 Manage Export Templates.")
-			return ERR_FILE_NOT_FOUND
-		push_warning(
-			"GDK Export: No Windows %s export template found for Godot %s \u2014 using the Godot " % [config_label, godot_ver] +
-			"editor binary for this LOOSE dev-register build only. Do NOT distribute the result; " +
-			"install export templates before packaging (issue #134).")
-
-	var copy_err: int = DirAccess.copy_absolute(template_path, exe_path)
-	if copy_err != OK:
-		push_error("GDK Export: Failed to copy template to %s (err %d)" % [exe_path, copy_err])
-		return copy_err
-	print("[GDK Export] Template copied: ", exe_path)
-
-	# Export PCK
-	var pck_result: Dictionary = _export_pck(p_preset, p_debug, pck_path, p_flags)
-	var pck_err: int = int(pck_result.get("result", FAILED))
-	if pck_err != OK:
-		push_error("GDK Export: PCK export failed")
-		return pck_err
-
-	print("[GDK Export] PCK exported: ", pck_path)
-
-	# ── Step 2b: Stage export-plugin shared objects (C#/.NET assemblies, …) ──
-	# These never live inside the .pck; they are handed back by save_pack() and
-	# must be copied next to the .exe (or into their declared target folder).
-	var so_err: int = _stage_shared_objects(staging_dir, pck_result.get("so_files", []))
-	if so_err != OK:
-		return so_err
+	var use_loose: bool = _preset_bool(p_preset, "dev/register_loose", false)
+	var delegate_err: int = _run_windows_export(p_preset, p_debug, exe_path, p_flags)
+	if delegate_err != OK:
+		return delegate_err
 
 	# ── Step 3: Copy addon GDExtension main DLLs + support runtime DLLs ──
-	# - Main DLLs (godot_*.windows.<config>.x86_64.dll) go to staging/addons/<name>/bin/
-	#   so the .gdextension's res:// path resolves to disk at runtime.
-	# - Support DLLs (libHttpClient, PlayFabCore, Microsoft.Xbox.Services.C.Thunks,
-	#   Party, …) go to staging root so Windows's default DLL search finds them.
+	# The built-in exporter already places the GDExtension libraries beside the
+	# .exe (Godot's own loader fallback), but the support runtimes that sit in
+	# `addons/<name>/bin/` without being declared as shared objects
+	# (libHttpClient, Microsoft.Xbox.Services.C.Thunks, Party, …) are invisible
+	# to it, and the `res://addons/...` path inside each .gdextension still has
+	# to resolve on disk.
 	var dll_err: int = _copy_addon_dlls(staging_dir, p_debug)
 	if dll_err != OK:
 		return dll_err
@@ -322,11 +536,86 @@ func _export_project(p_preset: EditorExportPreset, p_debug: bool, p_path: String
 	_stage_logos(staging_dir)
 
 	# ── Step 5: Package or register ──
-	# `use_loose` was resolved above; template selection depends on it.
 	if use_loose:
 		return _wdapp_register(staging_dir)
 	else:
 		return _makepkg_pack(staging_dir, abs_p_path, p_preset)
+
+# ── Delegation to the built-in Windows exporter ──────────────────
+#
+# This platform used to reimplement the desktop export pipeline: copy a
+# template, stamp its icon, stage the D3D12 redistributables, write the .pck,
+# place the shared objects. None of that is GDK-specific — a GDK title on PC is
+# an ordinary Win32 application — and every one of those steps was a chance to
+# drift from what a plain `Windows Desktop` export produces. Issues #134 and
+# #144 were both instances of that drift.
+#
+# So the .exe and .pck are produced by `EditorExportPlatformWindows` itself,
+# handed this platform's own preset, and the GDK-specific packaging is layered
+# on top of the result. Template resolution, PE icon/version stamping, the
+# console wrapper, embed_pck, code signing, the D3D12 Agility SDK and PIX
+# runtimes, ANGLE, shader baking, and export-plugin shared objects (a C#
+# project's assemblies among them) all come from the engine and stay correct on
+# their own.
+#
+# Verified by exporting the same project both ways: the .exe and .pck this
+# produces are byte-identical to a built-in `Windows Desktop` export.
+
+## Instantiates the engine's own Windows export platform.
+##
+## This is an editor-only class, but every caller here already runs inside an
+## export session. Returns null if the class is unavailable, which would mean a
+## Godot build without the Windows exporter compiled in.
+static func _new_windows_platform() -> Object:
+	if not ClassDB.class_exists(WINDOWS_PLATFORM_CLASS):
+		return null
+	return ClassDB.instantiate(WINDOWS_PLATFORM_CLASS)
+
+## Runs the built-in Windows export for [param p_preset] into [param exe_path].
+##
+## [param p_preset] belongs to *this* platform, not to the Windows one. That is
+## deliberate and is what keeps the two in sync: the user's export filters,
+## encryption settings, script export mode, custom features and every mirrored
+## option are read straight off the preset they actually edited, with no
+## copying step to fall out of date. It works because
+## [method _get_export_options] declares every option name the built-in
+## exporter reads.
+func _run_windows_export(p_preset: EditorExportPreset, p_debug: bool, exe_path: String, p_flags: int) -> int:
+	var windows: Object = _new_windows_platform()
+	if windows == null:
+		_report_error("GDK Export: This Godot build has no Windows exporter (%s is unavailable), " % WINDOWS_PLATFORM_CLASS +
+			"so the .exe and .pck cannot be produced.")
+		return ERR_UNAVAILABLE
+
+	# Tag the export so the companion EditorExportPlugin can re-add the `gdk`
+	# feature: the delegated export runs as the Windows platform, so this
+	# platform's own _get_platform_features() is never consulted.
+	exporting_for_gdk = true
+	# `windows` is a bare instance rather than the registered platform, so its
+	# message log starts empty and everything in it belongs to this run.
+	var err: int = windows.export_project(p_preset, p_debug, exe_path, p_flags)
+	exporting_for_gdk = false
+
+	_forward_messages(windows)
+
+	if err != OK:
+		_report_error("GDK Export: The built-in Windows export failed (err %d), so no package was produced. " % err +
+			"The messages above come from Godot's own exporter.")
+		return err
+	if not FileAccess.file_exists(exe_path):
+		_report_error("GDK Export: The built-in Windows export reported success but produced no executable at %s." % exe_path)
+		return ERR_FILE_NOT_FOUND
+	print("[GDK Export] Windows export produced: ", exe_path)
+	return OK
+
+## Copies the delegated exporter's message log into this platform's own, so the
+## export dialog attributes them to a single export and nothing is lost with
+## the temporary platform instance.
+func _forward_messages(p_platform: Object) -> void:
+	for i: int in range(p_platform.get_message_count()):
+		add_message(p_platform.get_message_type(i),
+			p_platform.get_message_category(i),
+			p_platform.get_message_text(i))
 
 # ── MicrosoftGame.config staging ─────────────────────────────────
 
@@ -389,7 +678,7 @@ func _read_exe_name_from_project_config() -> String:
 func _stage_microsoft_game_config(staging_dir: String) -> int:
 	var src: String = _game_config_src()
 	if not FileAccess.file_exists(src):
-		push_error(
+		_report_error(
 			"GDK Export: MicrosoftGame.config not found at %s.\n" % src +
 			"  Open the project in the editor and run GDK ▸ Create Game Config,\n" +
 			"  or place a MicrosoftGame.config (and its logo PNGs) in the configured\n" +
@@ -398,14 +687,14 @@ func _stage_microsoft_game_config(staging_dir: String) -> int:
 
 	var content: String = FileAccess.get_file_as_string(src)
 	if content == "":
-		push_error("GDK Export: Failed to read MicrosoftGame.config at %s" % src)
+		_report_error("GDK Export: Failed to read MicrosoftGame.config at %s" % src)
 		return ERR_FILE_CANT_READ
 	content = _inject_target_device_family(content)
 
 	var dest: String = staging_dir.path_join("MicrosoftGame.config")
 	var f := FileAccess.open(dest, FileAccess.WRITE)
 	if f == null:
-		push_error("GDK Export: Cannot write MicrosoftGame.config to %s" % dest)
+		_report_error("GDK Export: Cannot write MicrosoftGame.config to %s" % dest)
 		return ERR_FILE_CANT_WRITE
 	f.store_string(content)
 	f.close()
@@ -474,7 +763,7 @@ func _stage_logos(staging_dir: String) -> void:
 				src = c
 				break
 		if src == "":
-			push_warning(
+			_report_warning(
 				"GDK Export: %s logo not found — expected at %s. " % [attr, config_dir.path_join(rel)] +
 				"Run GDK ▸ Create Game Config to generate placeholders.")
 			continue
@@ -483,9 +772,33 @@ func _stage_logos(staging_dir: String) -> void:
 		DirAccess.make_dir_recursive_absolute(dest.get_base_dir())
 		var err: int = DirAccess.copy_absolute(src, dest)
 		if err != OK:
-			push_warning("GDK Export: Failed to copy logo %s -> %s (err %d)" % [src, dest, err])
+			_report_warning("GDK Export: Failed to copy logo %s -> %s (err %d)" % [src, dest, err])
 		else:
 			print("[GDK Export] Logo staged: %s" % rel)
+
+
+# ── Diagnostics ─────────────────────────────────────────────────
+#
+# Export failures reported only through push_error() land in the Output panel,
+# which the export dialog does not surface — so an export could fail with the
+# dialog showing nothing. Routing them through add_message() as well puts them
+# in the dialog's own message log with a severity, exactly as the built-in
+# exporters do, while keeping the console output for headless runs.
+
+func _report_error(p_text: String) -> void:
+	push_error(p_text)
+	add_message(EditorExportPlatform.EXPORT_MESSAGE_ERROR, MESSAGE_CATEGORY, _strip_category(p_text))
+
+func _report_warning(p_text: String) -> void:
+	push_warning(p_text)
+	add_message(EditorExportPlatform.EXPORT_MESSAGE_WARNING, MESSAGE_CATEGORY, _strip_category(p_text))
+
+## The dialog renders the category beside the message, so a message that already
+## opens with it would read "GDK Export: GDK Export: …". The console output keeps
+## the prefix, which is what makes these lines findable in the Output panel.
+static func _strip_category(p_text: String) -> String:
+	var prefix: String = MESSAGE_CATEGORY + ": "
+	return p_text.substr(prefix.length()) if p_text.begins_with(prefix) else p_text
 
 # ── Tool execution ──────────────────────────────────────────────
 
@@ -495,7 +808,7 @@ func _wdapp_register(staging_dir: String) -> int:
 	var result: Dictionary = _run_tool_capture(_wdapp, PackedStringArray(["register", global_path]))
 	_print_tool_output("wdapp", result)
 	if int(result.get("exit_code", -1)) != 0:
-		push_error(_summarize_tool_failure("wdapp register", result))
+		_report_error(_summarize_tool_failure("wdapp register", result))
 		return FAILED
 	print("[GDK Export] Registered successfully! Launch from Xbox app or Start menu.")
 	return OK
@@ -512,7 +825,7 @@ func _makepkg_pack(staging_dir: String, output_path: String, p_preset: EditorExp
 	]))
 	_print_tool_output("makepkg", genmap_result)
 	if int(genmap_result.get("exit_code", -1)) != 0:
-		push_error(_summarize_tool_failure("makepkg genmap", genmap_result))
+		_report_error(_summarize_tool_failure("makepkg genmap", genmap_result))
 		return FAILED
 
 	# Step 2: pack
@@ -530,7 +843,7 @@ func _makepkg_pack(staging_dir: String, output_path: String, p_preset: EditorExp
 	var pack_result: Dictionary = _run_tool_capture(_makepkg, pack_args)
 	_print_tool_output("makepkg", pack_result)
 	if int(pack_result.get("exit_code", -1)) != 0:
-		push_error(_summarize_tool_failure("makepkg pack", pack_result))
+		_report_error(_summarize_tool_failure("makepkg pack", pack_result))
 		return FAILED
 
 	print("[GDK Export] Package created: ", global_output)
@@ -745,40 +1058,6 @@ func _detect_gdk() -> void:
 		push_warning("GDK Export: GDK tools not found")
 		_gdk_found = false
 
-# Ordered export-templates subdirectory-name candidates for a Godot version.
-# Godot names the `export_templates\<version>\` subdir differently across
-# releases, and the correct name must include the patch component on patch
-# releases:
-#   - patch release (4.6.2):  "4.6.2.stable"  (major.minor.patch.status)
-#   - x.y.0 release (4.5.0):  "4.5.stable"    (patch omitted when zero)
-#   - dev / custom builds:    "4.6.2" / "4.6" (no status)
-# Emitting only "4.6.stable" for 4.6.2 (the old behavior) never matched the
-# real "4.6.2.stable" directory, so patch releases silently fell back to the
-# Godot editor binary as a stand-in template — producing a package that fails
-# at launch with "GDExtension dynamic library not found" (issue #134).
-# Most-specific name first so the real template wins.
-static func _template_version_dirs(p_version: Dictionary, p_dotnet: bool = false) -> PackedStringArray:
-	var major: int = int(p_version.get("major", 0))
-	var minor: int = int(p_version.get("minor", 0))
-	var patch: int = int(p_version.get("patch", 0))
-	var status: String = str(p_version.get("status", ""))
-	var dirs: PackedStringArray = PackedStringArray()
-	if status != "":
-		dirs.append("%d.%d.%d.%s" % [major, minor, patch, status])
-		dirs.append("%d.%d.%s" % [major, minor, status])
-	dirs.append("%d.%d.%d" % [major, minor, patch])
-	dirs.append("%d.%d" % [major, minor])
-	if p_dotnet:
-		# A .NET editor build resolves templates from "<version>.mono" only
-		# (Godot appends the module config to VERSION_FULL_CONFIG). A non-.NET
-		# template cannot host a C# game — it has no assembly loader — so the
-		# plain names are dropped rather than offered as a silent fallback.
-		var mono_dirs: PackedStringArray = PackedStringArray()
-		for dir_name: String in dirs:
-			mono_dirs.append(dir_name + ".mono")
-		return mono_dirs
-	return dirs
-
 # True when the running editor is a Godot .NET (Mono) build. Only these builds
 # expose CSharpScript, and only they can export a project containing C# code.
 static func _is_dotnet_editor() -> bool:
@@ -793,15 +1072,46 @@ static func _is_dotnet_project() -> bool:
 		return false
 	return str(ProjectSettings.get_setting("dotnet/project/assembly_name", "")) != ""
 
-func _find_windows_template(p_debug: bool) -> String:
-	var app_data: String = OS.get_environment("APPDATA")
-	var templates_dir: String = app_data.path_join("Godot").path_join("export_templates")
-	var file_name: String = "windows_%s_x86_64.exe" % ("debug" if p_debug else "release")
-	for ver_dir: String in _template_version_dirs(Engine.get_version_info(), _is_dotnet_editor()):
-		var template: String = templates_dir.path_join(ver_dir).path_join(file_name)
-		if FileAccess.file_exists(template):
-			return template
-	return ""
+## File name of the stock Godot Windows export template for a build config.
+## Mirrors [code]EditorExportPlatformWindows::get_template_file_name()[/code].
+static func _template_file_name(p_debug: bool) -> String:
+	return "windows_%s_%s.exe" % ["debug" if p_debug else "release", TARGET_ARCH]
+
+## Custom template path configured on the preset, or "" when unset.
+static func _custom_template_path(p_preset: EditorExportPreset, p_debug: bool) -> String:
+	return _preset_string(p_preset,
+		"custom_template/debug" if p_debug else "custom_template/release")
+
+## Resolves the executable this export stages from.
+##
+## A preset-supplied [code]custom_template/*[/code] wins outright — as in
+## [code]EditorExportPlatformPC::export_project()[/code] — and when it is set
+## but missing this returns "" rather than quietly falling back, so the caller
+## can report the user's own broken path instead of an unrelated
+## "install export templates" message.
+##
+## Otherwise the lookup is delegated to the inherited
+## [method EditorExportPlatform.find_export_template]. That is deliberately the
+## same call the built-in Windows exporter makes: it resolves
+## [code]<templates dir>/<VERSION_FULL_CONFIG>/<file>[/code], which handles the
+## patch-qualified directory name and the [code].mono[/code] suffix of a .NET
+## editor build, and honours self-contained mode and a relocated editor data
+## directory — none of which the previous hand-rolled [code]%APPDATA%[/code]
+## probe did. It is also stricter: there is no fallback to a
+## near-miss version directory, so a 4.6.2 editor never silently packages a
+## 4.6 template (the class of mismatch behind issue #134).
+##
+## The bound method returns a Dictionary of
+## [code]{result, path, error_string}[/code] on both Godot 4.5 and 4.6; only the
+## path is needed here, and it is empty when the template is missing.
+func _find_windows_template(p_preset: EditorExportPreset, p_debug: bool) -> String:
+	var custom: String = _custom_template_path(p_preset, p_debug)
+	if custom != "":
+		return custom if FileAccess.file_exists(custom) else ""
+	var found: Dictionary = find_export_template(_template_file_name(p_debug))
+	if int(found.get("result", FAILED)) != OK:
+		return ""
+	return str(found.get("path", ""))
 
 # Walks every `addons/<name>/bin/` directory and copies:
 # - GDExtension main DLLs (`godot_*.windows.<config>.x86_64.dll`, matching this
@@ -826,7 +1136,7 @@ func _copy_addon_dlls(staging_dir: String, p_debug: bool) -> int:
 
 	var addons := DirAccess.open(addons_dir)
 	if addons == null:
-		push_warning("GDK Export: Cannot open addons directory: %s" % addons_dir)
+		_report_warning("GDK Export: Cannot open addons directory: %s" % addons_dir)
 		return OK
 
 	var main_copied: int = 0
@@ -853,11 +1163,11 @@ func _copy_addon_dlls(staging_dir: String, p_debug: bool) -> int:
 									var dst_dir: String = staging_dir.path_join("addons").path_join(addon_name).path_join("bin")
 									var mk_err: int = DirAccess.make_dir_recursive_absolute(dst_dir)
 									if mk_err != OK:
-										push_error("GDK Export: Failed to create %s (err %d)" % [dst_dir, mk_err])
+										_report_error("GDK Export: Failed to create %s (err %d)" % [dst_dir, mk_err])
 										return mk_err
 									var copy_err: int = DirAccess.copy_absolute(src, dst_dir.path_join(fname))
 									if copy_err != OK:
-										push_error("GDK Export: Failed to copy %s -> %s (err %d)" % [src, dst_dir, copy_err])
+										_report_error("GDK Export: Failed to copy %s -> %s (err %d)" % [src, dst_dir, copy_err])
 										return copy_err
 									main_copied += 1
 								# else: opposite config; skip silently
@@ -867,7 +1177,7 @@ func _copy_addon_dlls(staging_dir: String, p_debug: bool) -> int:
 								if not FileAccess.file_exists(dst):
 									var copy_err2: int = DirAccess.copy_absolute(src, dst)
 									if copy_err2 != OK:
-										push_warning("GDK Export: Failed to copy support DLL %s (err %d)" % [src, copy_err2])
+										_report_warning("GDK Export: Failed to copy support DLL %s (err %d)" % [src, copy_err2])
 									else:
 										support_copied += 1
 						fname = bin.get_next()
@@ -883,7 +1193,7 @@ func _copy_addon_dlls(staging_dir: String, p_debug: bool) -> int:
 	# release after only a debug build. Fail loudly at export time with the
 	# exact fix instead of shipping a broken package (issue #134).
 	if main_copied == 0:
-		push_error(_missing_main_dll_message(this_config))
+		_report_error(_missing_main_dll_message(this_config))
 		return ERR_FILE_NOT_FOUND
 
 	return OK
@@ -898,127 +1208,6 @@ static func _missing_main_dll_message(p_config: String) -> String:
 		"  Build the native addons in this configuration first:\n" +
 		"      cmake --build build --preset %s\n" % build_preset +
 		"  then re-export. (In the Godot export dialog, \"Export With Debug\" unchecked selects release.)")
-
-## Writes the project PCK and returns [method EditorExportPlatform.save_pack]'s
-## raw dictionary: [code]{"result": Error, "so_files": Array}[/code].
-##
-## Using [code]save_pack()[/code] instead of [code]export_pack()[/code] is
-## deliberate and load-bearing:
-##
-## - [code]export_pack()[/code] opens a *second* [code]ExportNotifier[/code]
-##   inside the one [code]EditorExportPlatformExtension[/code] already opened
-##   around [code]_export_project()[/code], so every export plugin's
-##   [code]_export_begin[/code] / [code]_export_end[/code] runs twice (the C#
-##   plugin publishes the whole assembly set twice), and its
-##   [code]_export_end[/code] deletes the C# publish temp directory before this
-##   platform ever gets a chance to stage it.
-## - [code]export_pack()[/code] calls [code]save_pack()[/code] with a null
-##   shared-object sink, so every file an export plugin registered via
-##   [code]add_shared_object()[/code] is silently discarded.
-##
-## Godot delivers a C#/.NET project's published assemblies *exclusively* as
-## shared objects targeted at [code]data_<assembly>_windows_x86_64/[/code], so
-## the discarded set was the entire managed runtime: the packaged game shipped
-## without a single C# DLL (issue #144). [code]save_pack()[/code] hands the
-## list back so [method _stage_shared_objects] can place it.
-func _export_pck(p_preset: EditorExportPreset, p_debug: bool, p_path: String, _p_flags: int) -> Dictionary:
-	return save_pack(p_preset, p_debug, p_path)
-
-## Copies the shared objects that export plugins registered during
-## [code]_export_begin[/code] into [param staging_dir], mirroring what Godot's
-## built-in desktop exporter does with [code]save_pack()[/code]'s
-## [code]so_files[/code]: an entry with an empty [code]target_folder[/code]
-## lands next to the .exe, any other entry lands in that subfolder.
-##
-## This is the only channel through which a C#/.NET project's assemblies reach
-## the package (issue #144).
-##
-## Entries directly under [code]addons/<name>/bin/[/code] are skipped —
-## [method _copy_addon_dlls] already stages those with debug/release filtering
-## and the [code]addons/[/code] layout the .gdextension expects, so copying
-## them here would drop an unfiltered duplicate in the package root.
-func _stage_shared_objects(staging_dir: String, so_files: Variant) -> int:
-	if not (so_files is Array):
-		return OK
-	var project_dir: String = ProjectSettings.globalize_path("res://")
-	var staged: int = 0
-	for entry: Variant in (so_files as Array):
-		if not (entry is Dictionary):
-			continue
-		var shared_object: Dictionary = entry
-		var raw_path: String = str(shared_object.get("path", ""))
-		if raw_path.is_empty():
-			continue
-		var src: String = ProjectSettings.globalize_path(raw_path)
-		if _is_addon_bin_library(src, project_dir):
-			continue
-		var dest: String = _shared_object_destination(
-			staging_dir, src, str(shared_object.get("target_folder", "")))
-		if dest.is_empty():
-			push_warning("GDK Export: Skipping shared object with unusable target: %s" % src)
-			continue
-		var dest_dir: String = dest.get_base_dir()
-		var mk_err: int = DirAccess.make_dir_recursive_absolute(dest_dir)
-		if mk_err != OK:
-			push_error("GDK Export: Failed to create %s (err %d)" % [dest_dir, mk_err])
-			return mk_err
-		var copy_err: int = OK
-		if DirAccess.dir_exists_absolute(src):
-			copy_err = _copy_dir_recursive(src, dest)
-		else:
-			copy_err = DirAccess.copy_absolute(src, dest)
-		if copy_err != OK:
-			push_error("GDK Export: Failed to copy shared object %s -> %s (err %d)" % [
-				src, dest, copy_err])
-			return copy_err
-		staged += 1
-	if staged > 0:
-		print("[GDK Export] Staged %d export-plugin shared object(s)" % staged)
-	return OK
-
-# Resolves where a save_pack() shared-object entry must land inside the staging
-# directory. An empty target folder means "next to the .exe". Returns "" for any
-# entry whose target would escape the staging root (absolute, drive-qualified,
-# res://-style, or `..`-relative), so a misbehaving export plugin cannot write
-# outside the package.
-static func _shared_object_destination(staging_dir: String, src_path: String,
-		target_folder: String) -> String:
-	var file_name: String = src_path.replace("\\", "/").simplify_path().get_file()
-	if file_name.is_empty():
-		return ""
-	var target: String = target_folder.replace("\\", "/").strip_edges()
-	var dest_dir: String = staging_dir
-	if not target.is_empty():
-		if target.begins_with("/") or target.contains("://") or _has_windows_drive(target):
-			return ""
-		dest_dir = staging_dir.path_join(target)
-	var dest: String = dest_dir.path_join(file_name).replace("\\", "/").simplify_path()
-	if not _is_path_inside_dir(dest, staging_dir):
-		return ""
-	return dest
-
-# True when `src_path` is a file directly inside `<project>/addons/<name>/bin/`,
-# i.e. the set _copy_addon_dlls() already owns.
-static func _is_addon_bin_library(src_path: String, project_dir: String) -> bool:
-	var src: String = src_path.replace("\\", "/").simplify_path()
-	var root: String = project_dir.replace("\\", "/").simplify_path()
-	if not root.ends_with("/"):
-		root += "/"
-	var addons_root: String = root + "addons/"
-	if not src.to_lower().begins_with(addons_root.to_lower()):
-		return false
-	var parts: PackedStringArray = src.substr(addons_root.length()).split("/")
-	return parts.size() == 3 and parts[1] == "bin"
-
-static func _has_windows_drive(path: String) -> bool:
-	return path.length() >= 2 and path.substr(1, 1) == ":"
-
-static func _is_path_inside_dir(candidate_path: String, root_dir: String) -> bool:
-	var candidate: String = candidate_path.replace("\\", "/").simplify_path().to_lower()
-	var root: String = root_dir.replace("\\", "/").simplify_path().to_lower()
-	if not root.ends_with("/"):
-		root += "/"
-	return candidate.begins_with(root)
 
 static func _copy_dir_recursive(src_dir: String, dest_dir: String) -> int:
 	var mk_err: int = DirAccess.make_dir_recursive_absolute(dest_dir)
@@ -1061,7 +1250,7 @@ func _rmdir_recursive(path: String) -> void:
 	DirAccess.remove_absolute(path)
 
 # Export option builder helper — flat dict format for EditorExportPlatformExtension
-func _opt(p_name: String, type: int, default_value: Variant = null,
+static func _opt(p_name: String, type: int, default_value: Variant = null,
 		hint: int = PROPERTY_HINT_NONE, hint_string: String = "",
 		required: bool = false) -> Dictionary:
 	var d := {
@@ -1070,7 +1259,9 @@ func _opt(p_name: String, type: int, default_value: Variant = null,
 		"hint": hint,
 		"hint_string": hint_string,
 		"default_value": default_value,
-		"update_visibility": p_name.begins_with("dev/"),
+		# Options whose value changes which *other* options are shown must ask
+		# the dialog to re-query _get_export_option_visibility().
+		"update_visibility": p_name.begins_with("dev/") or p_name == "application/modify_resources",
 	}
 	if required:
 		d["required"] = true

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -34,7 +34,13 @@ Today it:
 - installs or updates the addon-owned `GDKBootstrap` autoload on
   `_enable_plugin`
 - registers the `XBOX on PC` export platform on `_enter_tree`
+- registers `gdk_export_features_plugin.gd`, the `EditorExportPlugin` that
+  restores the `gdk` feature tag during a delegated export (see
+  *Feature tags under delegation*)
 - does **not** dock `gdk_setup_panel.gd`
+
+Both registrations are undone in `_exit_tree`, so disabling the addon leaves
+nothing behind.
 
 `gdk_editor_plugin.gd` owns startup wiring for the runtime addon and
 the export-platform registration; the rest of the packaging UI lives in
@@ -98,16 +104,22 @@ diagnostic must carry that reason instead of an internal error code.
 Two silent ways an `XBOX on PC` export used to produce a package that failed at
 launch with *"GDExtension dynamic library not found"* are now hard errors:
 
-- **No export template for the running Godot version.** The exporter looks for
-  `%APPDATA%\Godot\export_templates\<version>\windows_<config>_x86_64.exe` and
-  now tries the patch-qualified directory first (`4.6.2.stable`), then the
-  patch-less form (`4.6.stable`, used by `x.y.0` releases). If no template is
-  found it **refuses to package** rather than substituting the Godot editor
-  binary — that binary makes `OS.has_feature("editor")` true at runtime and
-  resolves the GDExtension from the dev machine's source tree, so a package
-  built from it fails on any other machine. A **loose** dev-register build still
-  tolerates the editor binary, with a loud warning. Install export templates via
-  **Editor ▸ Manage Export Templates…** (match your patch version).
+- **No export template for the running Godot version.** The `.exe` and `.pck`
+  are produced by Godot's own `EditorExportPlatformWindows` (see
+  *Delegating the .exe and .pck to Godot* below), which resolves
+  `<export templates dir>/<version>/windows_<config>_x86_64.exe`. That means the
+  version directory name (including the patch component, e.g. `4.6.2.stable`,
+  and the `.mono` suffix on a .NET editor build), self-contained mode, and a
+  relocated editor data directory are all handled by the engine instead of being
+  re-derived here. It is also strict: there is no fallback to a near-miss
+  version directory, so a 4.6.2 editor never silently packages a 4.6 template.
+  There is **no** editor-binary stand-in — that binary makes
+  `OS.has_feature("editor")` true at runtime and resolves the GDExtension from
+  the dev machine's source tree, so a package built from it fails on any other
+  machine. A missing template blocks a **loose** dev-register build too. Install
+  export templates via **Editor ▸ Manage Export Templates…** (match your patch
+  version). Validation performs the same lookup up front so the failure appears
+  as a greyed-out **Export Project…** with a reason, not a failed export.
 
 - **No GDExtension DLL for the requested config.** A **release** export stages
   `godot_gdk.windows.release.x86_64.dll`; a **debug** export stages the debug
@@ -117,48 +129,201 @@ launch with *"GDExtension dynamic library not found"* are now hard errors:
   (`cmake --build build --preset release`) instead of shipping a DLL-less
   package. In the export dialog, **Export With Debug** unchecked selects release.
 
-### Export-plugin shared objects / C# assemblies (issue #144)
 
-A third silent failure mode was that an `XBOX on PC` export produced a package
-containing **no C# assemblies at all** — the `data_<assembly>_windows_x86_64`
-folder that a Godot .NET build normally places next to the `.exe` was simply
-absent, so a C# project failed at launch.
+### Texture-format feature tags (issue #144)
 
-Godot hands an export platform two separate things: the resource `.pck`, and a
-list of **shared objects** that export plugins registered via
-`add_shared_object()` during `_export_begin`. The C# export plugin publishes the
-managed assemblies to a temp directory and registers **every published file** as
-a shared object targeted at `data_<assembly>_windows_x86_64/`. That list is the
-*only* channel through which those assemblies reach a package.
+A related — and far more destructive — silent failure: an `XBOX on PC` package
+whose `.pck` came out a **fraction** of the size the same project's
+`Windows Desktop` export produced, with the game dying at load on
+*"Can't load dependency: `res://…`"* for every texture.
 
-The platform used to build the `.pck` with `EditorExportPlatform.export_pack()`,
-which is the wrong primitive for a custom platform:
+Godot resolves an imported resource through the `[remap]` section of its
+`.import` file, and a **VRAM-compressed** texture has no plain `path` key at
+all — only feature-tagged variants:
 
-- it calls `save_pack()` with a **null shared-object sink**, discarding every
-  registered shared object, and
-- it opens a **second** `ExportNotifier` inside the one
-  `EditorExportPlatformExtension` already opens around `_export_project()`, so
-  each export plugin's `_export_begin` / `_export_end` runs **twice** (the C#
-  publish ran twice) and the inner `_export_end` deleted the C# publish temp
-  directory before the platform could copy anything out of it.
+```ini
+[remap]
 
-`_export_pck()` now calls `EditorExportPlatform.save_pack()` — available since
-Godot 4.4 — which returns `{"result": Error, "so_files": Array}`. Each entry is
-`{path, tags, target_folder}`; `_stage_shared_objects()` copies it into the
-staging directory, placing an entry with an empty `target_folder` next to the
-`.exe` and everything else inside that folder, exactly as Godot's built-in
-desktop exporter does. Targets that would escape the staging root are rejected.
+importer="texture"
+path.s3tc="res://.godot/imported/tex.png-<hash>.s3tc.ctex"
+```
 
-Shared objects living directly in `addons/<name>/bin/` are skipped, because
-`_copy_addon_dlls()` already stages those with debug/release filtering and the
-`addons/` layout the `.gdextension` expects; staging them twice would also leave
-an unfiltered duplicate in the package root. Shared objects from anywhere else
-(the C# publish temp dir, a GDExtension that does not use the `bin/` layout) are
-staged by `_stage_shared_objects()`.
+When it writes the `.pck`, Godot compares each `path.<feature>` key against the
+feature tags the platform reports from `_get_platform_features()` +
+`_get_preset_features()`, and **erases** every remap whose feature is missing.
+This platform used to report only `["windows", "gdk", "x86_64"]`, so `s3tc`
+never matched: every VRAM-compressed texture was dropped from the package,
+leaving the `.ctex` its scenes and materials reference unresolvable.
 
-Projects that enable **Embed Build Outputs** are unaffected either way: in that
-mode the C# plugin writes the assemblies into the `.pck` via `add_file()`
-instead of registering shared objects.
+Since the `.pck` is now written by the built-in Windows platform (see
+*Delegating the `.exe` and `.pck` to Godot*), the tags Godot actually consults
+are its own — derived from the very same preset options below. This platform
+derives them identically in `_get_preset_features()`, via two export options
+that mirror the built-in Windows preset:
+
+| Option | Default | Feature tags reported |
+| --- | --- | --- |
+| `texture_format/s3tc_bptc` | `true` | `s3tc`, `bptc` |
+| `texture_format/etc2_astc` | `false` | `etc2`, `astc` |
+
+Existing `export_presets.cfg` files pick the defaults up automatically — Godot
+seeds a preset from the platform's option defaults before applying the stored
+values — so `s3tc`/`bptc` are reported without touching the preset.
+
+Leave **S3TC/BPTC** enabled for any desktop/Xbox target. Turning it off is what
+reproduces the empty-package failure above; the option exists only so a project
+that also imports mobile texture variants can control which set ships.
+
+### Delegating the `.exe` and `.pck` to Godot (issues #134, #144)
+
+A GDK title on PC is an ordinary Win32 application: it runs the stock Godot
+Windows export template on a Windows desktop. The only things that legitimately
+differ from a **Windows Desktop** export are MSIXVC packaging via `makepkg`, the
+GDK staging steps (`MicrosoftGame.config`, logos, addon support DLLs), and the
+`gdk` feature tag.
+
+This platform used to reimplement the whole desktop pipeline anyway — copy a
+template, stamp its icon, stage the D3D12 redistributables, write the `.pck`,
+place the export plugins' shared objects — and every one of those steps was a
+chance to drift from what Godot produces. Issues #134 and #144 were both
+instances of that drift:
+
+- a package shipped with **no C# assemblies**, because `export_pack()` discards
+  the shared objects the .NET export plugin registers (and double-fires every
+  plugin's `_export_begin` / `_export_end`);
+- a package shipped with **no VRAM-compressed textures**, because the platform
+  reported the wrong feature tags;
+- a package shipped with the **stock Godot template icon**, because rcedit was
+  never invoked — and then Godot **removed rcedit entirely in 4.5**, replacing
+  it with a native `TemplateModifier` that is not exposed to GDScript, so an
+  rcedit-based icon path could not work on any version this addon supports.
+
+So `_export_project()` no longer builds the binaries. It hands **its own
+preset** to the engine's `EditorExportPlatformWindows`:
+
+```gdscript
+var windows: Object = ClassDB.instantiate("EditorExportPlatformWindows")
+var err: int = windows.export_project(p_preset, p_debug, exe_path, p_flags)
+```
+
+and then layers the GDK-specific steps on the result:
+
+1. `_copy_addon_dlls()` — addon support runtimes and the `addons/<name>/bin/`
+   layout the `.gdextension` expects.
+2. `_stage_microsoft_game_config()` — identity and shell visuals.
+3. `_stage_logos()` — the images `MicrosoftGame.config` references.
+4. `_wdapp_register()` or `_makepkg_pack()`.
+
+Everything else now comes from the engine and stays correct on its own:
+template resolution, PE icon and `VERSIONINFO` stamping, the console wrapper,
+`binary_format/embed_pck`, Authenticode signing, the D3D12 Agility SDK and PIX
+runtimes, ANGLE, shader baking, and every export plugin's shared objects
+(a C# project's published assemblies among them).
+
+**Passing our own preset is the point.** The user's export filters, encryption
+settings, script export mode, custom features and every mirrored option are read
+straight off the preset they actually edited — there is no copy step that can
+fall out of date. Verified by exporting the same project both ways: the `.exe`
+and `.pck` this produces are **byte-identical** (SHA-256) to a built-in
+`Windows Desktop` export of the same project.
+
+#### The export option table is load-bearing
+
+Delegation only works because `_get_export_options()` declares **every** option
+name the built-in exporter reads — all 38: `EditorExportPlatformWindows`'
+31 plus its `EditorExportPlatformPC` base's 7, which are identical on Godot 4.5
+and 4.6. A missing name reads back as `null` *inside Godot*, and the failure is
+neither obvious nor local: omitting `custom_template/debug` aborts the export
+with *"Mismatching custom export template executable architecture: found
+'invalid'"*.
+
+Only 18 of those options are discoverable at runtime from a preset — Godot
+filters advanced-only options out of `get_property_list()`, and
+`advanced_options` cannot be set from GDScript — so the list is written out
+explicitly and pinned by `test_export_platform_errors.gd`. If a future Godot
+version adds a Windows export option, that test fails instead of an export.
+Regenerate the expected set by grepping `PropertyInfo(Variant::` out of
+`platform/windows/export/export_plugin.cpp` and
+`editor/export/editor_export_platform_pc.cpp`.
+
+Option **visibility** mirrors Godot's grouping too: the executable-resource
+fields collapse behind **Application ▸ Modify Resources** (the renderer options
+`export_angle` / `export_d3d12` / `d3d12_agility_sdk_multiarch` stay visible, as
+in Godot), the signing fields behind **Codesign ▸ Enable**, and the SSH fields
+behind **SSH Remote Deploy ▸ Enabled**. Hiding is cosmetic — every option stays
+declared and readable by the delegate.
+
+#### Feature tags under delegation
+
+Export feature tags come from the platform *performing* the export. Under
+delegation that is the Windows platform, so it reports `pc` / `windows` — the
+same list this platform reports — but `gdk` would silently disappear from every
+packaged build.
+
+`gdk_export_features_plugin.gd` restores it. An `EditorExportPlugin`'s
+`_get_export_features()` is consulted whichever platform is running, so the
+plugin returns `["gdk"]` while `GDKExportPlatform.exporting_for_gdk` is set —
+which is only for the duration of a delegated GDK export, leaving a plain
+`Windows Desktop` export in the same editor session untouched. The plugin is
+registered and unregistered alongside the platform in `gdk_editor_plugin.gd`.
+
+`_get_platform_features()` reports `pc`, `windows` and `gdk`, mirroring
+`EditorExportPlatformPC` plus the one tag genuinely specific to this platform.
+It previously also reported `xbox` and `d3d12`, which Godot defines for no
+platform. Because feature tags drive `OS.has_feature()`, `ProjectSettings`
+`setting.<tag>` overrides, **and** which `path.<feature>` remaps survive into
+the `.pck`, those invented tags made the same project resolve differently
+depending on whether it was packaged here or through `gdkpkg` (which drives the
+built-in Windows Desktop preset). The architecture tag is reported by
+`_get_preset_features()`, which is where Godot puts it.
+
+#### Diagnostics from the delegate
+
+The delegate is a bare instance, so its message log would die with it. Every
+message it produced is copied onto this platform via `_forward_messages()`, so
+the export dialog attributes the whole export to a single run. A delegated
+export that returns `OK` is still checked against a real executable on disk
+before packaging proceeds.
+
+### What is still implemented here
+
+**Export dialog diagnostics.** Export failures are reported through
+`add_message()` as well as `push_error()`/`push_warning()`, so they appear in the
+export dialog's own message log with a severity instead of only in the Output
+panel, which the dialog does not surface. `_export_project()` calls
+`clear_messages()` first so each run's log reflects only that run. The dialog
+renders the category (`GDK Export`) beside each message, so the console-facing
+`GDK Export: ` prefix is stripped from the dialog copy only. Validation
+failures continue to use `set_config_error()` — see below.
+
+**Validation.** `has_valid_export_configuration()` is not exposed to GDScript,
+so it cannot be delegated. This platform keeps its own pre-flight check —
+GDK installed, `MicrosoftGame.config` present, export template resolvable — so
+the export dialog can grey out the button *with a reason* before anything runs.
+
+**The executable name.** Derived from `<Executable Name="…">` in the project's
+`MicrosoftGame.config` rather than from a preset field, so the packaged
+identity and the staged binary cannot disagree.
+
+### Verified against a real export
+
+The behaviour above was confirmed end to end on a Windows machine with the
+Microsoft GDK installed, exporting a probe project through the `XBOX on PC`
+preset and inspecting the staging folder:
+
+- A control experiment exported the same project twice — once through this
+  platform, once through a built-in `Windows Desktop` preset — and the `.exe`
+  and `.pck` were **byte-identical** (matching SHA-256) both times.
+- The icon and `VERSIONINFO` strings were stamped natively by Godot: the colour
+  extracted from the packaged `.exe`'s PE icon resource matched the source icon,
+  and `CompanyName` / `FileVersion` matched the preset.
+- A VRAM-compressed texture whose `.import` carried only a `path.s3tc` entry was
+  present in the `.pck`, which is the fix for issue #144 observed directly.
+- The D3D12 Agility SDK DLLs were staged into `x86_64\` with the architecture
+  suffix stripped, matching the built-in exporter's layout.
+- `wdapp register` completed against the staged folder, and the probe app was
+  unregistered afterwards.
+
 
 ### Why "Export Project…" is greyed out
 
@@ -174,14 +339,15 @@ and reports them together:
 | --- | --- |
 | Microsoft GDK not installed / no `makepkg.exe` + `wdapp.exe` | install command (`winget install Microsoft.Gaming.GDK`) and "restart the editor" |
 | `MicrosoftGame.config` missing from the configured game-config directory | the exact path probed, the **GDK ▸ Create Game Config…** menu entry, the `.template` fallback, and the `gdk/packaging/game_config_dir` Project Setting |
-| No Windows export template for the running Godot version (packaged export only) | the failing config (`debug`/`release`), the Godot version, and **Editor ▸ Manage Export Templates…** |
-| No Windows **.NET/Mono** export template, on a project containing C# | the same, plus that the .NET template package is required and that loose dev-register cannot substitute for it |
+| No Windows export template for the running Godot version | the failing config (`debug`/`release`), the Godot version, and **Editor ▸ Manage Export Templates…** |
+| No Windows **.NET/Mono** export template, on a project containing C# | the same, plus that the .NET template *package* is required rather than the standard one |
+| A configured `custom_template/debug`\|`release` that does not exist | the failing path and the option that names it — never silently swapped for an installed template |
 
 The template check also calls `set_config_missing_templates(true)` so Godot
-shows its built-in **Manage Export Templates** shortcut. It is skipped when
-**Dev ▸ Register Loose** is on, because a loose dev-register build does not
-need a template — *except* on a C# project, which always needs a real .NET
-template (see below). `_has_valid_project_configuration()` reports the
+shows its built-in **Manage Export Templates** shortcut. It applies to **every**
+export, including **Dev ▸ Register Loose**: the `.exe` is produced by Godot's
+own Windows exporter, so there is no editor-binary stand-in that a loose build
+could fall back to. `_has_valid_project_configuration()` reports the
 missing-GDK reason through the same message helper.
 
 Each blocker is reported independently, so a project missing both the GDK and
@@ -189,14 +355,13 @@ Each blocker is reported independently, so a project missing both the GDK and
 
 ### .NET export templates for C# projects (".NET assemblies not found")
 
-`_find_windows_template()` probes
-`%APPDATA%\Godot\export_templates\<version>\windows_<config>_x86_64.exe`. Godot
-appends its module config to that directory name, so a **.NET editor build**
-installs its templates under `4.7.1.stable.mono`, not `4.7.1.stable`. Probing
-only the plain name found nothing on a .NET editor, and the export silently fell
-back to `OS.get_executable_path()` — the Godot **editor** binary.
+Godot appends its module config to the export-template directory name, so a
+**.NET editor build** installs its templates under `4.7.1.stable.mono`, not
+`4.7.1.stable`. A hand-rolled probe that looked only at the plain name found
+nothing on a .NET editor, and the export used to fall back to
+`OS.get_executable_path()` — the Godot **editor** binary.
 
-That fallback is fatal for a C# game. The editor binary is built with
+That fallback was fatal for a C# game. The editor binary is built with
 `TOOLS_ENABLED`, so it resolves .NET assemblies from `<exe_dir>/GodotSharp/Api/`
 instead of the exported `data_<assembly>_windows_x86_64/` directory, and the
 game dies on startup with:
@@ -204,21 +369,27 @@ game dies on startup with:
 > Unable to find the .NET assemblies directory. Make sure the
 > `…/GodotSharp/Api/Debug` directory exists and contains the .NET assemblies.
 
-Two changes close this:
+Both halves of this are closed:
 
-- `_template_version_dirs()` takes a `p_dotnet` flag. When the running editor is
-  a .NET build (`_is_dotnet_editor()`, i.e. `ClassDB.class_exists("CSharpScript")`)
-  every candidate directory gets a `.mono` suffix, and the plain names are
-  **dropped** rather than offered as a fallback — a non-.NET template has no
-  assembly loader and could never host a C# game.
-- `_is_dotnet_project()` (a .NET editor *and* a non-empty
-  `dotnet/project/assembly_name`) makes a real template mandatory. Unlike a
-  GDScript project, a C# project does **not** get the loose dev-register
-  editor-binary fallback; both `_has_valid_export_configuration()` and
-  `_export_project()` hard-fail with a message naming the .NET template package.
+- The `.mono` suffix is handled by the engine's own resolver, which uses the
+  running editor's version config — so a .NET editor only ever resolves a .NET
+  template, and a non-.NET template (which has no assembly loader and could
+  never host a C# game) is never offered as a fallback.
+- The editor-binary fallback is gone entirely. The `.exe` comes from
+  `EditorExportPlatformWindows`, which requires a real template for every
+  export, loose dev-register included.
 
-A GDScript project on a standard (non-.NET) editor build is unaffected: the
-candidate list and the loose fallback behave exactly as before.
+`_is_dotnet_project()` (a .NET editor *and* a non-empty
+`dotnet/project/assembly_name`) survives only to make the validation message
+name the .NET template package specifically, so the user is not sent back to the
+same instruction that just failed them.
+
+A C# project's published assemblies now reach the package the same way they
+reach a `Windows Desktop` export: the .NET export plugin registers them as
+shared objects and the built-in exporter places them in
+`data_<assembly>_windows_x86_64/`. Projects that enable **Embed Build Outputs**
+are unaffected either way — in that mode the plugin writes the assemblies into
+the `.pck` instead.
 
 ### GDK detection lifecycle
 

--- a/tests/godot/gdk/tests/test_export_platform_errors.gd
+++ b/tests/godot/gdk/tests/test_export_platform_errors.gd
@@ -16,6 +16,8 @@ extends "res://addons/godot_gdk_tests/gdk_test_base.gd"
 
 const ExportPlatform := preload("res://addons/godot_gdk/editor/gdk_export_platform.gd")
 const SCRIPT_PATH := "res://addons/godot_gdk/editor/gdk_export_platform.gd"
+const FEATURES_PLUGIN_PATH := "res://addons/godot_gdk/editor/gdk_export_features_plugin.gd"
+const EDITOR_PLUGIN_PATH := "res://addons/godot_gdk/editor/gdk_editor_plugin.gd"
 
 # Real strings captured from GDK 260400 makepkg.exe on failure.
 const GENMAP_STDERR := "'C:\\out\\layout.xml' map file was not created, error = 0x80070003"
@@ -180,79 +182,114 @@ func test_ensure_detected_is_guarded_one_shot() -> void:
 		"_initialize() routes through _ensure_detected()")
 
 
-# ── Export template version-dir resolution (issue #134) ───────────────────
+# ── Export template resolution (issues #134, #144 follow-up) ─────────────
 #
-# `_find_windows_template` used to build the export_templates subdir name as
-# "<major>.<minor>.<status>" (e.g. "4.6.stable"), which never matched the real
-# "4.6.2.stable" directory on a patch release — so patch releases silently fell
-# back to the Godot editor binary as a stand-in template and shipped a package
-# that failed at launch with "GDExtension dynamic library not found". The
-# candidate names now include the patch component, most-specific first.
-
-func test_template_version_dirs_prefers_patch_qualified() -> void:
-	var dirs := ExportPlatform._template_version_dirs(
-		{"major": 4, "minor": 6, "patch": 2, "status": "stable"})
-	assert_eq(dirs[0], "4.6.2.stable",
-		"patch-qualified dir name is tried first (issue #134)")
-	assert_true(dirs.has("4.6.2.stable"),
-		"the real patch-release template dir is a candidate")
-
-
-func test_template_version_dirs_handles_x_y_zero() -> void:
-	# Godot omits the patch component for x.y.0 releases ("4.5.stable"), so that
-	# form must stay a candidate alongside the patch-qualified name.
-	var dirs := ExportPlatform._template_version_dirs(
-		{"major": 4, "minor": 5, "patch": 0, "status": "stable"})
-	assert_true(dirs.has("4.5.stable"),
-		"patch-less dir name (x.y.0) is still a candidate")
-
-
-func test_template_version_dirs_statusless_fallbacks() -> void:
-	# Dev/custom builds may carry no status; bare "major.minor.patch" and
-	# "major.minor" must still be offered.
-	var dirs := ExportPlatform._template_version_dirs(
-		{"major": 4, "minor": 6, "patch": 2, "status": ""})
-	assert_true(dirs.has("4.6.2"), "statusless patch dir is a candidate")
-	assert_true(dirs.has("4.6"), "statusless minor dir is a candidate")
-
-
-func test_find_windows_template_uses_version_dir_helper() -> void:
-	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
-	assert_string_contains(_func_body(src, "_find_windows_template"),
-		"_template_version_dirs",
-		"_find_windows_template resolves candidates via _template_version_dirs")
-
-
-# ── .NET template resolution (".NET assemblies not found") ────────────────
+# Template lookup used to be hand-rolled: it built `%APPDATA%\Godot\
+# export_templates\<version>\` itself and guessed the version directory name
+# from Engine.get_version_info(), including the `.mono` suffix for .NET editor
+# builds. Getting that name wrong is what made patch releases silently fall
+# back to the Godot editor binary and ship a package that died at launch with
+# "GDExtension dynamic library not found" (issue #134).
 #
-# Godot resolves export templates from `<version>.mono` when the editor is a
-# .NET build. Looking only at the plain `<version>` dir found nothing, so a C#
-# project silently fell back to the Godot editor binary — which starts up
-# looking for `<exe_dir>/GodotSharp/Api/Debug` and aborts with ".NET assemblies
-# not found" instead of loading the exported `data_*` assemblies.
+# Godot exposes the exact lookup its own Windows exporter uses, so the platform
+# now delegates to it. find_export_template() resolves
+# `<templates dir>/<VERSION_FULL_CONFIG>/<file>`, which already encodes the
+# patch component, the `.mono` suffix, self-contained mode and a relocated
+# editor data directory — none of which the hand-rolled probe handled.
 
-func test_template_version_dirs_uses_mono_suffix_for_dotnet() -> void:
-	var dirs := ExportPlatform._template_version_dirs(
-		{"major": 4, "minor": 7, "patch": 1, "status": "stable"}, true)
-	assert_eq(dirs[0], "4.7.1.stable.mono",
-		"a .NET editor resolves the patch-qualified .mono template dir first")
-	for dir_name: String in dirs:
-		assert_true(dir_name.ends_with(".mono"),
-			"a non-.NET template cannot host a C# game, so plain dirs are not offered")
+func test_template_file_name_matches_godot_naming() -> void:
+	assert_eq(ExportPlatform._template_file_name(true), "windows_debug_x86_64.exe",
+		"debug template file name matches Godot's Windows exporter")
+	assert_eq(ExportPlatform._template_file_name(false), "windows_release_x86_64.exe",
+		"release template file name matches Godot's Windows exporter")
 
 
-func test_template_version_dirs_default_is_non_mono() -> void:
-	var dirs := ExportPlatform._template_version_dirs(
-		{"major": 4, "minor": 7, "patch": 1, "status": "stable"})
-	assert_eq(dirs[0], "4.7.1.stable",
-		"a standard editor build keeps resolving the plain template dir")
-
-
-func test_find_windows_template_asks_whether_editor_is_dotnet() -> void:
+func test_find_windows_template_delegates_to_engine_lookup() -> void:
 	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
-	assert_string_contains(_func_body(src, "_find_windows_template"),
-		"_is_dotnet_editor()",
-		"_find_windows_template selects .mono candidates on a .NET editor build")
+	var body := _func_body(src, "_find_windows_template")
+	assert_ne(body, "", "_find_windows_template() is defined")
+	assert_string_contains(body, "find_export_template(",
+		"template lookup delegates to EditorExportPlatform.find_export_template()")
+	# The hand-rolled probe must be gone, not merely bypassed: it is the piece
+	# that got the version directory wrong in issue #134.
+	assert_false(body.contains("APPDATA"),
+		"the hand-rolled %APPDATA% probe no longer exists")
+	assert_false(body.contains("export_templates"),
+		"the templates directory is resolved by the engine, not rebuilt here")
+	assert_false(src.contains("_template_version_dirs"),
+		"the version-dir guessing helper is removed along with its only caller")
+
+
+func test_find_windows_template_unwraps_engine_result_dictionary() -> void:
+	# find_export_template() is bound as returning {result, path, error_string}
+	# on both Godot 4.5 and 4.6 — treating it as a String silently yields a
+	# Dictionary-to-String conversion instead of a path.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_find_windows_template")
+	assert_string_contains(body, "\"path\"",
+		"the resolved path is read out of the result dictionary")
+	assert_string_contains(body, "\"result\"",
+		"the result code is checked before trusting the path")
+
+
+# ── Custom export templates ──────────────────────────────────────────────
+#
+# `custom_template/debug` and `custom_template/release` are the standard Godot
+# way to package against a custom engine build. EditorExportPlatformPC honours
+# them ahead of the installed templates; this platform ignored them entirely,
+# so a title built on a patched engine could not be packaged at all.
+
+func test_custom_template_options_are_offered() -> void:
+	var names: PackedStringArray = ExportPlatform.declared_option_names()
+	assert_true("custom_template/debug" in names,
+		"a custom debug template option is offered")
+	assert_true("custom_template/release" in names,
+		"a custom release template option is offered")
+
+
+func test_custom_template_path_selects_option_by_build_config() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_custom_template_path")
+	assert_string_contains(body, "custom_template/debug",
+		"a debug export reads the debug custom template")
+	assert_string_contains(body, "custom_template/release",
+		"a release export reads the release custom template")
+
+
+func test_custom_template_wins_over_installed_template() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_find_windows_template")
+	var custom_idx: int = body.find("_custom_template_path")
+	var engine_idx: int = body.find("find_export_template(")
+	assert_gt(custom_idx, -1, "_find_windows_template consults the custom template option")
+	assert_gt(engine_idx, custom_idx,
+		"a configured custom template is preferred over the installed template")
+
+
+func test_missing_custom_template_is_reported_as_itself() -> void:
+	# A broken custom template path is the user's own explicit configuration, so
+	# it must not be reported as (or silently treated as) a missing *installed*
+	# template.
+	var msg: String = ExportPlatform._missing_custom_template_message(
+		false, "C:\\builds\\my_template.exe")
+	assert_string_contains(msg, "C:\\builds\\my_template.exe",
+		"the failing path is named")
+	assert_string_contains(msg, "custom_template/release",
+		"the offending option is named")
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_has_valid_export_configuration")
+	var custom_idx: int = body.find("_missing_custom_template_message")
+	var installed_idx: int = body.find("_missing_template_message")
+	assert_gt(custom_idx, -1, "validation reports a broken custom template")
+	assert_gt(installed_idx, custom_idx,
+		"a broken custom template is reported instead of the installed-template message")
+
+
+func test_validation_reports_broken_custom_template() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_has_valid_export_configuration")
+	assert_string_contains(body, "_missing_custom_template_message",
+		"export validation surfaces a broken custom template before export starts")
 
 
 func test_dotnet_project_detection_requires_assembly_name() -> void:
@@ -278,19 +315,13 @@ func test_dotnet_missing_template_message_is_actionable() -> void:
 		"the shared template message can name the .NET flavor")
 
 
-func test_export_refuses_editor_binary_for_dotnet_even_when_loose() -> void:
+func test_dotnet_project_needs_a_real_template_up_front() -> void:
 	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
-	var body := _func_body(src, "_export_project")
-	assert_string_contains(body, "_is_dotnet_project()",
-		"a C# project is checked before the loose editor-binary fallback")
-	var dotnet_idx: int = body.find("_is_dotnet_project()")
-	var loose_idx: int = body.find("OS.get_executable_path()")
-	assert_true(dotnet_idx != -1 and loose_idx != -1 and dotnet_idx < loose_idx,
-		"the C# hard error precedes the loose editor-binary fallback")
-
 	var validation := _func_body(src, "_has_valid_export_configuration")
 	assert_string_contains(validation, "_dotnet_requires_template_message",
 		"export validation blocks a template-less C# export up front")
+	assert_string_contains(validation, "set_config_missing_templates(true)",
+		"the dialog is told to offer the Manage Export Templates shortcut")
 
 
 # ── Zero-GDExtension-DLL guard (issue #134) ───────────────────────────────
@@ -325,106 +356,211 @@ func test_copy_addon_dlls_fails_when_zero_main_dlls() -> void:
 		"_copy_addon_dlls aborts the export when no main DLL was staged")
 
 
-# ── Editor-binary-as-template guard (issue #134) ──────────────────────────
+# ── Delegation to the built-in Windows exporter ───────────────────────────
 #
-# The Godot editor binary is not a valid game template: it enables
-# has_feature("editor") and resolves GDExtension DLLs from the dev machine's
-# source tree, so a package built from it fails "not found" elsewhere. Packaged
-# exports must refuse it; only same-machine loose dev-register may fall back.
+# The .exe and .pck used to be produced here: copy a template, stamp its icon
+# with rcedit, stage the D3D12 redistributables, save_pack(), place the shared
+# objects. None of that is GDK-specific (a GDK title on PC is an ordinary Win32
+# application) and every step was a chance to drift from a plain
+# `Windows Desktop` export — issues #134 and #144 were both instances of that
+# drift, and Godot 4.5 removing rcedit outright broke the icon path completely.
+#
+# So the platform hands its own preset to EditorExportPlatformWindows and
+# layers GDK packaging on the result. These tests pin that the in-house
+# pipeline is really gone rather than merely bypassed.
 
-func test_export_refuses_editor_binary_when_packaging() -> void:
+func test_export_delegates_the_exe_and_pck_to_godot() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_run_windows_export")
+	assert_string_contains(body, "WINDOWS_PLATFORM_CLASS",
+		"the built-in Windows platform is what produces the binaries")
+	assert_string_contains(body, "export_project(p_preset, p_debug, exe_path, p_flags)",
+		"this platform's own preset is handed straight to the built-in exporter")
+	assert_eq(ExportPlatform.WINDOWS_PLATFORM_CLASS, "EditorExportPlatformWindows",
+		"the delegate is Godot's Windows exporter")
+
+
+func test_export_project_delegates_before_layering_gdk_packaging() -> void:
 	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
 	var body := _func_body(src, "_export_project")
-	assert_string_contains(body, "if not use_loose:",
-		"a non-loose (packaged) export refuses to continue without a real template")
-	assert_string_contains(body, "OS.get_executable_path()",
-		"the editor-binary fallback remains reachable for loose dev-register")
+	var delegate_at: int = body.find("_run_windows_export(")
+	var dll_at: int = body.find("_copy_addon_dlls(")
+	var config_at: int = body.find("_stage_microsoft_game_config(")
+	var pack_at: int = body.find("_makepkg_pack(")
+	assert_gt(delegate_at, -1, "the export delegates to the built-in Windows exporter")
+	assert_gt(dll_at, delegate_at, "addon DLLs are staged onto the delegated output")
+	assert_gt(config_at, dll_at, "MicrosoftGame.config is staged after the DLLs")
+	assert_gt(pack_at, config_at, "packaging runs last")
 
 
-# ── Export-plugin shared objects / C# assemblies (issue #144) ─────────────
-#
-# `export_pack()` calls `save_pack()` with a null shared-object sink and opens a
-# second ExportNotifier inside the one EditorExportPlatformExtension already
-# opened around `_export_project()`. That ran every export plugin's
-# `_export_begin`/`_export_end` twice AND discarded everything the plugins
-# registered via `add_shared_object()`. Godot ships a C#/.NET project's
-# published assemblies exclusively as shared objects targeted at
-# `data_<assembly>_windows_x86_64/`, so an `XBOX on PC` export produced a
-# package with zero managed DLLs. `save_pack()` returns those entries so the
-# platform can stage them itself.
-
-func test_export_pck_uses_save_pack_to_capture_shared_objects() -> void:
-	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
-	var body := _func_body(src, "_export_pck")
-	assert_string_contains(body, "save_pack(",
-		"_export_pck() uses save_pack() so so_files come back to the platform")
-	assert_false(body.contains("export_pack("),
-		"export_pack() drops add_shared_object() entries and double-fires " +
-		"every export plugin's _export_begin/_export_end — issue #144")
-
-
-func test_export_project_stages_shared_objects_before_addon_dlls() -> void:
+func test_delegated_export_failure_aborts_the_package() -> void:
 	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
 	var body := _func_body(src, "_export_project")
-	assert_string_contains(body, "_stage_shared_objects(",
-		"the export stages the shared objects save_pack() reported")
-	assert_string_contains(body, "so_files",
-		"the export reads save_pack()'s so_files list")
-	var so_at := body.find("_stage_shared_objects(")
-	var dll_at := body.find("_copy_addon_dlls(")
-	assert_true(so_at != -1 and dll_at != -1 and so_at < dll_at,
-		"shared objects are staged before _copy_addon_dlls() so its " +
-		"already-present guard keeps addon DLLs authoritative")
+	assert_string_contains(body, "if delegate_err != OK:",
+		"a failed Windows export must not be packaged")
+	var run_body := _func_body(src, "_run_windows_export")
+	assert_string_contains(run_body, "FileAccess.file_exists(exe_path)",
+		"a success return is still verified against a real executable on disk")
 
 
-func test_shared_object_without_target_lands_next_to_the_exe() -> void:
-	var dest: String = ExportPlatform._shared_object_destination(
-		"C:/out/_gdk_staging", "C:/tmp/publish/Game.dll", "")
-	assert_eq(dest, "C:/out/_gdk_staging/Game.dll",
-		"an empty target folder means the package root")
+func test_delegated_exporter_messages_reach_the_dialog() -> void:
+	# The delegate is a bare instance, so its message log dies with it unless
+	# it is copied across — losing exactly the diagnostics that explain a
+	# failure the user is looking at.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_forward_messages")
+	assert_string_contains(body, "get_message_count()",
+		"every message the delegate logged is walked")
+	assert_string_contains(body, "add_message(",
+		"the delegate's messages are re-emitted on this platform")
+	assert_string_contains(_func_body(src, "_run_windows_export"), "_forward_messages(windows)",
+		"messages are forwarded whether the delegated export succeeded or not")
 
 
-func test_shared_object_target_folder_is_preserved() -> void:
-	var dest: String = ExportPlatform._shared_object_destination(
-		"C:/out/_gdk_staging", "C:/tmp/publish/Game.dll", "data_Game_windows_x86_64")
-	assert_eq(dest, "C:/out/_gdk_staging/data_Game_windows_x86_64/Game.dll",
-		"the C# data_<assembly>_windows_x86_64 target folder is honoured")
+func test_in_house_export_pipeline_is_gone() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	# rcedit was removed from Godot in 4.5 (replaced by a native PE resource
+	# writer that is not exposed to GDScript), so an rcedit-based icon path
+	# cannot work on any version this addon supports.
+	for helper: String in ["_resolve_rcedit_path", "_rcedit_args", "_modify_staged_executable"]:
+		assert_false(src.contains(helper),
+			"%s is removed, not merely unused — Godot 4.5 dropped rcedit" % helper)
+	assert_false(src.contains("_write_ico"),
+		"the hand-rolled .ico writer is gone; Godot stamps the icon natively")
+	assert_false(src.contains("save_pack("),
+		"the .pck is written by the built-in exporter")
+	assert_false(src.contains("_stage_shared_objects"),
+		"export-plugin shared objects (C# assemblies included) are placed by Godot")
+	assert_false(src.contains("AGILITY_SDK_LIBS"),
+		"the D3D12 Agility SDK / PIX redistributables are staged by Godot")
+	assert_false(src.contains("OS.get_executable_path()"),
+		"the editor binary is never substituted for an export template (issue #134)")
 
 
-func test_shared_object_nested_target_folder_is_preserved() -> void:
-	var dest: String = ExportPlatform._shared_object_destination(
-		"C:/out/_gdk_staging", "C:/tmp/publish/sub/dep.dll",
-		"data_Game_windows_x86_64/sub")
-	assert_eq(dest, "C:/out/_gdk_staging/data_Game_windows_x86_64/sub/dep.dll",
-		"nested publish subdirectories keep their relative layout")
+func test_gdk_feature_tag_survives_the_delegated_export() -> void:
+	# Export feature tags come from the platform performing the export, so the
+	# delegated run reports `windows`/`pc` and would silently drop `gdk`. An
+	# EditorExportPlugin's features are consulted whichever platform is running.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	assert_string_contains(_func_body(src, "_run_windows_export"), "exporting_for_gdk = true",
+		"the delegated export is flagged so the feature can be restored")
+	assert_string_contains(_func_body(src, "_run_windows_export"), "exporting_for_gdk = false",
+		"the flag is cleared again so a plain Windows export is unaffected")
+
+	var plugin_src := FileAccess.get_file_as_string(FEATURES_PLUGIN_PATH)
+	assert_ne(plugin_src, "", "the feature-restoring export plugin exists")
+	assert_string_contains(plugin_src, "_get_export_features",
+		"the plugin contributes export features")
+	assert_string_contains(plugin_src, "exporting_for_gdk",
+		"the plugin only contributes during a GDK export")
+	assert_string_contains(plugin_src, "\"gdk\"", "the restored tag is `gdk`")
+
+	var plugin_body := _func_body(plugin_src, "_get_export_features")
+	assert_string_contains(plugin_body, "return PackedStringArray()",
+		"a plain Windows Desktop export in the same session gets no gdk tag")
 
 
-func test_shared_object_target_cannot_escape_the_staging_dir() -> void:
-	for target: String in ["..", "../../elsewhere", "/abs/path", "C:/abs", "res://x"]:
-		var dest: String = ExportPlatform._shared_object_destination(
-			"C:/out/_gdk_staging", "C:/tmp/publish/Game.dll", target)
-		assert_eq(dest, "",
-			"target %s must be rejected instead of writing outside the package" % target)
+func test_features_plugin_is_registered_with_the_platform() -> void:
+	var plugin_src := FileAccess.get_file_as_string(EDITOR_PLUGIN_PATH)
+	assert_string_contains(plugin_src, "add_export_plugin(",
+		"the feature-restoring plugin is registered")
+	assert_string_contains(plugin_src, "remove_export_plugin(",
+		"and removed again on _exit_tree, so disabling the addon leaves no trace")
 
 
-func test_addon_bin_libraries_are_left_to_copy_addon_dlls() -> void:
-	var project := "C:/proj/"
-	assert_true(ExportPlatform._is_addon_bin_library(
-		"C:/proj/addons/godot_gdk/bin/godot_gdk.windows.debug.x86_64.dll", project),
-		"addons/<name>/bin/ DLLs are staged by _copy_addon_dlls with config filtering")
+# ── Export option coverage ────────────────────────────────────────────────
+#
+# Handing our preset to the built-in exporter only works because we declare
+# every option it reads. A missing name reads back as null *inside Godot*, and
+# the failure is neither obvious nor local: omitting `custom_template/debug`
+# aborts the export with "Mismatching custom export template executable
+# architecture: found 'invalid'".
+#
+# The expected set below is EditorExportPlatformWindows::get_export_options()
+# plus its EditorExportPlatformPC base, which are identical on Godot 4.5 and
+# 4.6. Regenerate by grepping `PropertyInfo(Variant::` out of
+# platform/windows/export/export_plugin.cpp and
+# editor/export/editor_export_platform_pc.cpp.
+
+const GODOT_WINDOWS_EXPORT_OPTIONS: Array[String] = [
+	# EditorExportPlatformPC
+	"custom_template/debug",
+	"custom_template/release",
+	"debug/export_console_wrapper",
+	"binary_format/embed_pck",
+	"texture_format/s3tc_bptc",
+	"texture_format/etc2_astc",
+	"shader_baker/enabled",
+	# EditorExportPlatformWindows
+	"binary_format/architecture",
+	"codesign/enable",
+	"codesign/identity_type",
+	"codesign/identity",
+	"codesign/password",
+	"codesign/timestamp",
+	"codesign/timestamp_server_url",
+	"codesign/digest_algorithm",
+	"codesign/description",
+	"codesign/custom_options",
+	"application/modify_resources",
+	"application/icon",
+	"application/console_wrapper_icon",
+	"application/icon_interpolation",
+	"application/file_version",
+	"application/product_version",
+	"application/company_name",
+	"application/product_name",
+	"application/file_description",
+	"application/copyright",
+	"application/trademarks",
+	"application/export_angle",
+	"application/export_d3d12",
+	"application/d3d12_agility_sdk_multiarch",
+	"ssh_remote_deploy/enabled",
+	"ssh_remote_deploy/host",
+	"ssh_remote_deploy/port",
+	"ssh_remote_deploy/extra_args_ssh",
+	"ssh_remote_deploy/extra_args_scp",
+	"ssh_remote_deploy/run_script",
+	"ssh_remote_deploy/cleanup_script",
+]
 
 
-func test_non_addon_bin_shared_objects_are_staged() -> void:
-	var project := "C:/proj/"
-	assert_false(ExportPlatform._is_addon_bin_library(
-		"C:/tmp/godot-publish-dotnet/1234-ExportRelease-win-x64/Game.dll", project),
-		"C# publish output is outside the project and must be staged")
-	assert_false(ExportPlatform._is_addon_bin_library(
-		"C:/proj/addons/other/lib/native.dll", project),
-		"a GDExtension outside addons/<name>/bin/ still needs staging")
-	assert_false(ExportPlatform._is_addon_bin_library(
-		"C:/proj/addons/godot_gdk/bin/sub/nested.dll", project),
-		"only files directly in addons/<name>/bin/ are owned by _copy_addon_dlls")
+func test_every_builtin_windows_option_is_declared() -> void:
+	var declared: PackedStringArray = ExportPlatform.declared_option_names()
+	var missing: Array[String] = []
+	for name: String in GODOT_WINDOWS_EXPORT_OPTIONS:
+		if not (name in declared):
+			missing.append(name)
+	assert_eq(missing, [] as Array[String],
+		"every option the built-in Windows exporter reads must be declared, or " +
+		"it reads back as null inside Godot and fails the export in a way that " +
+		"points nowhere near this platform")
+
+
+func test_gdk_specific_options_are_declared() -> void:
+	var declared: PackedStringArray = ExportPlatform.declared_option_names()
+	for name: String in ["packaging/ekb_file", "dev/register_loose", "dev/sandbox_id"]:
+		assert_true(name in declared, "%s is offered by this platform" % name)
+
+
+func test_option_names_are_unique() -> void:
+	var seen: Dictionary = {}
+	for name: String in ExportPlatform.declared_option_names():
+		assert_false(seen.has(name), "option %s is declared exactly once" % name)
+		seen[name] = true
+
+
+func test_declared_options_have_a_complete_shape() -> void:
+	# EditorExportPlatformExtension wants a flat dict; the nested
+	# {"option": {...}} shape used by EditorExportPlugin crashes the editor with
+	# `Condition "!d.has("name")" is true`.
+	for entry: Dictionary in ExportPlatform.export_option_list():
+		assert_true(entry.has("name"), "each option carries a top-level name")
+		assert_true(entry.has("type"), "each option carries a type")
+		assert_true(entry.has("default_value"), "each option carries a default")
+		assert_false(entry.has("option"),
+			"the nested EditorExportPlugin shape is rejected by the extension API")
 
 
 # ── Silent disabled Export button ─────────────────────────────────────────
@@ -465,8 +601,11 @@ func test_has_valid_export_configuration_reports_every_blocker() -> void:
 			"%s() feeds the export-dialog error text" % message_fn)
 	assert_string_contains(body, "set_config_missing_templates(true)",
 		"a missing export template is flagged so the dialog offers the template manager")
-	assert_string_contains(body, "dev/register_loose",
-		"loose dev-register stays exempt from the export-template requirement")
+	# The .exe is produced by Godot's own exporter now, so there is no
+	# editor-binary stand-in left and loose dev-register is no longer exempt
+	# from the export-template requirement.
+	assert_false(body.contains("dev/register_loose"),
+		"a missing export template blocks loose dev-register too")
 
 
 func test_has_valid_project_configuration_reports_missing_gdk() -> void:
@@ -476,3 +615,217 @@ func test_has_valid_project_configuration_reports_missing_gdk() -> void:
 		"project validation surfaces its reason via set_config_error()")
 	assert_string_contains(body, "_gdk_missing_message",
 		"the missing-GDK reason is shared with export validation")
+
+
+# ── Texture-format feature tags (issue #144 follow-up) ────────────────────
+#
+# Godot matches a preset's feature tags against the `path.<feature>` keys in
+# every imported resource's .import file and ERASES any remap whose feature is
+# missing. A VRAM-compressed texture's only variant is `path.s3tc`, so a
+# platform that never reports "s3tc" silently dropped every such texture from
+# the .pck: the package came out a fraction of its real size and the game died
+# at load with "Can't load dependency: res://...". The tags must be derived
+# from the preset exactly the way EditorExportPlatformPC derives them.
+
+func test_texture_format_features_default_desktop_set() -> void:
+	var features := ExportPlatform._texture_format_features(true, false)
+	assert_true(features.has("s3tc"),
+		"the default desktop preset reports s3tc, or every VRAM-compressed texture is dropped")
+	assert_true(features.has("bptc"), "s3tc_bptc reports bptc alongside s3tc")
+	assert_false(features.has("etc2"), "etc2 is not reported unless etc2_astc is enabled")
+	assert_false(features.has("astc"), "astc is not reported unless etc2_astc is enabled")
+
+
+func test_texture_format_features_mobile_set() -> void:
+	var features := ExportPlatform._texture_format_features(false, true)
+	assert_true(features.has("etc2"), "etc2_astc reports etc2")
+	assert_true(features.has("astc"), "etc2_astc reports astc")
+	assert_false(features.has("s3tc"), "s3tc is not reported when s3tc_bptc is off")
+
+
+func test_texture_format_features_can_report_both() -> void:
+	var features := ExportPlatform._texture_format_features(true, true)
+	for tag: String in ["s3tc", "bptc", "etc2", "astc"]:
+		assert_true(features.has(tag), "%s is reported when both toggles are on" % tag)
+
+
+func test_texture_format_features_none_when_both_disabled() -> void:
+	assert_eq(ExportPlatform._texture_format_features(false, false).size(), 0,
+		"disabling both toggles reports no texture-format tags")
+
+
+func test_preset_features_derive_texture_tags_from_the_preset() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_get_preset_features")
+	assert_string_contains(body, "_texture_format_features(",
+		"_get_preset_features() reports the texture-format tags")
+	assert_string_contains(body, "texture_format/s3tc_bptc",
+		"the s3tc/bptc tags follow the preset toggle")
+	assert_string_contains(body, "texture_format/etc2_astc",
+		"the etc2/astc tags follow the preset toggle")
+
+
+func test_texture_format_options_exist_with_pc_defaults() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "export_option_list")
+	assert_string_contains(body, '_opt("texture_format/s3tc_bptc", TYPE_BOOL, true',
+		"s3tc_bptc defaults to true, matching EditorExportPlatformPC")
+	assert_string_contains(body, '_opt("texture_format/etc2_astc", TYPE_BOOL, false',
+		"etc2_astc defaults to false, matching EditorExportPlatformPC")
+
+
+func test_preset_bool_falls_back_for_presets_predating_the_option() -> void:
+	# An export_presets.cfg written before an option existed has no value for
+	# it; the default must still apply rather than reading as `false`.
+	assert_true(ExportPlatform._preset_bool(null, "texture_format/s3tc_bptc", true),
+		"a missing preset value falls back to the option default")
+	assert_false(ExportPlatform._preset_bool(null, "texture_format/etc2_astc", false),
+		"the fallback is the option's own default, not a hardcoded true")
+
+
+
+# ── Platform feature tags mirror a plain Win32 target ────────────────────
+#
+# A GDK title on PC is an ordinary Win32 application running the stock Godot
+# Windows export template. The platform used to also report "xbox" and "d3d12",
+# which Godot defines for no platform, so the same project packaged through
+# gdkpkg (which drives the built-in Windows Desktop preset) resolved
+# OS.has_feature() checks, `setting.<tag>` ProjectSettings overrides and
+# `.import` remaps differently than it did here. That is the same class of
+# silent divergence as issue #144.
+
+func test_platform_features_match_godot_pc_plus_gdk() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_get_platform_features")
+	assert_ne(body, "", "_get_platform_features() is defined")
+	# EditorExportPlatformPC reports "pc" plus the lowercased OS name.
+	for tag: String in ["\"pc\"", "\"windows\""]:
+		assert_string_contains(body, tag,
+			"%s is reported, matching EditorExportPlatformPC" % tag)
+	assert_string_contains(body, "\"gdk\"",
+		"the one platform-specific tag, gdk, is still reported")
+
+
+func test_invented_platform_feature_tags_are_gone() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_get_platform_features")
+	assert_false(body.contains("\"xbox\""),
+		"the invented xbox tag is gone — GDK on PC is a plain Win32 target")
+	assert_false(body.contains("\"d3d12\""),
+		"the invented d3d12 tag is gone — Godot defines no such platform tag")
+
+
+func test_architecture_tag_is_reported_with_the_preset() -> void:
+	# Godot puts the architecture in get_preset_features(), not the platform
+	# feature list; dropping it from one without the other would erase it from
+	# the exported feature set entirely.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	assert_string_contains(_func_body(src, "_get_preset_features"), "x86_64",
+		"the architecture tag is carried by the preset features, as in Godot")
+
+
+# ── Export option visibility ─────────────────────────────────────────────
+#
+# Visibility is cosmetic — every option stays declared and readable by the
+# built-in exporter — but it has to mirror Godot's grouping or the inspector
+# shows a wall of fields that a `Windows Desktop` preset keeps collapsed.
+
+func test_d3d12_options_are_offered_with_godot_defaults() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "export_option_list")
+	assert_string_contains(body, "application/export_d3d12",
+		"the export_d3d12 mode option is offered")
+	assert_string_contains(body, "Auto,Yes,No",
+		"the mode option uses Godot's Auto/Yes/No enum")
+	assert_string_contains(body, "application/d3d12_agility_sdk_multiarch",
+		"the multiarch option is offered")
+
+
+func test_renderer_options_stay_visible_without_resource_modification() -> void:
+	# These share the `application/` prefix with the executable-resource fields
+	# but describe DLL staging, so turning off resource modification must not
+	# hide them — Godot exempts the same three.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_get_export_option_visibility")
+	assert_string_contains(body, "NON_RESOURCE_APPLICATION_OPTIONS",
+		"the renderer options are exempt from the modify_resources collapse")
+	for name: String in ["application/export_angle", "application/export_d3d12",
+			"application/d3d12_agility_sdk_multiarch"]:
+		assert_string_contains(body, name, "%s is exempt, as in Godot" % name)
+
+
+func test_codesign_and_ssh_options_collapse_behind_their_toggle() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_get_export_option_visibility")
+	assert_string_contains(body, "codesign/enable",
+		"the codesign fields collapse behind codesign/enable, as in Godot")
+	assert_string_contains(body, "ssh_remote_deploy/enabled",
+		"the SSH fields collapse behind ssh_remote_deploy/enabled, as in Godot")
+
+
+
+# ── Export dialog diagnostics ────────────────────────────────────────────
+#
+# push_error()/push_warning() only reach the Output panel, which the export
+# dialog does not surface — an export could fail with the dialog showing
+# nothing at all. EditorExportPlatform.add_message() feeds the dialog's own
+# message log, exactly as the built-in exporters do.
+
+func test_export_diagnostics_reach_the_export_dialog() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var err_body := _func_body(src, "_report_error")
+	var warn_body := _func_body(src, "_report_warning")
+	assert_string_contains(err_body, "EXPORT_MESSAGE_ERROR",
+		"errors are added to the dialog log at error severity")
+	assert_string_contains(warn_body, "EXPORT_MESSAGE_WARNING",
+		"warnings are added to the dialog log at warning severity")
+	# Console output is kept so headless/CI runs still show the reason.
+	assert_string_contains(err_body, "push_error(",
+		"errors still reach the Output panel for headless runs")
+	assert_string_contains(warn_body, "push_warning(",
+		"warnings still reach the Output panel for headless runs")
+
+
+func test_export_starts_from_a_clean_message_log() -> void:
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	var body := _func_body(src, "_export_project")
+	assert_string_contains(body, "clear_messages()",
+		"a new export clears messages left over from the previous run")
+
+
+func test_export_pipeline_reports_through_the_dialog_helpers() -> void:
+	# Every failure the export pipeline can hit must be visible in the dialog,
+	# so the pipeline functions route through the helpers rather than calling
+	# push_error()/push_warning() directly.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	for fn: String in ["_export_project", "_stage_microsoft_game_config",
+			"_copy_addon_dlls", "_run_windows_export", "_wdapp_register"]:
+		var body := _func_body(src, fn)
+		assert_ne(body, "", "%s() is defined" % fn)
+		assert_false(body.contains("push_error("),
+			"%s() reports errors through _report_error()" % fn)
+
+
+func test_dialog_messages_do_not_repeat_the_category() -> void:
+	# add_message() renders the category beside the message, so a message that
+	# already opens with it reads "GDK Export: GDK Export: ...". Observed in a
+	# real export before the prefix was stripped.
+	assert_eq(ExportPlatform._strip_category("GDK Export: wdapp register failed"),
+		"wdapp register failed",
+		"the redundant category prefix is removed for the dialog")
+	assert_eq(ExportPlatform._strip_category("makepkg pack failed"),
+		"makepkg pack failed",
+		"a message without the prefix is passed through untouched")
+
+
+func test_console_output_keeps_the_category_prefix() -> void:
+	# The prefix is what makes these lines findable in the Output panel, so only
+	# the dialog copy is stripped.
+	var src := FileAccess.get_file_as_string(SCRIPT_PATH)
+	for fn: String in ["_report_error", "_report_warning"]:
+		var body := _func_body(src, fn)
+		var push_idx: int = body.find("push_")
+		var strip_idx: int = body.find("_strip_category(")
+		assert_gt(push_idx, -1, "%s() writes to the console" % fn)
+		assert_gt(strip_idx, push_idx,
+			"%s() strips the prefix only for the dialog, not the console" % fn)


### PR DESCRIPTION
…porter

The custom `XBOX on PC` export platform reimplemented Godot's desktop export pipeline by hand instead of driving the engine's own, so it inherited none of Godot's Windows export behaviour. Issue #144 (C# assemblies missing from the package) and issue #134 were both instances of that gap, and so were two more defects found while investigating it:

- VRAM-compressed textures were silently dropped from the .pck. Godot resolves an imported texture through `path.<feature>` keys in its `.import` remap and erases every remap whose feature the exporting platform does not report; this platform reported no texture-format tags at all, so `path.s3tc` never matched. A 864 MB `Windows Desktop` .pck came out of `XBOX on PC` at 147 MB and the game died at load on `Can't load dependency`.
- The staged .exe kept the stock Godot icon and carried no VERSIONINFO.
- The platform reported invented `xbox`, `d3d12` and `x86_64` feature tags, so `OS.has_feature()`, per-feature ProjectSettings overrides and `.import` remaps resolved differently here than under the `Windows Desktop` preset that `gdkpkg` already drives for the same project.

Patching these one at a time kept losing races with the engine. Godot 4.5 removed rcedit and moved PE resource patching into a native TemplateModifier that is not exposed to GDScript, so the icon and version-info path cannot be reimplemented from a GDScript export platform at all any more.

So stop reimplementing it. `_export_project()` now instantiates EditorExportPlatformWindows and calls `export_project()` on it with *our own* preset, then layers the GDK packaging steps on top of the result:

- The .exe, the console wrapper .exe, the .pck, the embedded PE icon, version info, code signing, .NET assemblies, texture-format feature tags, the D3D12 Agility SDK and PIX runtimes, and declared shared objects are all produced by the engine. Whatever Godot adds to its Windows exporter in a future release is inherited for free, and there is no copy of that logic here to fall out of date.
- MicrosoftGame.config generation, the support-runtime DLL copy (libHttpClient, Thunks, XCurl, GameChat2), makepkg layout generation and the loose dev-register flow stay here, because they are genuinely GDK-specific.

Two mechanical consequences of delegating:

- The export option table is load-bearing. The built-in exporter reads its options back off the preset it is handed, so every name it touches must be declared here or it reads back null (omitting `custom_template/debug`, for instance, fails the export with "Mismatching custom export template executable architecture: found 'invalid'"). All 38 options from EditorExportPlatformWindows and EditorExportPlatformPC are now declared verbatim -- the list is identical in Godot 4.5 and 4.6 -- alongside the 3 GDK-specific ones, and Godot's own visibility rules are mirrored so the inspector still collapses the codesign, SSH and non-resource application groups. A test pins the list so drift is caught.
- Export feature tags come from the platform *performing* the export, so a delegated run would otherwise drop `gdk`. A small EditorExportPlugin (gdk_export_features_plugin.gd) re-adds it for the duration of a GDK export and stays out of the way otherwise:

      # Still works from game code under an XBOX on PC export.
      if OS.has_feature("gdk"):
          GDK.initialize()

      # And in project.godot per-feature overrides:
      #   [display]
      #   window/size/mode.gdk=3

No public GDScript API changed; every affected method is internal to the export platform. The user-visible new surface is export-preset options, configured in the export dialog rather than from script -- the full Windows option set is now present under `Project > Export... > XBOX on PC`, including Application (icon, version strings), Texture Format, Binary Format, Codesign and Dotnet.

Behaviour change: a loose dev-register export is no longer exempt from the export-template requirement. The old code substituted the running editor binary when no template was installed; Godot's exporter requires a real template, so that stand-in is gone and the export now fails with a clear message instead of producing a package that cannot run standalone.

Validation:
- tools/run_all_tests.ps1 (full offline tier): overall pass -- parse gate, cmake debug build, C++ doctest, GUT hosts (gdk 330 tests / 3424 asserts, playfab 81, gameinput 60, 0 failures) and all 13 bootstrap mini-runners.
- Live tests: skipped (default; no -Live).
- Verified end to end against an installed Microsoft GDK: a probe project exported through `XBOX on PC` and `wdapp register` succeeded.
- Control experiment: the same project exported through a real `Windows Desktop` preset produced a byte-identical .exe and console .exe (SHA-256), and a .pck differing only by the `gdk` string in `_custom_features`.

Fixes #144.

<!--
This template is auto-applied by GitHub when a PR is opened. Fill it in honestly
— the agent workflow expects each section to be present and substantive. If a
section truly does not apply, write "Not applicable: <reason>" rather than
deleting it.
-->

## Summary

<!-- 1–3 lines. Name the branch and the user-visible change. -->

## Public API changes

<!--
Every renamed/added GDScript-visible class, method, property, signal, or enum
goes here, with a short GDScript usage example for each. If the PR adds no
public API, write "None".
-->

```gdscript
# Example for a new API:
# var result := await PlayFab.users.sign_in_with_custom_id_async("my-id").completed
```

## Spec / docs / samples updated

<!-- Tick the boxes that apply to the touched surfaces. -->

- [ ] `spec\gdext-<feature>.md` updated (Plan / Progress sections if multi-session work)
- [ ] `docs\godot-<addon>-*.md` updated
- [ ] `addons\<addon>\doc_classes\*.xml` updated for any public API change
- [ ] Sample content (`sample\<host>\`) updated when public addon behaviour changed
- [ ] Path-scoped instruction file (`.github\instructions\<addon>.instructions.md`) updated if conventions changed
- [ ] Not applicable — no public addon behaviour changed

## Test coverage delta

<!--
State how the test pipeline moved. Use the per-tier counts from the orchestrator
summary (`build\test-results\run-summary.md`).
-->

- Contract (offline) tests added/removed: …
- Live-read tests added/removed: …
- Live-write tests added/removed: …
- Live title id used (if any): …

## Validation run

<!--
The commands actually executed for this change. Paste the trailing summary
line(s) where possible. Do not skip — reviewers should not have to guess what
was run locally.
-->

```text
# Example:
# pwsh ...\check_gd_scripts_headless.ps1   -> PASS (52 files)
# pwsh ...\run_all_tests.ps1               -> PASS (parse, build, doctest, GUT, bootstrap)
# pwsh ...\run_all_tests.ps1 -Live         -> PASS (live reads only; live writes pending)
```

## Migration notes

<!--
Only if this PR breaks the public surface or changes a Project Setting key.
Otherwise write "None".
-->

None.
