### PR TITLE
fix(build): stop release builds from silently linking the debug godot-cpp

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,19 +16,26 @@ Each addon owns its own `CMakeLists.txt`. The root `CMakeLists.txt` is a thin su
 ## Build Commands
 
 ```powershell
-# Configure the default repo build
+# Configure and build debug
 cmake --preset default
+cmake --build --preset debug
 
-# Build debug
-cmake --build build --preset debug
-
-# Build release
-cmake --build build --preset release
+# Configure and build release (separate build tree - see below)
+cmake --preset default-release
+cmake --build --preset release
 
 # Optional: build only the GameInput addon
 cmake --preset gameinput-only
 cmake --build --preset debug-gameinput
 ```
+
+Debug and Release use **separate configure presets and binary directories**
+because godot-cpp's `GODOTCPP_TARGET` is a configure-time cache variable. Every
+configure preset has a `-release` sibling (`default-release`,
+`gdk-only-release`, `playfab-only-release`, `gameinput-only-release`,
+`addon-package-release`, `installed-gdk-release`). `cmake --build build --config
+Release` is guarded and fails on purpose; see
+`docs\troubleshooting.md` ("Release build linked the debug godot-cpp").
 
 Output binaries land in each addon's `bin\` folder. Addon-local build logic may also sync files into `sample\addons\...\`.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,12 @@ endif()
 
 add_subdirectory(godot-cpp)
 
+# godot-cpp's GODOTCPP_TARGET is a configure-time cache string, so a single
+# binary directory can only ever build one configuration correctly. Each addon
+# calls godot_cpp_config_guard() on its own target (add_custom_command(TARGET)
+# must run in the directory that created the target).
+include(GodotCppConfigGuard)
+
 if(BUILD_GODOT_GDK)
     add_subdirectory(addons/godot_gdk)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,13 +14,14 @@
                 "CMAKE_MAP_IMPORTED_CONFIG_DEBUG": "Release;",
                 "CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO": "Release;",
                 "CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL": "Release;",
