### PR TITLE
docs: add Visit our Blog and Join our Discord badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![.NET supported][badge-dotnet]][link-dotnet]
 [![Documentation on Microsoft Learn][badge-docs]][link-docs]
 [![Visit our Blog][badge-blog]][link-blog]
-[![Join our Discord][badge-discord]][link-discord]
+[![Join us on Discord][badge-discord]][link-discord]
 [![PRs welcome][badge-prs]][link-prs]
 
 **Learn to build your Godot 4 game for XBOX on PC.** Reference GDExtension addons binding the Microsoft **GDK**, **XBOX Services**, **PlayFab**, and **GameInput** into Godot - usable from both GDScript and C#/.NET.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![GameInput supported][badge-gameinput]][link-gameinput]
 [![.NET supported][badge-dotnet]][link-dotnet]
 [![Documentation on Microsoft Learn][badge-docs]][link-docs]
+[![Visit our Blog][badge-blog]][link-blog]
+[![Join our Discord][badge-discord]][link-discord]
 [![PRs welcome][badge-prs]][link-prs]
 
 **Learn to build your Godot 4 game for XBOX on PC.** Reference GDExtension addons binding the Microsoft **GDK**, **XBOX Services**, **PlayFab**, and **GameInput** into Godot - usable from both GDScript and C#/.NET.
@@ -118,5 +120,9 @@ Design specs live in [`spec/`](spec/) - design intent that is not always reflect
 [link-dotnet]: docs/getting-started.md
 [badge-docs]: https://img.shields.io/badge/docs-Microsoft%20Learn-0078D4
 [link-docs]: https://aka.ms/XBOXGodotDocs
+[badge-blog]: https://img.shields.io/badge/Visit%20our-Blog-FFA500?logo=rss&logoColor=white
+[link-blog]: https://developer.microsoft.com/en-us/games/articles/
+[badge-discord]: https://img.shields.io/badge/Join%20us%20on-Discord-7289DA?logo=discord&logoColor=white
+[link-discord]: https://aka.ms/msftgamedevdiscord
 [badge-prs]: https://img.shields.io/badge/PRs-welcome-d6336c
 [link-prs]: CONTRIBUTING.md


### PR DESCRIPTION
## Summary

Branch `readme-blog-discord-badges`. Adds two badges to the README badge row, between the **Documentation on Microsoft Learn** badge and the **PRs welcome** badge:

- **Visit our Blog** -> https://developer.microsoft.com/en-us/games/articles/
- **Join us on Discord** -> https://aka.ms/msftgamedevdiscord

Badge iconography and colors match [`microsoft/godot-csharp-essentials`](https://github.com/microsoft/godot-csharp-essentials) (`rss` logo / `FFA500` for the blog, `discord` logo / `7289DA` for Discord). Only the Discord link target differs, pointing at the Microsoft game dev Discord aka.ms link as requested. Definitions follow the existing reference-style `[badge-*]` / `[link-*]` convention at the bottom of the README.

## Public API changes

None.

```gdscript
# No API surface touched by this change.
```

## Spec / docs / samples updated

- [ ] `spec\gdext-<feature>.md` updated (Plan / Progress sections if multi-session work)
- [ ] `docs\godot-<addon>-*.md` updated
- [ ] `addons\<addon>\doc_classes\*.xml` updated for any public API change
- [ ] Sample content (`sample\<host>\`) updated when public addon behaviour changed
- [ ] Path-scoped instruction file (`.github\instructions\<addon>.instructions.md`) updated if conventions changed
- [x] Not applicable - no public addon behaviour changed

Root `README.md` is the only file touched.

## Test coverage delta

- Contract (offline) tests added/removed: none
- Live-read tests added/removed: none
- Live-write tests added/removed: none
- Live title id used (if any): none

## Validation run

Markdown-only change - no `.gd`, `.cpp`, or build files touched, so the parse gate and test orchestrator were intentionally **not** run (nothing they cover appears in this diff). `pr-gates.yml` path filters also skip pure `**.md` churn. Validation performed instead was link/asset reachability:

```text
# HTTP checks (Invoke-WebRequest, redirects followed)
https://img.shields.io/badge/Visit%20our-Blog-FFA500?logo=rss&logoColor=white           -> 200
https://img.shields.io/badge/Join%20us%20on-Discord-7289DA?logo=discord&logoColor=white -> 200
https://developer.microsoft.com/en-us/games/articles/                                   -> 200
https://aka.ms/msftgamedevdiscord                                                       -> 200
```

Live tests: skipped (default). `-AllowLiveWrites` was not used.

## Migration notes

None.
