### PR TITLE
Raise Gerardo Malpartida Vela from Push to Maintain

### DIFF
--- a/.github/acl/access.yml
+++ b/.github/acl/access.yml
@@ -16,6 +16,5 @@ configuration:
     role: Maintain
   - member: jameslen
     role: Maintain
-  # Write (Push) members
   - member: GerardoMal-ATG
-    role: Push
+    role: Maintain


### PR DESCRIPTION
Follow-up to #180, which added Gerardo Malpartida Vela (`GerardoMal-ATG`) with `Push`.

This raises him to `Maintain`, matching every other entry in this ACL. #180 introduced the only `Push` entry in the file; folding him into the existing tier removes that one-off section and keeps the policy uniform.

He is picking up the open bugs filed against this repo (#161, #178) as part of the Middleware, Samples & Skills squad.

### Validation

No `.gd`, C++, or build files are touched, so the parse gate and test orchestrator are not applicable; this is a policy-only edit. The file was confirmed to parse as valid YAML, with 6 entries all resolving to `role: Maintain`. `GitOps/YmlSchemaValidation` is the authoritative gate.