+                "GODOTCPP_TARGET": "template_debug",
                 "BUILD_GODOT_GDK": "ON",
                 "BUILD_GODOT_GAMEINPUT": "ON"
             }
         },
         {
             "name": "default",
-            "displayName": "Visual Studio 2022 x64",
+            "displayName": "Visual Studio 2022 x64 (Debug / godot-cpp template_debug)",
             "inherits": "_base",
             "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "cacheVariables": {
@@ -28,8 +29,17 @@
             }
         },
         {
+            "name": "default-release",
+            "displayName": "Visual Studio 2022 x64 (Release / godot-cpp template_release)",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build/release",
+            "cacheVariables": {
+                "GODOTCPP_TARGET": "template_release"
+            }
+        },
+        {
             "name": "gdk-only",
-            "displayName": "GDK addon only",
+            "displayName": "GDK addon only (Debug)",
             "inherits": "default",
             "binaryDir": "${sourceDir}/build/gdk-only",
             "cacheVariables": {
@@ -41,8 +51,17 @@
             }
         },
         {
+            "name": "gdk-only-release",
+            "displayName": "GDK addon only (Release)",
+            "inherits": "gdk-only",
+            "binaryDir": "${sourceDir}/build/gdk-only-release",
+            "cacheVariables": {
+                "GODOTCPP_TARGET": "template_release"
+            }
+        },
+        {
             "name": "gameinput-only",
-            "displayName": "GameInput addon only",
+            "displayName": "GameInput addon only (Debug)",
             "inherits": "default",
             "binaryDir": "${sourceDir}/build/gameinput-only",
             "cacheVariables": {
@@ -54,8 +73,17 @@
             }
         },
         {
+            "name": "gameinput-only-release",
+            "displayName": "GameInput addon only (Release)",
+            "inherits": "gameinput-only",
+            "binaryDir": "${sourceDir}/build/gameinput-only-release",
+            "cacheVariables": {
+                "GODOTCPP_TARGET": "template_release"
+            }
+        },
+        {
             "name": "playfab-only",
-            "displayName": "PlayFab addon only",
+            "displayName": "PlayFab addon only (Debug)",
             "inherits": "default",
             "binaryDir": "${sourceDir}/build/playfab-only",
             "cacheVariables": {
@@ -67,8 +95,17 @@
             }
         },
         {
+            "name": "playfab-only-release",
+            "displayName": "PlayFab addon only (Release)",
+            "inherits": "playfab-only",
+            "binaryDir": "${sourceDir}/build/playfab-only-release",
+            "cacheVariables": {
+                "GODOTCPP_TARGET": "template_release"
+            }
+        },
+        {
             "name": "addon-package",
-            "displayName": "Drop-in addon package",
+            "displayName": "Drop-in addon package (Debug)",
             "inherits": "default",
             "binaryDir": "${sourceDir}/build/addon-package",
             "cacheVariables": {
@@ -80,13 +117,31 @@
             }
         },
         {
+            "name": "addon-package-release",
+            "displayName": "Drop-in addon package (Release)",
+            "inherits": "addon-package",
+            "binaryDir": "${sourceDir}/build/addon-package-release",
+            "cacheVariables": {
+                "GODOTCPP_TARGET": "template_release"
+            }
+        },
+        {
             "name": "installed-gdk",
-            "displayName": "Installed GDK on disk (no vcpkg required; GameInput via NuGet)",
+            "displayName": "Installed GDK on disk, Debug (no vcpkg required; GameInput via NuGet)",
             "inherits": "_base",
             "binaryDir": "${sourceDir}/build/installed-gdk",
             "cacheVariables": {
                 "GDK_DEPENDENCY_SOURCE": "installed",
                 "GAMEINPUT_SOURCE": "nuget"
+            }
+        },
+        {
+            "name": "installed-gdk-release",
+            "displayName": "Installed GDK on disk, Release (no vcpkg required; GameInput via NuGet)",
+            "inherits": "installed-gdk",
+            "binaryDir": "${sourceDir}/build/installed-gdk-release",
+            "cacheVariables": {
+                "GODOTCPP_TARGET": "template_release"
             }
         },
         {
@@ -137,7 +192,7 @@
         {
             "name": "release",
             "displayName": "Release",
-            "configurePreset": "default",
+            "configurePreset": "default-release",
             "configuration": "Release"
         },
         {
@@ -152,7 +207,7 @@
         {
             "name": "release-gdk",
             "displayName": "Release (godot_gdk only)",
-            "configurePreset": "gdk-only",
+            "configurePreset": "gdk-only-release",
             "configuration": "Release",
             "targets": [
                 "godot_gdk"
@@ -170,7 +225,7 @@
         {
             "name": "release-gameinput",
             "displayName": "Release (godot_gameinput only)",
-            "configurePreset": "gameinput-only",
+            "configurePreset": "gameinput-only-release",
             "configuration": "Release",
             "targets": [
                 "godot_gameinput"
@@ -188,7 +243,7 @@
         {
             "name": "release-playfab",
             "displayName": "Release (godot_playfab only)",
-            "configurePreset": "playfab-only",
+            "configurePreset": "playfab-only-release",
             "configuration": "Release",
             "targets": [
                 "godot_playfab"
@@ -208,7 +263,7 @@
         {
             "name": "release-addon-package",
             "displayName": "Release (drop-in addon package)",
-            "configurePreset": "addon-package",
+            "configurePreset": "addon-package-release",
             "configuration": "Release",
             "targets": [
                 "godot_gdk",
@@ -225,7 +280,7 @@
         {
             "name": "release-installed-gdk",
             "displayName": "Release (installed GDK)",
-            "configurePreset": "installed-gdk",
+            "configurePreset": "installed-gdk-release",
             "configuration": "Release"
         },
         {

--- a/addons/godot_gameinput/CMakeLists.txt
+++ b/addons/godot_gameinput/CMakeLists.txt
@@ -27,6 +27,8 @@ target_link_libraries(godot_gameinput PRIVATE
     Microsoft::GameInput
 )
 
+godot_cpp_config_guard(godot_gameinput)
+
 target_compile_definitions(godot_gameinput PRIVATE _GAMING_DESKTOP)
 
 godot_addon_configure_target(

--- a/addons/godot_gdk/CMakeLists.txt
+++ b/addons/godot_gdk/CMakeLists.txt
@@ -53,6 +53,8 @@ target_link_libraries(godot_gdk PRIVATE
     Xbox::GameChat2
 )
 
+godot_cpp_config_guard(godot_gdk)
+
 target_compile_definitions(godot_gdk PRIVATE _GAMING_DESKTOP)
 
 godot_addon_configure_target(

--- a/addons/godot_gdk/editor/gdk_export_platform.gd
+++ b/addons/godot_gdk/editor/gdk_export_platform.gd
@@ -1200,13 +1200,17 @@ func _copy_addon_dlls(staging_dir: String, p_debug: bool) -> int:
 
 # Actionable diagnostic for the zero-GDExtension-DLL failure mode (issue #134).
 static func _missing_main_dll_message(p_config: String) -> String:
-	var build_preset: String = "debug" if p_config == "debug" else "release"
+	var is_debug: bool = p_config == "debug"
+	var configure_preset: String = "default" if is_debug else "default-release"
+	var build_preset: String = "debug" if is_debug else "release"
 	return (
 		"GDK Export: no GDExtension main DLL for the '%s' configuration was found in any addons/*/bin.\n" % p_config +
 		"  A '%s' export must stage godot_*.windows.%s.x86_64.dll next to its .gdextension, or the\n" % [p_config, p_config] +
 		"  packaged game fails at launch with \"GDExtension dynamic library not found\".\n" +
-		"  Build the native addons in this configuration first:\n" +
-		"      cmake --build build --preset %s\n" % build_preset +
+		"  Build the native addons in this configuration first (each configuration has its own\n" +
+		"  configure preset and build tree):\n" +
+		"      cmake --preset %s\n" % configure_preset +
+		"      cmake --build --preset %s\n" % build_preset +
 		"  then re-export. (In the Godot export dialog, \"Export With Debug\" unchecked selects release.)")
 
 static func _copy_dir_recursive(src_dir: String, dest_dir: String) -> int:

--- a/addons/godot_playfab/CMakeLists.txt
+++ b/addons/godot_playfab/CMakeLists.txt
@@ -39,6 +39,8 @@ target_link_libraries(godot_playfab PRIVATE
     Xbox::PlayFabGameSave
 )
 
+godot_cpp_config_guard(godot_playfab)
+
 option(GODOT_PLAYFAB_TEST_HOOKS_ENABLED
     "Expose internal test-only methods on PlayFab classes (used by the GUT test host)."
     ON)

--- a/cmake/AssertGodotCppConfig.cmake
+++ b/cmake/AssertGodotCppConfig.cmake
@@ -1,0 +1,62 @@
+# AssertGodotCppConfig.cmake
+#
+# Standalone script (cmake -P) that fails the build when the configuration being
+# built disagrees with the godot-cpp target the binary directory was configured
+# for.
+#
+# godot-cpp's GODOTCPP_TARGET is a configure-time cache string; it is not tied to
+# $<CONFIG>. It drives DEBUG_FEATURES (godot-cpp/cmake/godotcpp.cmake), which in
+# turn drives the PUBLIC DEBUG_ENABLED / HOT_RELOAD_ENABLED definitions in
+# godot-cpp/cmake/common_compiler_flags.cmake. Those propagate to every target
+# that links godot-cpp. With a multi-config generator a single configure serves
+# both configurations, so `--config Release` against a template_debug configure
+# silently produces a release-named DLL carrying debug-only ABI. That mismatch
+# is not diagnosable from the binary at load time: it loads fine and corrupts
+# the heap later (STATUS_HEAP_CORRUPTION, 0xC0000374) on shutdown.
+#
+# Required -D arguments:
+#   GODOTCPP_TARGET  the configured godot-cpp target
+#   BUILD_CONFIG     the configuration currently being built ($<CONFIG>)
+#   TARGET_NAME      the target being built, for the error message
+
+if(NOT DEFINED GODOTCPP_TARGET OR GODOTCPP_TARGET STREQUAL "")
+    message(FATAL_ERROR "AssertGodotCppConfig.cmake requires -DGODOTCPP_TARGET=<target>.")
+endif()
+
+if(NOT DEFINED BUILD_CONFIG OR BUILD_CONFIG STREQUAL "")
+    # Single-config generators can legitimately build with no configuration
+    # name. The configure-time check in GodotCppConfigGuard.cmake covers those.
+    return()
+endif()
+
+if(NOT DEFINED TARGET_NAME)
+    set(TARGET_NAME "<unknown>")
+endif()
+
+if(GODOTCPP_TARGET STREQUAL "template_release")
+    set(_allowed_configs Release RelWithDebInfo MinSizeRel)
+    set(_fix_hint "cmake --preset default\n      cmake --build --preset debug")
+else()
+    set(_allowed_configs Debug)
+    set(_fix_hint "cmake --preset default-release\n      cmake --build --preset release")
+endif()
+
+if(BUILD_CONFIG IN_LIST _allowed_configs)
+    return()
+endif()
+
+string(REPLACE ";" ", " _allowed_display "${_allowed_configs}")
+message(FATAL_ERROR
+    "godot-cpp configuration mismatch while building '${TARGET_NAME}'.\n"
+    "This binary directory was configured with GODOTCPP_TARGET=${GODOTCPP_TARGET}, "
+    "which only supports building: ${_allowed_display}. You asked to build: ${BUILD_CONFIG}.\n"
+    "Building '${BUILD_CONFIG}' here would link godot-cpp's ${GODOTCPP_TARGET} library and "
+    "compile DEBUG_ENABLED / HOT_RELOAD_ENABLED into the output. The resulting DLL loads "
+    "successfully and then corrupts the heap (STATUS_HEAP_CORRUPTION, 0xC0000374) inside a "
+    "Godot build of the other configuration, so this is failing now rather than shipping a "
+    "broken binary.\n"
+    "GODOTCPP_TARGET is a configure-time cache variable, so one binary directory can only "
+    "ever serve one configuration correctly. Configure the matching preset into its own "
+    "binary directory instead:\n"
+    "      ${_fix_hint}\n"
+    "See docs/troubleshooting.md ('Release build linked the debug godot-cpp').")

--- a/cmake/AssertGodotCppConfig.cmake
+++ b/cmake/AssertGodotCppConfig.cmake
@@ -36,12 +36,17 @@ endif()
 if(GODOTCPP_TARGET STREQUAL "template_release")
     set(_allowed_configs Release RelWithDebInfo MinSizeRel)
     set(_fix_hint "cmake --preset default\n      cmake --build --preset debug")
+    set(_consequence "link godot-cpp's template_release library and omit the debug-only DEBUG_ENABLED / HOT_RELOAD_ENABLED definitions that a debug build expects")
 else()
     set(_allowed_configs Debug)
     set(_fix_hint "cmake --preset default-release\n      cmake --build --preset release")
+    set(_consequence "link godot-cpp's template_debug library and compile the debug-only DEBUG_ENABLED / HOT_RELOAD_ENABLED definitions into the output")
 endif()
 
-if(BUILD_CONFIG IN_LIST _allowed_configs)
+# list(FIND) rather than if(... IN_LIST ...): IN_LIST needs policy CMP0057 set
+# to NEW, which is not guaranteed in `cmake -P` script mode on CMake 3.x.
+list(FIND _allowed_configs "${BUILD_CONFIG}" _config_index)
+if(NOT _config_index EQUAL -1)
     return()
 endif()
 
@@ -50,8 +55,7 @@ message(FATAL_ERROR
     "godot-cpp configuration mismatch while building '${TARGET_NAME}'.\n"
     "This binary directory was configured with GODOTCPP_TARGET=${GODOTCPP_TARGET}, "
     "which only supports building: ${_allowed_display}. You asked to build: ${BUILD_CONFIG}.\n"
-    "Building '${BUILD_CONFIG}' here would link godot-cpp's ${GODOTCPP_TARGET} library and "
-    "compile DEBUG_ENABLED / HOT_RELOAD_ENABLED into the output. The resulting DLL loads "
+    "Building '${BUILD_CONFIG}' here would ${_consequence}. The resulting DLL loads "
     "successfully and then corrupts the heap (STATUS_HEAP_CORRUPTION, 0xC0000374) inside a "
     "Godot build of the other configuration, so this is failing now rather than shipping a "
     "broken binary.\n"

--- a/cmake/GodotCppConfigGuard.cmake
+++ b/cmake/GodotCppConfigGuard.cmake
@@ -28,7 +28,8 @@ endfunction()
 get_property(_godot_cpp_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT _godot_cpp_multi_config AND CMAKE_BUILD_TYPE)
     godot_cpp_expected_configs(_expected)
-    if(NOT CMAKE_BUILD_TYPE IN_LIST _expected)
+    list(FIND _expected "${CMAKE_BUILD_TYPE}" _expected_index)
+    if(_expected_index EQUAL -1)
         string(REPLACE ";" ", " _expected_display "${_expected}")
         message(FATAL_ERROR
             "godot-cpp configuration mismatch.\n"

--- a/cmake/GodotCppConfigGuard.cmake
+++ b/cmake/GodotCppConfigGuard.cmake
@@ -1,0 +1,56 @@
+# GodotCppConfigGuard.cmake
+#
+# Guards against building a configuration that disagrees with the godot-cpp
+# target this binary directory was configured for. See
+# cmake/AssertGodotCppConfig.cmake for why a mismatch is dangerous and why one
+# binary directory cannot serve both configurations.
+#
+# Provides:
+#   godot_cpp_config_guard(<target>...)
+#       Attaches a PRE_BUILD check to each target so a mismatched build fails
+#       loudly before any object file is produced.
+#
+# Also performs the single-config-generator check at configure time, where
+# CMAKE_BUILD_TYPE is known.
+
+set(_GODOT_CPP_ASSERT_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/AssertGodotCppConfig.cmake")
+
+function(godot_cpp_expected_configs out_var)
+    if(GODOTCPP_TARGET STREQUAL "template_release")
+        set(${out_var} Release RelWithDebInfo MinSizeRel PARENT_SCOPE)
+    else()
+        set(${out_var} Debug PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Configure-time check. Multi-config generators do not know the configuration
+# yet, so they are covered by the per-target PRE_BUILD guard below.
+get_property(_godot_cpp_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT _godot_cpp_multi_config AND CMAKE_BUILD_TYPE)
+    godot_cpp_expected_configs(_expected)
+    if(NOT CMAKE_BUILD_TYPE IN_LIST _expected)
+        string(REPLACE ";" ", " _expected_display "${_expected}")
+        message(FATAL_ERROR
+            "godot-cpp configuration mismatch.\n"
+            "  GODOTCPP_TARGET=${GODOTCPP_TARGET} supports: ${_expected_display}\n"
+            "  CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}\n"
+            "  Configure a separate binary directory for this configuration "
+            "(see the *-release presets in CMakePresets.json).")
+    endif()
+endif()
+
+function(godot_cpp_config_guard)
+    foreach(target IN LISTS ARGN)
+        if(NOT TARGET ${target})
+            message(FATAL_ERROR "godot_cpp_config_guard(): '${target}' is not a target.")
+        endif()
+        add_custom_command(TARGET ${target} PRE_BUILD
+            COMMAND "${CMAKE_COMMAND}"
+                "-DGODOTCPP_TARGET=${GODOTCPP_TARGET}"
+                "-DBUILD_CONFIG=$<CONFIG>"
+                "-DTARGET_NAME=${target}"
+                -P "${_GODOT_CPP_ASSERT_SCRIPT}"
+            COMMENT "Checking ${target} configuration against GODOTCPP_TARGET=${GODOTCPP_TARGET}"
+            VERBATIM)
+    endforeach()
+endfunction()

--- a/docs/gdk/editor-tools.md
+++ b/docs/gdk/editor-tools.md
@@ -125,8 +125,9 @@ launch with *"GDExtension dynamic library not found"* are now hard errors:
   `godot_gdk.windows.release.x86_64.dll`; a **debug** export stages the debug
   DLL. `cmake --build build --preset debug` (the default) only produces the
   debug DLL, so a release export after a debug-only build would stage zero
-  GDExtension DLLs. The exporter now aborts with the exact build command
-  (`cmake --build build --preset release`) instead of shipping a DLL-less
+  GDExtension DLLs. The exporter now aborts with the exact build commands
+  (`cmake --preset default-release` then `cmake --build --preset release`)
+  instead of shipping a DLL-less
   package. In the export dialog, **Export With Debug** unchecked selects release.
 
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -570,15 +570,20 @@ produces an addons zip):
 For local development builds:
 
 ```powershell
-# Configure all addons
+# Configure the debug build tree
 cmake --preset default
+cmake --build --preset debug
 
-# Build debug
-cmake --build build --preset debug
-
-# Build release
-cmake --build build --preset release
+# Release needs its own configure and its own build tree
+cmake --preset default-release
+cmake --build --preset release
 ```
+
+> **Debug and Release are separate build trees.** godot-cpp's `GODOTCPP_TARGET`
+> is a configure-time cache variable, so `build/` only ever produces correct
+> Debug binaries and `build/release/` only ever produces correct Release
+> binaries. `cmake --build build --config Release` fails on purpose. See
+> [Release build linked the debug godot-cpp](troubleshooting.md#release-build-linked-the-debug-godot-cpp).
 
 The build:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,67 @@
 
 Common build and runtime issues for the XBOX Godot Sample addons.
 
+## Release build linked the debug godot-cpp
+
+**Symptom:**
+
+A release Godot export loads the addons successfully, runs, and then dies on
+shutdown with `STATUS_HEAP_CORRUPTION` (`0xC0000374`). The debug export of the
+same project is fine. Or the build simply fails with a
+`godot-cpp configuration mismatch` error from CMake.
+
+**Cause:** godot-cpp's `GODOTCPP_TARGET` is a **configure-time cache string**
+(default `template_debug`). It is not tied to `$<CONFIG>`. It drives godot-cpp's
+`DEBUG_FEATURES`, which declares `DEBUG_ENABLED` and `HOT_RELOAD_ENABLED` as
+**PUBLIC** compile definitions — so they propagate into every addon DLL that
+links godot-cpp.
+
+Every preset here uses the multi-config `Visual Studio 17 2022` generator, where
+a single configure serves both configurations. So a `--config Release` build in
+a `template_debug` binary directory produces a *release-named* DLL that links
+the *debug* godot-cpp and carries debug-only ABI. It loads without complaint and
+corrupts the heap later.
+
+**Fix:** Use one binary directory per godot-cpp target. Each configure preset
+has a `-release` sibling with its own `binaryDir`:
+
+| Debug configure preset | Release configure preset | Release binary dir |
+| --- | --- | --- |
+| `default` | `default-release` | `build/release` |
+| `gdk-only` | `gdk-only-release` | `build/gdk-only-release` |
+| `playfab-only` | `playfab-only-release` | `build/playfab-only-release` |
+| `gameinput-only` | `gameinput-only-release` | `build/gameinput-only-release` |
+| `addon-package` | `addon-package-release` | `build/addon-package-release` |
+| `installed-gdk` | `installed-gdk-release` | `build/installed-gdk-release` |
+
+```powershell
+# Debug
+cmake --preset default
+cmake --build --preset debug
+
+# Release
+cmake --preset default-release
+cmake --build --preset release
+```
+
+Do **not** run `cmake --build build --config Release`. A build-time guard
+(`cmake/AssertGodotCppConfig.cmake`) now fails that invocation with an
+explanatory error instead of producing a broken binary.
+
+**Verifying a release DLL:**
+
+```powershell
+Select-String build\release\CMakeCache.txt -Pattern '^GODOTCPP_TARGET:'
+# GODOTCPP_TARGET:STRING=template_release
+
+Get-Item addons\godot_gdk\bin\godot_gdk.windows.release.x86_64.dll |
+    Select-Object Name, @{n='MB';e={[math]::Round($_.Length/1MB,2)}}
+# ~2.5 MB is correct. ~4.7 MB means it linked the debug godot-cpp.
+```
+
+`tools\package_addons.ps1` configures and builds each configuration in its own
+binary directory, so it is the safest way to produce distributable binaries.
+
 ## DLL load failure: Error 126
 
 **Symptom:**
@@ -34,9 +95,11 @@ godot_gdk.windows.debug.x86_64.dll
   running the sample. The Godot editor always loads the `debug` variant of the
   extension.
 - **Use a Release build** if Visual Studio cannot be installed. Release builds
-  use redistributable CRT DLLs (`MSVCP140.dll`) that are widely available:
+  use redistributable CRT DLLs (`MSVCP140.dll`) that are widely available.
+  Release has its own configure preset and build tree:
   ```powershell
-  cmake --build build --config Release
+  cmake --preset default-release
+  cmake --build --preset release
   ```
 
 ## GDExtension dynamic library not found (packaged / exported build)
@@ -68,7 +131,8 @@ line, an entry matched but the file is missing.
   export dialog, leaving **Export With Debug** unchecked selects *release*.
   Build the release native addon first, then re-export:
   ```powershell
-  cmake --build build --preset release
+  cmake --preset default-release
+  cmake --build --preset release
   ```
   The GDK exporter now aborts with this exact guidance instead of silently
   shipping a package that contains no GDExtension DLL.
@@ -299,8 +363,9 @@ the `editor` feature tag and use plain `XGameRuntimeInitialize()` in every
 exported build.
 
 **Fix:** Rebuild the addons so the packaged build carries the editor-gated
-runtime (`cmake --build build --preset release`), then re-export and re-package.
-A packaged build should never take the `WithOptions` path.
+runtime (`cmake --preset default-release` then `cmake --build --preset
+release`), then re-export and re-package. A packaged build should never take
+the `WithOptions` path.
 
 ## Packaged build doesn't launch like a retail install (`wdapp install /bootstrapper`)
 

--- a/tests/godot/gdk/tests/test_export_platform_errors.gd
+++ b/tests/godot/gdk/tests/test_export_platform_errors.gd
@@ -335,13 +335,17 @@ func test_missing_main_dll_message_is_actionable() -> void:
 	assert_string_contains(msg, "release", "message names the failing config")
 	assert_string_contains(msg, "GDExtension dynamic library not found",
 		"message ties the failure to the runtime symptom")
-	assert_string_contains(msg, "cmake --build build --preset release",
+	assert_string_contains(msg, "cmake --preset default-release",
+		"message names the release configure preset")
+	assert_string_contains(msg, "cmake --build --preset release",
 		"message gives the exact build command to fix a release export")
 
 
 func test_missing_main_dll_message_debug_variant() -> void:
 	var msg: String = ExportPlatform._missing_main_dll_message("debug")
-	assert_string_contains(msg, "cmake --build build --preset debug",
+	assert_string_contains(msg, "cmake --preset default",
+		"debug variant names the debug configure preset")
+	assert_string_contains(msg, "cmake --build --preset debug",
 		"debug variant names the debug build preset")
 
 

--- a/tools/build_addons.ps1
+++ b/tools/build_addons.ps1
@@ -69,14 +69,17 @@ Set-StrictMode -Version Latest
 
 $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 
-# Configure preset -> (build-preset prefix, binary dir relative to repo root).
-# Mirrors CMakePresets.json. Update both files together if presets change.
+# Configure preset -> (build-preset prefix, per-configuration configure presets and
+# binary dirs relative to repo root). godot-cpp's GODOTCPP_TARGET is a
+# configure-time cache variable, so Debug and Release each need their own
+# configure preset and binary directory. Mirrors CMakePresets.json - update both
+# files together if presets change.
 $script:PresetMap = @{
-    'default'        = @{ BuildPrefix = '';            BinaryDir = 'build' }
-    'gdk-only'       = @{ BuildPrefix = '-gdk';        BinaryDir = 'build/gdk-only' }
-    'playfab-only'   = @{ BuildPrefix = '-playfab';    BinaryDir = 'build/playfab-only' }
-    'gameinput-only' = @{ BuildPrefix = '-gameinput';  BinaryDir = 'build/gameinput-only' }
-    'addon-package'  = @{ BuildPrefix = '-addon-package'; BinaryDir = 'build/addon-package' }
+    'default'        = @{ BuildPrefix = '';               Debug = @{ ConfigurePreset = 'default';                BinaryDir = 'build' };                Release = @{ ConfigurePreset = 'default-release';        BinaryDir = 'build/release' } }
+    'gdk-only'       = @{ BuildPrefix = '-gdk';           Debug = @{ ConfigurePreset = 'gdk-only';               BinaryDir = 'build/gdk-only' };       Release = @{ ConfigurePreset = 'gdk-only-release';       BinaryDir = 'build/gdk-only-release' } }
+    'playfab-only'   = @{ BuildPrefix = '-playfab';       Debug = @{ ConfigurePreset = 'playfab-only';           BinaryDir = 'build/playfab-only' };   Release = @{ ConfigurePreset = 'playfab-only-release';   BinaryDir = 'build/playfab-only-release' } }
+    'gameinput-only' = @{ BuildPrefix = '-gameinput';     Debug = @{ ConfigurePreset = 'gameinput-only';         BinaryDir = 'build/gameinput-only' }; Release = @{ ConfigurePreset = 'gameinput-only-release'; BinaryDir = 'build/gameinput-only-release' } }
+    'addon-package'  = @{ BuildPrefix = '-addon-package'; Debug = @{ ConfigurePreset = 'addon-package';          BinaryDir = 'build/addon-package' };  Release = @{ ConfigurePreset = 'addon-package-release';  BinaryDir = 'build/addon-package-release' } }
 }
 
 function Invoke-Cmake {
@@ -95,10 +98,12 @@ function Invoke-Cmake {
 }
 
 $entry = $script:PresetMap[$Preset]
-$binaryDirAbs = Join-Path $script:RepoRoot $entry.BinaryDir
+$configEntry = $entry[$Configuration]
+$configurePreset = $configEntry.ConfigurePreset
+$binaryDirAbs = Join-Path $script:RepoRoot $configEntry.BinaryDir
 $buildPreset  = $Configuration.ToLowerInvariant() + $entry.BuildPrefix
 
-Write-Host "build_addons.ps1: Preset=$Preset Configuration=$Configuration BuildPreset=$buildPreset BinaryDir=$($entry.BinaryDir)"
+Write-Host "build_addons.ps1: Preset=$Preset Configuration=$Configuration ConfigurePreset=$configurePreset BuildPreset=$buildPreset BinaryDir=$($configEntry.BinaryDir)"
 
 if ($Clean -and (Test-Path $binaryDirAbs)) {
     Write-Host "  Cleaning $binaryDirAbs"
@@ -109,10 +114,10 @@ $cacheFile = Join-Path $binaryDirAbs 'CMakeCache.txt'
 $needConfigure = $Clean.IsPresent -or $Reconfigure.IsPresent -or -not (Test-Path $cacheFile)
 
 if ($needConfigure) {
-    Write-Host "  Configuring (cmake --preset $Preset)"
-    Invoke-Cmake @('--preset', $Preset)
+    Write-Host "  Configuring (cmake --preset $configurePreset)"
+    Invoke-Cmake @('--preset', $configurePreset)
 } else {
-    Write-Host "  Reusing existing $($entry.BinaryDir) (use -Reconfigure to force)"
+    Write-Host "  Reusing existing $($configEntry.BinaryDir) (use -Reconfigure to force)"
 }
 
 Write-Host "  Building (cmake --build --preset $buildPreset)"

--- a/tools/package_addons.ps1
+++ b/tools/package_addons.ps1
@@ -3,10 +3,16 @@
     Build and zip the XBOX Godot Sample addons for drop-in use in a Godot project.
 
 .DESCRIPTION
-    Configures the package-specific CMake preset, builds the requested native
-    addon configurations, stages only the files a game project should receive,
-    then writes a zip whose root contains an `addons\` directory and a
-    `GETTING_STARTED.md` quickstart for the recipient.
+    Configures the package-specific CMake preset for each requested
+    configuration, builds the native addons, stages only the files a game
+    project should receive, then writes a zip whose root contains an `addons\`
+    directory and a `GETTING_STARTED.md` quickstart for the recipient.
+
+    Debug and Release are configured into separate binary directories
+    (`build\addon-package` and `build\addon-package-release`) because
+    godot-cpp's `GODOTCPP_TARGET` is a configure-time cache variable. A shared
+    binary directory would link the debug godot-cpp into the Release DLLs,
+    which load fine and then corrupt the heap at runtime.
 
     The default `Both` configuration includes Debug and Release GDExtension
     DLLs because the addon's .gdextension manifests declare both library paths.
@@ -25,12 +31,14 @@
     default to keep the drop-in zip small.
 
 .PARAMETER Clean
-    Remove `build\addon-package` before configuring and building. The staging
-    directory is always cleared before packaging.
+    Remove each selected configuration's package build directory
+    (`build\addon-package` and/or `build\addon-package-release`) before
+    configuring and building. The staging directory is always cleared before
+    packaging.
 
 .PARAMETER Reconfigure
-    Force `cmake --preset addon-package` even when the package build directory
-    already has a CMake cache.
+    Force a fresh `cmake --preset` for each selected configuration even when
+    that configuration's build directory already has a CMake cache.
 
 .OUTPUTS
     Exits 0 on success; otherwise throws with the failing command or missing
@@ -62,14 +70,23 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
-$script:ConfigurePreset = 'addon-package'
-$script:BinaryDirRel = 'build\addon-package'
-$script:BinaryDir = Join-Path $script:RepoRoot $script:BinaryDirRel
 $script:DistDir = Join-Path $script:RepoRoot 'build\dist'
 $script:StageDir = Join-Path $script:DistDir 'godot-gdk-addons'
-$script:BuildPresets = @{
-    Debug = 'debug-addon-package'
-    Release = 'release-addon-package'
+
+# godot-cpp's GODOTCPP_TARGET is a configure-time cache variable, so each
+# configuration needs its own configure preset and binary directory. Sharing one
+# binary directory silently links the debug godot-cpp into Release DLLs.
+$script:BuildPlans = @{
+    Debug = @{
+        ConfigurePreset = 'addon-package'
+        BuildPreset     = 'debug-addon-package'
+        BinaryDirRel    = 'build\addon-package'
+    }
+    Release = @{
+        ConfigurePreset = 'addon-package-release'
+        BuildPreset     = 'release-addon-package'
+        BinaryDirRel    = 'build\addon-package-release'
+    }
 }
 
 $script:NativeAddons = @(
@@ -116,6 +133,30 @@ function Invoke-Cmake {
         }
     } finally {
         Pop-Location
+    }
+}
+
+# A reused binary directory must still match the configuration being built.
+# godot-cpp's GODOTCPP_TARGET is baked into the cache at configure time.
+function Assert-GodotCppTarget {
+    param(
+        [string]$CacheFile,
+        [string]$Configuration,
+        [string]$BinaryDirRel
+    )
+
+    $expected = if ($Configuration -eq 'Release') { 'template_release' } else { 'template_debug' }
+    $line = Select-String -LiteralPath $CacheFile -Pattern '^GODOTCPP_TARGET:STRING=(.*)$' | Select-Object -First 1
+    if (-not $line) {
+        throw "Could not read GODOTCPP_TARGET from $CacheFile. Re-run with -Reconfigure."
+    }
+
+    $actual = $line.Matches[0].Groups[1].Value.Trim()
+    if ($actual -ne $expected) {
+        throw ("Binary directory '$BinaryDirRel' was configured with GODOTCPP_TARGET=$actual " +
+               "but the $Configuration package requires $expected. Building here would link the " +
+               "wrong godot-cpp and produce a DLL that corrupts the heap at runtime. " +
+               "Re-run with -Reconfigure (or -Clean).")
     }
 }
 
@@ -307,26 +348,31 @@ if ($outputFullPath.StartsWith($stagePrefix, [System.StringComparison]::OrdinalI
     throw "OutputPath must not be inside the staging directory: $stageFullPath"
 }
 
-Write-Host "package_addons.ps1: Configuration=$Configuration Preset=$($script:ConfigurePreset) Output=$outputFullPath"
-
-if ($Clean.IsPresent -and (Test-Path -LiteralPath $script:BinaryDir)) {
-    Write-Host "  Cleaning $($script:BinaryDirRel)"
-    Remove-Item -LiteralPath $script:BinaryDir -Recurse -Force
-}
-
-$cacheFile = Join-Path $script:BinaryDir 'CMakeCache.txt'
-$needConfigure = $Clean.IsPresent -or $Reconfigure.IsPresent -or -not (Test-Path -LiteralPath $cacheFile -PathType Leaf)
-if ($needConfigure) {
-    Write-Host "  Configuring (cmake --preset $($script:ConfigurePreset))"
-    Invoke-Cmake @('--preset', $script:ConfigurePreset)
-} else {
-    Write-Host "  Reusing existing $($script:BinaryDirRel) (use -Reconfigure to force)"
-}
+Write-Host "package_addons.ps1: Configuration=$Configuration Output=$outputFullPath"
 
 foreach ($config in $script:SelectedConfigurations) {
-    $buildPreset = $script:BuildPresets[$config]
-    Write-Host "  Building (cmake --build --preset $buildPreset)"
-    Invoke-Cmake @('--build', '--preset', $buildPreset)
+    $plan = $script:BuildPlans[$config]
+    $binaryDir = Join-Path $script:RepoRoot $plan.BinaryDirRel
+
+    Write-Host "  [$config] ConfigurePreset=$($plan.ConfigurePreset) BinaryDir=$($plan.BinaryDirRel)"
+
+    if ($Clean.IsPresent -and (Test-Path -LiteralPath $binaryDir)) {
+        Write-Host "    Cleaning $($plan.BinaryDirRel)"
+        Remove-Item -LiteralPath $binaryDir -Recurse -Force
+    }
+
+    $cacheFile = Join-Path $binaryDir 'CMakeCache.txt'
+    $needConfigure = $Clean.IsPresent -or $Reconfigure.IsPresent -or -not (Test-Path -LiteralPath $cacheFile -PathType Leaf)
+    if ($needConfigure) {
+        Write-Host "    Configuring (cmake --preset $($plan.ConfigurePreset))"
+        Invoke-Cmake @('--preset', $plan.ConfigurePreset)
+    } else {
+        Assert-GodotCppTarget -CacheFile $cacheFile -Configuration $config -BinaryDirRel $plan.BinaryDirRel
+        Write-Host "    Reusing existing $($plan.BinaryDirRel) (use -Reconfigure to force)"
+    }
+
+    Write-Host "    Building (cmake --build --preset $($plan.BuildPreset))"
+    Invoke-Cmake @('--build', '--preset', $plan.BuildPreset)
 }
 
 if (Test-Path -LiteralPath $script:StageDir) {


### PR DESCRIPTION
## Symptom

`cmake --build <dir> --config Release` produced addon DLLs that load successfully and then
corrupt the heap when a **release** build of Godot uses them. A Godot release export built
against them died on shutdown with `STATUS_HEAP_CORRUPTION` (`0xC0000374`). The debug export
was fine, so the failure only appeared in the configuration that ships and gets cert-tested.

## Root cause

`godot-cpp/cmake/godotcpp.cmake:319`:

```cmake
set(DEBUG_FEATURES "$<NOT:$<STREQUAL:${GODOTCPP_TARGET},template_release>>")
```

`GODOTCPP_TARGET` is a **configure-time cache string defaulting to `template_debug`**
(`godotcpp.cmake:109-114`). It is not tied to `$<CONFIG>`. `DEBUG_FEATURES` drives
`DEBUG_ENABLED` and `HOT_RELOAD_ENABLED`, declared **PUBLIC** in
`common_compiler_flags.cmake:162,166`, so they propagate to every addon target that links
godot-cpp.

Every preset uses the multi-config `Visual Studio 17 2022` generator, where one configure
serves both configurations. So `--config Release` still got `template_debug` godot-cpp plus
`DEBUG_ENABLED` and `HOT_RELOAD_ENABLED` compiled into the release DLL, silently.

This affected every debug/release build-preset pair that shared a configure preset, including
`tools/package_addons.ps1` — so **the release DLLs in the published drop-in zip were
mis-linked**.

`godot-cpp/` is a submodule and was not touched.

## What changed

### 1. One binary directory per godot-cpp target

Each configure preset now has a `-release` sibling with its own `binaryDir` and
`GODOTCPP_TARGET=template_release`. `GODOTCPP_TARGET=template_debug` is pinned explicitly on
the hidden `_base` preset.

| Debug configure preset | Release configure preset | Release binary dir |
| --- | --- | --- |
| `default` | `default-release` | `build/release` |
| `gdk-only` | `gdk-only-release` | `build/gdk-only-release` |
| `playfab-only` | `playfab-only-release` | `build/playfab-only-release` |
| `gameinput-only` | `gameinput-only-release` | `build/gameinput-only-release` |
| `addon-package` | `addon-package-release` | `build/addon-package-release` |
| `installed-gdk` | `installed-gdk-release` | `build/installed-gdk-release` |

All six release build presets were repointed at the matching configure preset.

I kept the existing preset names as the **debug** ones rather than renaming everything into
`*-debug`/`*-release` pairs. `cmake --preset default` appears in ~15 docs, sample READMEs, CI
actions and tooling; renaming would have been churn with no safety benefit, since the debug
half was already correct.

### 2. A hard guard so this cannot regress silently

`cmake/AssertGodotCppConfig.cmake` (a `cmake -P` script) plus `cmake/GodotCppConfigGuard.cmake`
attach a `PRE_BUILD` check to `godot_gdk`, `godot_playfab` and `godot_gameinput`, and a
configure-time check for single-config generators.

```
$ cmake --build build --config Release --target godot_gameinput

CMake Error: godot-cpp configuration mismatch while building 'godot_gameinput'.
  This binary directory was configured with GODOTCPP_TARGET=template_debug, which only
  supports building: Debug. You asked to build: Release.
  Building 'Release' here would link godot-cpp's template_debug library and compile
  DEBUG_ENABLED / HOT_RELOAD_ENABLED into the output. The resulting DLL loads successfully
  and then corrupts the heap (STATUS_HEAP_CORRUPTION, 0xC0000374) ...
      cmake --preset default-release
      cmake --build --preset release
```

### 3. `tools/package_addons.ps1` builds each configuration in its own tree

Debug goes to `build/addon-package`, Release to `build/addon-package-release`. A reused cache
is re-validated against the expected `GODOTCPP_TARGET` before building. `RequiredRuntimeDlls`
staging and the documented `Thunks.Debug.dll` requirement are unchanged.

`tools/build_addons.ps1 -Configuration Release` likewise selects the `-release` configure
preset and its own binary directory.

### 4. Docs

New troubleshooting section **"Release build linked the debug godot-cpp"**, and the
`cmake --build build --config Release` recommendation in `docs/troubleshooting.md` (the exact
broken invocation) is replaced. `docs/getting-started.md`, `docs/gdk/editor-tools.md` and
`.github/copilot-instructions.md` now show the two-step release flow.

The GDK exporter's missing-main-DLL error (`gdk_export_platform.gd`) also printed the old
single-tree command; it now prints the configure step too, with its tests updated.

## Usage

```powershell
# Debug (unchanged)
cmake --preset default
cmake --build --preset debug

# Release (new configure step, new build tree)
cmake --preset default-release
cmake --build --preset release
```

`tools\package_addons.ps1` is unchanged from the caller's side and remains the safest way to
produce distributable binaries.

## Verification — by export, not inspection

The acceptance bar was a real release export, because the mis-linked DLL loads fine and only
corrupts the heap later. `tutorial_integrated` was exported as release and run headless with
`--headless --quit-after 300`, swapping **only** the `godot_gdk` DLL between runs:

| `godot_gdk.windows.release.x86_64.dll` linked against | Exit code |
| --- | --- |
| `libgodot-cpp.windows.template_release.x86_64.lib` (this PR) | `0` — clean shutdown |
| `libgodot-cpp.windows.template_debug.x86_64.lib` (the bug) | `0xC0000374` STATUS_HEAP_CORRUPTION |

Both runs loaded the extension successfully and printed identical logs
(`[GDK] Runtime initialized`, `[GDK] Bootstrap: GDK.initialize() succeeded.`, user sign-in) —
confirming that load success and symbol inspection are not sufficient signals.

Other checks:

- `build/release/CMakeCache.txt` → `GODOTCPP_TARGET:STRING=template_release`
- `godot_gdk.windows.release.x86_64.dll` is **2.50 MB** (mis-linked was ~4.7 MB per the report)
- `build/release/addons/godot_gdk/godot_gdk.vcxproj` links
  `libgodot-cpp.windows.template_release.x86_64.lib` and contains **no** `DEBUG_ENABLED` /
  `HOT_RELOAD_ENABLED` (the old `build/` tree contains both in all four config sections)
- `cmake --build build --config Release` now fails with the guard's message
- `package_addons.ps1 -Configuration Both` → zip whose debug and release DLLs each link the
  matching godot-cpp; both caches verified
- `build_addons.ps1 -Preset gameinput-only -Configuration Release` selects
  `gameinput-only-release` / `build/gameinput-only-release`
- Programmatic audit of `CMakePresets.json`: all 14 build presets agree with their configure
  preset's resolved `GODOTCPP_TARGET`

### Local validation

- `tools\check_gd_scripts_headless.ps1` — passed
- `tools\run_all_tests.ps1` — **pass**; 474 GUT tests (gdk 330 / playfab 84 / gameinput 60),
  0 failed; C++ doctest OK; 13 bootstrap runners OK
- `tools\run_csharp_tests.ps1` — 107/107 facade parity
- **Live coverage: skipped** (default, no `-Live`). No live-service or online-write behaviour
  is touched by this change.

## Open question for reviewers

The report raised whether `package_addons.ps1` should become the *only* supported way to
produce distributable binaries. Because `addons/*/bin/*` is gitignored, downstream syncs pick
up whatever the working copy last built, so a stale or mis-linked release DLL can still
propagate. This PR makes a mis-linked DLL impossible to produce accidentally, but does not
address staleness. Happy to follow up if you want that enforced.
