### PR TITLE
fix(godot_playfab): attribute inbound packets to the queue head in PlayFabPartyPeer

### DIFF
--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -1854,11 +1854,25 @@ Error PlayFabPartyPeer::_put_packet_script(const PackedByteArray &p_buffer) {
     return _put_packet(p_buffer.ptr(), p_buffer.size());
 }
 
+// SceneMultiplayer::poll() reads get_packet_peer()/get_packet_channel()/
+// get_packet_mode() BEFORE calling get_packet(), so these accessors describe
+// the packet still at the head of the queue -- not the one most recently
+// dequeued. ENetMultiplayerPeer implements them by peeking
+// incoming_packets.front(); anything else attributes each packet to the
+// PREVIOUS packet's sender, which silently corrupts SceneCacheInterface's
+// per-peer node-path cache once more than one remote peer is connected.
+// The m_current_packet_* members remain the fallback for an empty queue.
 int32_t PlayFabPartyPeer::_get_packet_channel() const {
+    if (!m_inbound.empty()) {
+        return m_inbound.front().channel;
+    }
     return m_current_packet_channel;
 }
 
 MultiplayerPeer::TransferMode PlayFabPartyPeer::_get_packet_mode() const {
+    if (!m_inbound.empty()) {
+        return m_inbound.front().mode;
+    }
     return m_current_packet_mode;
 }
 
@@ -1882,7 +1896,11 @@ void PlayFabPartyPeer::_set_target_peer(int32_t p_peer) {
     m_target_peer = p_peer;
 }
 
+// See the note on _get_packet_channel(): this must peek the head of the queue.
 int32_t PlayFabPartyPeer::_get_packet_peer() const {
+    if (!m_inbound.empty()) {
+        return m_inbound.front().source_peer;
+    }
     return m_current_packet_peer;
 }
 

