### PR TITLE
Grant Gerardo Malpartida Vela write access to the repo

### DIFF
--- a/.github/acl/access.yml
+++ b/.github/acl/access.yml
@@ -16,3 +16,6 @@ configuration:
     role: Maintain
   - member: jameslen
     role: Maintain
+  # Write (Push) members
+  - member: GerardoMal-ATG
+    role: Push


### PR DESCRIPTION
Adds Gerardo Malpartida Vela (`GerardoMal-ATG`) to the ACL policy with `Push`.

He is joining the Middleware, Samples & Skills squad and is picking up the open bugs filed against this sample repo:

- #161 -- [Bug]: PlayFab tutorial never exits when run headless
- #178 -- [Bug]: GameInput stuck actions test file still fails to parse, so its six tests never run

`Push` is the least privilege that still lets him push fix branches and be assigned issues. The existing entries are all `Maintain`, so this adds the first write-tier entry.

Note that `GerardoMal-ATG` is his non-EMU account. The `gerardomal_microsoft` account used in the `gaming-microsoft` enterprise cannot be added to this organization, so the equivalent grant there (gaming-microsoft/GDST-Middleware#395) does not carry over.

### Validation

No `.gd`, C++, or build files are touched, so the parse gate and test orchestrator are not applicable to this change; this is a policy-only edit. The file was confirmed to parse as valid YAML and the new entry reads back with `role: Push`. The `GitOps/YmlSchemaValidation` check is the authoritative gate.