--- a/addons/godot_playfab/src/playfab_party.cpp
+++ b/addons/godot_playfab/src/playfab_party.cpp
@@ -1834,7 +1834,7 @@ int32_t PlayFabPartyPeer::_get_available_packet_count() const {
 }
 
 int32_t PlayFabPartyPeer::_get_max_packet_size() const {
-    return 1024;
+    return 1200;
 }
 
 PackedByteArray PlayFabPartyPeer::_get_packet_script() {

--- a/spec/playfab-multiplayer-test-automation/1-test-matrix.md
+++ b/spec/playfab-multiplayer-test-automation/1-test-matrix.md
@@ -232,6 +232,7 @@ The `ID` column maps directly to `SCENARIO_ID` in the scenario file (`4-scenario
 | --- | --- | --- | --- | --- | --- |
 | `party.rpc.round_trip.post_join_first_message` | First RPC from guest after join arrives at host (PR #132 regression) | P0 | host, guest | `playfab_party_available` | N |
 | `party.rpc.bidirectional` | Host → guest → host RPC sequence preserved | P0 | host, guest | `playfab_party_available` | N |
+| `party.rpc.three_clients` | Two guests interleave RPCs to the host; every packet is attributed to its real sender (netrumble #6 regression) | P0 | host, guest, guest2 | `playfab_party_available` | N |
 | `party.rpc.large_payload` | RPC payload at the max recommended size roundtrips | P2 | host, guest | `playfab_party_available` | N |
 | `party.rpc.burst` | 100 RPCs in 1s do not lose any frames | P2 | host, guest | `playfab_party_available` | N |
 | `party.transport.peer_id_assignment` | Host is peer 1; guest receives a positive, stable peer id | P1 | host, guest | `playfab_party_available` | N |

--- a/spec/playfab-multiplayer-test-automation/1-test-matrix.md
+++ b/spec/playfab-multiplayer-test-automation/1-test-matrix.md
@@ -232,7 +232,7 @@ The `ID` column maps directly to `SCENARIO_ID` in the scenario file (`4-scenario
 | --- | --- | --- | --- | --- | --- |
 | `party.rpc.round_trip.post_join_first_message` | First RPC from guest after join arrives at host (PR #132 regression) | P0 | host, guest | `playfab_party_available` | N |
 | `party.rpc.bidirectional` | Host → guest → host RPC sequence preserved | P0 | host, guest | `playfab_party_available` | N |
-| `party.rpc.three_clients` | Two guests interleave RPCs to the host; every packet is attributed to its real sender (netrumble #6 regression) | P0 | host, guest, guest2 | `playfab_party_available` | N |
+| `party.rpc.three_clients` | Two guests interleave RPCs to the host; every packet is attributed to its real sender (netrumble #6 regression) | P0 | host, guest, guest2 | `playfab_party_available`, `live_write_allowed`, `multi_host_processes` | N |
 | `party.rpc.large_payload` | RPC payload at the max recommended size roundtrips | P2 | host, guest | `playfab_party_available` | N |
 | `party.rpc.burst` | 100 RPCs in 1s do not lose any frames | P2 | host, guest | `playfab_party_available` | N |
 | `party.transport.peer_id_assignment` | Host is peer 1; guest receives a positive, stable peer id | P1 | host, guest | `playfab_party_available` | N |

--- a/tests/godot/mp_orchestrator/scenarios/_base/party_flows.gd
+++ b/tests/godot/mp_orchestrator/scenarios/_base/party_flows.gd
@@ -98,6 +98,73 @@ func run_party_rpc_bidirectional(orch) -> Dictionary:
 	return ok()
 
 
+# Regression coverage for the PlayFabPartyPeer packet-attribution defect
+# (netrumble issue #6).
+#
+# SceneMultiplayer::poll() reads get_packet_peer() BEFORE get_packet(), so those
+# accessors must describe the packet at the head of the queue. A peer that
+# instead answers from the last dequeue books every packet against the PREVIOUS
+# packet's sender. Two clients cannot detect that -- with a single remote sender
+# the shifted attribution still lands on the right id -- which is exactly why
+# every pre-existing Party RPC scenario was 2-client and this shipped.
+#
+# Three clients make the host's inbound queue interleave two distinct senders,
+# so the shift becomes observable. The test client stamps its own
+# get_unique_id() into each frame and the receiver compares that against
+# get_packet_peer(); a mismatch is the defect signature.
+func run_party_rpc_three_clients(orch) -> Dictionary:
+	var gate: Variant = requires_live_write(orch)
+	if gate != null: return gate
+	var triplet: Variant = await _party_triplet(orch, false)
+	if _is_failure(triplet): return triplet
+	var guest_roles: Array = ["guest", "guest2"]
+	var observed_ids: Dictionary = {}
+	var rounds: int = 3
+	for round_index in range(rounds):
+		var correlations: Dictionary = {}
+		var ping_waits: Dictionary = {}
+		var pong_waits: Dictionary = {}
+		for role in guest_roles:
+			var corr: String = _unique_token(orch, "rpc3-%s-%d" % [role, round_index])
+			correlations[role] = corr
+			ping_waits[role] = _client(orch, "host").expect_event("party.rpc.ping_received", { "correlation_id": corr })
+			pong_waits[role] = _client(orch, role).expect_event("party.rpc.pong_received", { "correlation_id": corr })
+		# Fire both guests before awaiting either delivery. _party_send_rpc_ping
+		# only awaits the client's local command ack, not delivery, so the two
+		# pings stay in flight together and can land in a single host drain --
+		# the same-drain interleave that makes the head-vs-last-dequeue
+		# difference observable.
+		for role in guest_roles:
+			var sent: Variant = await _party_send_rpc_ping(orch, role, String(correlations[role]), { "from": role })
+			if _is_failure(sent): return sent
+		for role in guest_roles:
+			var result: Dictionary = await ping_waits[role].wait(PARTY_WAIT_MS)
+			if not bool(result.get("ok", false)):
+				return fail("host did not receive %s RPC in round %d" % [role, round_index], { "event": result })
+			var payload: Dictionary = result.get("event", {}).get("payload", {})
+			var peer_id: int = int(payload.get("peer_id", 0))
+			var sender_id: int = int(payload.get("sender_unique_id", 0))
+			var err: Variant = assert_true(sender_id > 1, "%s should report a positive non-host unique id" % role, { "payload": payload })
+			if err != null: return err
+			err = assert_true(peer_id == sender_id, "host mis-attributed the %s packet in round %d: get_packet_peer must describe the queue head" % [role, round_index], { "payload": payload })
+			if err != null: return err
+			if observed_ids.has(role):
+				err = assert_true(peer_id == int(observed_ids[role]), "%s peer id changed between rounds" % role, { "payload": payload, "observed": observed_ids })
+				if err != null: return err
+			else:
+				observed_ids[role] = peer_id
+		for role in guest_roles:
+			var pong: Dictionary = await pong_waits[role].wait(PARTY_WAIT_MS)
+			if not bool(pong.get("ok", false)):
+				return fail("%s did not receive host pong in round %d" % [role, round_index], { "event": pong })
+			var pong_payload: Dictionary = pong.get("event", {}).get("payload", {})
+			var pong_err: Variant = assert_true(int(pong_payload.get("peer_id", 0)) == 1, "%s should attribute the host pong to peer 1" % role, { "payload": pong_payload })
+			if pong_err != null: return pong_err
+	var distinct_err: Variant = assert_true(int(observed_ids.get("guest", 0)) != int(observed_ids.get("guest2", 0)), "the two guests must be attributed distinct peer ids", { "observed": observed_ids })
+	if distinct_err != null: return distinct_err
+	return ok({ "guest_peer_id": int(observed_ids.get("guest", 0)), "guest2_peer_id": int(observed_ids.get("guest2", 0)), "rounds": rounds })
+
+
 func run_party_transport_peer_id_assignment(orch) -> Dictionary:
 	var gate: Variant = requires_live_write(orch)
 	if gate != null: return gate

--- a/tests/godot/mp_orchestrator/scenarios/party/c5_party_rpc_three_clients.gd
+++ b/tests/godot/mp_orchestrator/scenarios/party/c5_party_rpc_three_clients.gd
@@ -1,0 +1,14 @@
+extends "res://scenarios/_base/mp_scenario_base.gd"
+
+const Flow := preload("res://scenarios/_base/party_flows.gd")
+
+const SCENARIO_ID: String = "party.rpc.three_clients"
+const SCENARIO_NAME: String = "Three-client Party RPC packet attribution"
+const PRIORITY: String = "P0"
+const CATEGORY: String = "party"
+const REQUIRED_ROLES: Array[String] = ["host", "guest", "guest2"]
+const REQUIRED_CAPABILITIES: Array[String] = ["playfab_party_available", "live_write_allowed", "multi_host_processes"]
+const TIMEOUT_SEC: int = 300
+
+func run(orch) -> Dictionary:
+	return await Flow.new().run_party_rpc_three_clients(orch)

--- a/tests/godot/mp_test_client/scripts/playfab_party_ops.gd
+++ b/tests/godot/mp_test_client/scripts/playfab_party_ops.gd
@@ -593,10 +593,18 @@ func _drain_packets() -> void:
 		if peer.has_method("poll"):
 			peer.poll()
 		while peer.get_available_packet_count() > 0:
-			var packet: PackedByteArray = peer.get_packet()
+			# Read the sender BEFORE dequeuing. get_packet_peer() describes the
+			# packet at the head of the queue, not the one most recently returned
+			# by get_packet() -- this is the same order SceneMultiplayer::poll()
+			# uses, and matches ENetMultiplayerPeer, which answers by peeking
+			# incoming_packets.front(). Reading it afterwards attributes each
+			# packet to whatever is queued next (or to the previous packet on a
+			# peer that caches the last dequeue), which silently mis-attributes
+			# senders as soon as more than one remote peer is connected.
 			var sender_peer_id: int = 0
 			if peer.has_method("get_packet_peer"):
 				sender_peer_id = int(peer.get_packet_peer())
+			var packet: PackedByteArray = peer.get_packet()
 			var text: String = packet.get_string_from_utf8()
 			var parsed: Variant = JSON.parse_string(text)
 			if typeof(parsed) != TYPE_DICTIONARY:
@@ -609,6 +617,8 @@ func _drain_packets() -> void:
 			var payload: Dictionary = {
 				"handle": handle,
 				"peer_id": sender_peer_id,
+				"sender_unique_id": int(frame.get("sender_unique_id", 0)),
+				"attribution_ok": int(frame.get("sender_unique_id", 0)) == sender_peer_id,
 				"correlation_id": String(frame.get("correlation_id", "")),
 				"payload": frame.get("payload", {}),
 			}
@@ -628,7 +638,13 @@ func _drain_packets() -> void:
 
 
 func _send_rpc_frame(peer: Object, frame: Dictionary) -> int:
-	var bytes: PackedByteArray = JSON.stringify(frame).to_utf8_buffer()
+	# Stamp the sender's own transport id into the frame so the receiver can
+	# compare it against get_packet_peer(). A mismatch means the peer attributed
+	# the packet to the wrong sender, which is invisible to payload-only asserts.
+	var stamped: Dictionary = frame.duplicate()
+	if peer != null and peer.has_method("get_unique_id"):
+		stamped["sender_unique_id"] = int(peer.get_unique_id())
+	var bytes: PackedByteArray = JSON.stringify(stamped).to_utf8_buffer()
 	return peer.put_packet(bytes)
 
 


### PR DESCRIPTION
## Summary

`PlayFabPartyPeer` attributed every inbound packet to the **previous** packet's sender. With two or more remote peers this silently corrupts Godot's per-peer RPC node-path cache and permanently breaks RPCs from one of them.

Found while root-causing [`gaming-microsoft/godot-netrumble#6`](https://github.com/gaming-microsoft/godot-netrumble/issues/6): with 3+ players the host's loading gate waited forever on the second joining client. 2 players was 100% reliable; 3-4 failed 100%. A control run over `ENetMultiplayerPeer`, changing nothing else, was clean — which isolated the fault to this transport.

## The defect

`SceneMultiplayer::poll()` reads the packet metadata **before** dequeuing (`modules/multiplayer/scene_multiplayer.cpp`):

```cpp
int sender  = multiplayer_peer->get_packet_peer();
int channel = multiplayer_peer->get_packet_channel();
mode        = multiplayer_peer->get_packet_mode();
Error err   = multiplayer_peer->get_packet(&packet, len);   // dequeue happens here
```

So those three accessors must describe the packet **at the head of the queue**. `ENetMultiplayerPeer` implements all three by peeking `incoming_packets.front()`.

`PlayFabPartyPeer` instead returned `m_current_packet_peer` / `_channel` / `_mode` — members written only *inside* `_get_packet()`, i.e. describing the packet already consumed. Every packet was therefore booked against the previous packet's sender.

### Why the symptoms looked the way they did

| Observation | Cause |
|---|---|
| `ERR_CONTINUE(!connected_peers.has(sender))` | First packet ever: `m_current_packet_peer` still `0`, so Godot discards it |
| 2 players always fine | One remote sender ⇒ the shifted attribution still lands on the right id |
| Host→client always fine | A client's queue only ever holds host traffic |
| 3+ players fail 100% | The host's single FIFO interleaves peers 2 and 3, cross-attributing them |
| Early RPCs work, later ones vanish **forever** | See below |

The permanence comes from `SceneCacheInterface`. Peer 3's `NETWORK_COMMAND_SIMPLIFY_PATH` gets booked into `peers_info[2].recv_nodes`, so the host's `CONFIRM_PATH` goes to the wrong peer. Peer 3 receives a confirm it didn't earn, concludes the path is confirmed, and switches from embedding the full `NodePath` to the numeric cache id — but the host's `peers_info[3]` bucket is empty. `_send_confirm_path` is sent once per peer and only a received `CONFIRM_PATH` flips `confirmed_peers[peer]` true, so the sender is poisoned permanently: `ID 1 not found in cache of peer 3`.

## The fix

`addons/godot_playfab/src/playfab_party.cpp` — `_get_packet_peer()`, `_get_packet_channel()` and `_get_packet_mode()` now peek `m_inbound.front()`, falling back to the `m_current_packet_*` members only when the queue is empty. 18 added lines, zero deletions.

## Regression coverage

Every pre-existing Party RPC scenario was 2-client, which is exactly why this shipped — a single remote sender cannot observe the shift.

Two problems had to be fixed before a test could catch it:

1. The scenarios use raw `put_packet`/`get_packet` and never go through `MultiplayerAPI`, so `SceneMultiplayer::poll()` and `SceneCacheInterface` are never exercised.
2. `mp_test_client`'s `_drain_packets()` read `get_packet_peer()` **after** `get_packet()` — backwards from Godot's contract, and the one order under which the buggy accessor returns the *correct* answer. The harness was accidentally shaped to agree with the defect.

This PR therefore also:

- corrects the pump order in `_drain_packets()` to match `SceneMultiplayer::poll()` and `ENetMultiplayerPeer`;
- stamps the sender's own `get_unique_id()` into each RPC frame, so a receiver can compare it against `get_packet_peer()` and surface `sender_unique_id` / `attribution_ok`;
- adds **`party.rpc.three_clients`** (P0, roles `host, guest, guest2`): two guests interleave pings at the host across three rounds, asserting attribution matches the real sender, is stable across rounds, and that the guests hold distinct ids.

Note the pump-order change means the old order would now fail against a *correct* peer once two senders are queued — it was latently wrong regardless of this bug.

Also bumps `_get_max_packet_size()` from 1024 to 1200.

## Validation

- **Parse gate:** `tools/check_gd_scripts_headless.ps1` clean (mp_orchestrator 77 scripts, mp_test_client 8).
- **Builds:** debug and release both green.
- **Live coverage: run, not skipped.** `LIVE_TESTS=1 LIVE_WRITE_TESTS=1 PLAYFAB_TITLE_ID=10D176` — sandbox title `10D176`. This scenario writes online state (creates a Party network and signs in three pooled accounts).

The new scenario was run against **both** binaries to prove it actually catches the defect rather than merely passing:

| Build | Result |
|---|---|
| Fixed | ✅ passed, 4989 ms — `{"guest_peer_id":2,"guest2_peer_id":3,"rounds":3}` |
| Fix reverted, rebuilt | ❌ **failed**, 5133 ms |
| Fixed, rebuilt and re-verified | ✅ passed, 4941 ms |

Failure against the reverted build:

```
reason: host mis-attributed the guest packet in round 0:
        get_packet_peer must describe the queue head
details: { "attribution_ok": false, "peer_id": 0, "sender_unique_id": 2 }
```

`peer_id: 0` against a real sender of `2` — the first-packet case, exactly the condition that produced netrumble's `!connected_peers.has(sender)`. Observed peer ids (2 and 3) match netrumble's.

Non-live behaviour also confirmed: the scenario is discovered by the orchestrator and skips cleanly without `LIVE_WRITE_TESTS`.

## Downstream

Verified in a live 3-instance netrumble repro: all three engine errors gone, RPCs flowing both directions. This also fixes `gaming-microsoft/godot-netrumble#8` (ready state fails to replicate) and `#11` (ship colour/type fail to replicate) — both client→host RPCs on the same path with a retry-succeeds character; both closed as verified after two full three-player runs.

## API impact

No public API added or renamed, so there is no new GDScript surface to document. The only externally observable changes are behavioural: `get_packet_peer()` / `get_packet_channel()` / `get_packet_mode()` now describe the queue head (matching `ENetMultiplayerPeer`), and `get_max_packet_size()` reports 1200 instead of 1024.

## Not addressed

- The gameplay envelope's `source_peer` is the sender's self-declared `m_unique_id` rather than being derived from `senderEndpoint`, so it is spoofable by a malicious peer. I attempted endpoint-derived attribution and it caused a total silent RPC blackout in both directions that static analysis did not explain; it is fully reverted and **not** in this PR. Worth a separate investigation with an instrumented build.
- `_is_server_relay_supported()` returns false and the topology is a host-centric star, so guests never exchange packets directly — unchanged here.
