### PR TITLE
Document XBOX Godot NetRumble as a sample pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This is the **first step** in our XBOX Godot Sample integration journey. We plan
 
 The addons are designed to be dropped into any Godot 4.5+ project. This repository is where the addons are authored, built, tested, and demonstrated through the tutorial sample projects under `sample/tutorial_gdk/`, `sample/tutorial_playfab/`, `sample/tutorial_integrated/`, and `sample/tutorial_gameinput/`. Build the addons from source per [Getting started](docs/getting-started.md), then drop the addon folders into your project.
 
+For a complete game built on these addons rather than a per-surface walkthrough, see [XBOX Godot NetRumble](sample/tutorial_netrumble/README.md), which lives in a separate repository.
+
 | Addon | Description |
 |-------|-------------|
 | [`godot_gdk`](addons/godot_gdk/) | GDK runtime + PC-supported XBOX services: users, achievements, presence, social, profile, privacy, multiplayer activity, stats, leaderboards, title storage, string verification, package metadata + DLC, XStore commerce, GameUI, accessibility, capture, launcher, error reporting, system metadata |

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ docs/
 > - `sample/tutorial_playfab/` — PlayFab-only tutorial track (sign-in,
 >   leaderboards, lobby, Party)
 > - `sample/tutorial_integrated/` — integrated GDK + PlayFab track
->   (Xbox→PlayFab sign-in, integration tech demo)
+>   (XBOX→PlayFab sign-in, integration tech demo)
 > - `sample/tutorial_gameinput/` — standalone GameInput demo
 >
 > `sample/tutorial_netrumble/` is a pointer rather than a committed

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,11 @@ docs/
 >   (Xbox→PlayFab sign-in, integration tech demo)
 > - `sample/tutorial_gameinput/` — standalone GameInput demo
 >
+> `sample/tutorial_netrumble/` is a pointer rather than a committed
+> host: it documents [XBOX Godot NetRumble](../sample/tutorial_netrumble/README.md),
+> a full multiplayer game built on these addons that lives in a
+> separate repository.
+>
 > [The tutorials](../docs/tutorials/README.md) walk through each
 > surface, and the test hosts under `tests/godot/` exercise the
 > addons end-to-end.

--- a/docs/gdk/sample-and-tests.md
+++ b/docs/gdk/sample-and-tests.md
@@ -26,6 +26,11 @@ The repository currently ships four tutorial-driven sample projects:
 - `sample\tutorial_gameinput\` — standalone GameInput tutorial sample. It is
   wired for the GameInput addon rather than the Microsoft GDK runtime addon.
 
+`sample\tutorial_netrumble\` is not one of those four. It holds documentation only,
+pointing at [XBOX Godot NetRumble](../../sample/tutorial_netrumble/README.md), a full
+multiplayer game hosted in a separate repository. Nothing is mirrored into it by the
+CMake build.
+
 The test hosts under `tests\godot\` remain the automated coverage projects;
 the sample projects are reader-facing tutorial references, not GUT hosts.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -797,6 +797,11 @@ files stay intact.
 > once (`cmake --build build --preset debug`) so each project's mirrored
 > `addons/` are populated, then open one in Godot. See
 > [the tutorials](tutorials/README.md) for the per-track walkthroughs.
+>
+> `sample/tutorial_netrumble/` contains no project of its own. It
+> documents [XBOX Godot NetRumble](../sample/tutorial_netrumble/README.md),
+> a full multiplayer game built on these addons and hosted in a
+> separate repository.
 
 ### Run the tests
 
@@ -846,6 +851,7 @@ sample/                   # Tutorial sample projects:
                           #   tutorial_playfab/     — PlayFab-only track
                           #   tutorial_integrated/  — GDK + PlayFab track
                           #   tutorial_gameinput/   — standalone GameInput
+                          #   tutorial_netrumble/   — pointer to the external NetRumble game
 tests/                    # Baselines, C++ doctest sources, and Godot test hosts
   godot/gdk/              # GDK and GDK packaging test host
   godot/playfab/          # PlayFab test host

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -53,6 +53,11 @@ If your project drifts from a tutorial, open the matching sample scene and compa
 - [`sample/tutorial_integrated/`](../../sample/tutorial_integrated/README.md) — integrated Xbox + PlayFab track (`i01` → `i02`).
 - [`sample/tutorial_gameinput/`](../../sample/tutorial_gameinput/README.md) — standalone GameInput sample.
 
+For a complete game rather than a per-surface reference, see
+[`sample/tutorial_netrumble/`](../../sample/tutorial_netrumble/README.md), which documents
+XBOX Godot NetRumble. NetRumble is built on these addons and hosted in a separate
+repository.
+
 Samples have CMake-mirrored `addons/` folders; run `cmake --build build --preset debug` from the repo root once before opening them in Godot.
 
 ## Recommended reading order

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -50,7 +50,7 @@ If your project drifts from a tutorial, open the matching sample scene and compa
 
 - [`sample/tutorial_gdk/`](../../sample/tutorial_gdk/README.md) — GDK-only track (`g01` → `g04`).
 - [`sample/tutorial_playfab/`](../../sample/tutorial_playfab/README.md) — PlayFab-only track (`p01` → `p05`).
-- [`sample/tutorial_integrated/`](../../sample/tutorial_integrated/README.md) — integrated Xbox + PlayFab track (`i01` → `i02`).
+- [`sample/tutorial_integrated/`](../../sample/tutorial_integrated/README.md) — integrated XBOX + PlayFab track (`i01` → `i02`).
 - [`sample/tutorial_gameinput/`](../../sample/tutorial_gameinput/README.md) — standalone GameInput sample.
 
 For a complete game rather than a per-surface reference, see

--- a/sample/tutorial_gameinput/README.md
+++ b/sample/tutorial_gameinput/README.md
@@ -41,4 +41,4 @@ Install the Godot 4.6.1 export templates under
 - GDK-only sample: [`sample/tutorial_gdk/`](../tutorial_gdk/README.md)
 - PlayFab-only sample: [`sample/tutorial_playfab/`](../tutorial_playfab/README.md)
 - Integrated GDK + PlayFab sample: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_gameinput/README.md
+++ b/sample/tutorial_gameinput/README.md
@@ -41,3 +41,4 @@ Install the Godot 4.6.1 export templates under
 - GDK-only sample: [`sample/tutorial_gdk/`](../tutorial_gdk/README.md)
 - PlayFab-only sample: [`sample/tutorial_playfab/`](../tutorial_playfab/README.md)
 - Integrated GDK + PlayFab sample: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_gdk/README.md
+++ b/sample/tutorial_gdk/README.md
@@ -52,4 +52,4 @@ This Godot 4.x project is the reference implementation for the [GDK tutorial tra
 - [Tutorials index](../../docs/tutorials/README.md)
 - [GDK setup](../../docs/gdk/sample-setup.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_gdk/README.md
+++ b/sample/tutorial_gdk/README.md
@@ -52,3 +52,4 @@ This Godot 4.x project is the reference implementation for the [GDK tutorial tra
 - [Tutorials index](../../docs/tutorials/README.md)
 - [GDK setup](../../docs/gdk/sample-setup.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_gdk_csharp/README.md
+++ b/sample/tutorial_gdk_csharp/README.md
@@ -73,4 +73,4 @@ the GDScript samples demonstrate, expressed in C#.
 - GDScript counterpart: [`sample/tutorial_gdk/`](../tutorial_gdk/README.md)
 - [C# facade reference](../../docs/gdk/csharp.md)
 - [Tutorials index](../../docs/tutorials/README.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_gdk_csharp/README.md
+++ b/sample/tutorial_gdk_csharp/README.md
@@ -73,3 +73,4 @@ the GDScript samples demonstrate, expressed in C#.
 - GDScript counterpart: [`sample/tutorial_gdk/`](../tutorial_gdk/README.md)
 - [C# facade reference](../../docs/gdk/csharp.md)
 - [Tutorials index](../../docs/tutorials/README.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_integrated/README.md
+++ b/sample/tutorial_integrated/README.md
@@ -61,3 +61,4 @@ The sample includes a committed `export_presets.cfg` so a clean clone has editab
 - GDK-only sample: [`sample/tutorial_gdk/`](../tutorial_gdk/README.md)
 - PlayFab-only sample: [`sample/tutorial_playfab/`](../tutorial_playfab/README.md)
 - Standalone GameInput sample: [`sample/tutorial_gameinput/`](../tutorial_gameinput/README.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_integrated/README.md
+++ b/sample/tutorial_integrated/README.md
@@ -61,4 +61,4 @@ The sample includes a committed `export_presets.cfg` so a clean clone has editab
 - GDK-only sample: [`sample/tutorial_gdk/`](../tutorial_gdk/README.md)
 - PlayFab-only sample: [`sample/tutorial_playfab/`](../tutorial_playfab/README.md)
 - Standalone GameInput sample: [`sample/tutorial_gameinput/`](../tutorial_gameinput/README.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_integrated_csharp/README.md
+++ b/sample/tutorial_integrated_csharp/README.md
@@ -67,3 +67,4 @@ Party tab uses PlayFab Party's managed transport.
 - GDScript counterpart: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)
 - [C# facade reference](../../docs/gdk/csharp.md)
 - [Tutorials index](../../docs/tutorials/README.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_integrated_csharp/README.md
+++ b/sample/tutorial_integrated_csharp/README.md
@@ -67,4 +67,4 @@ Party tab uses PlayFab Party's managed transport.
 - GDScript counterpart: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)
 - [C# facade reference](../../docs/gdk/csharp.md)
 - [Tutorials index](../../docs/tutorials/README.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -1,7 +1,8 @@
 # XBOX Godot NetRumble
 
-**This folder is a pointer, not a project.** NetRumble lives in its own repository (currently private):
+**This folder is a pointer, not a project.** NetRumble lives in its own repository:
 [microsoft/XBOX-Godot-NetRumble](https://github.com/microsoft/XBOX-Godot-NetRumble)
+
 ## What it is
 
 NetRumble is a complete Godot 4 multiplayer game that integrates the Microsoft Game
@@ -44,11 +45,6 @@ account. Exporting to XBOX Series X|S additionally requires the W4 Games console
 Godot.
 
 Full setup lives in the NetRumble repository's own README and `docs/`.
-
-> [!NOTE]
-> The NetRumble repository is currently private, so the link above will return a 404 unless
-> you have been granted access. Request access from the XBOX Developer Middleware, Samples
-> and Skills squad.
 
 ## See also
 

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -1,8 +1,7 @@
 # XBOX Godot NetRumble
 
-**This folder is a pointer, not a project.** NetRumble lives in its own repository:
-**https://github.com/microsoft/XBOX-Godot-NetRumble**
-
+**This folder is a pointer, not a project.** NetRumble lives in its own repository (currently private):
+`microsoft/XBOX-Godot-NetRumble`
 ## What it is
 
 NetRumble is a complete Godot 4 multiplayer game that integrates the Microsoft Game

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -18,14 +18,15 @@ like once the addons are in use. It is a working sample, not a certified title.
 
 - GDK sign-in exchanged for a PlayFab identity, and a sign-in screen that cooperates with
   the system account picker
-- Join-code matchmaking with PlayFab Lobby, and PlayFab Party as a drop-in Godot
+- Join-code discovery with PlayFab Lobby, and PlayFab Party as a drop-in Godot
   `MultiplayerPeer`
 - Host-authoritative replication with client prediction
 - Multiplayer and communications privilege checks, plus per-player mute, block and avoid
 - Voice chat, and text verification before user-authored content is published
 - One-shot and incremental achievements
-- Cloud saves written to the Game Save folder rather than `user://`
-- Suspend, resume, and constraint handling
+- Console Game Save for profile, history and counters, written to the Game Save folder
+  rather than `user://`
+- Suspend, resume, and constrained-mode handling
 - Activity publishing, join-from-guide invites, and connectivity detection
 
 Every platform call goes through a single services facade, so gameplay and UI never reach
@@ -50,4 +51,4 @@ Full setup lives in the NetRumble repository's own README and `docs/`.
 
 - [Tutorials index](../../docs/tutorials/README.md)
 - [Getting started](../../docs/getting-started.md)
-- Integrated Xbox + PlayFab sample: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)
+- Integrated XBOX + PlayFab sample: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -1,7 +1,7 @@
 # XBOX Godot NetRumble
 
 **This folder is a pointer, not a project.** NetRumble lives in its own repository (currently private):
-`microsoft/XBOX-Godot-NetRumble`
+[microsoft/XBOX-Godot-NetRumble](https://github.com/microsoft/XBOX-Godot-NetRumble)
 ## What it is
 
 NetRumble is a complete Godot 4 multiplayer game that integrates the Microsoft Game

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -24,7 +24,7 @@ like once the addons are in use. It is a working sample, not a certified title.
 - Voice chat, and text verification before user-authored content is published
 - One-shot and incremental achievements
 - Cloud saves written to the Game Save folder rather than `user://`
-- Suspend, resume and constrain handling
+- Suspend, resume, and constraint handling
 - Activity publishing, join-from-guide invites, and connectivity detection
 
 Every platform call goes through a single services facade, so gameplay and UI never reach

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -42,7 +42,7 @@ GDK, PlayFab and GameInput addons flow into NetRumble when it moves that pin.
 
 Godot 4.6 or later on Windows, with the addons built once from the submodule. Sign-in,
 multiplayer and achievements need the PC in the **XDKS.1** sandbox and a signed-in test
-account. Exporting to XBOX Series X|S additionally requires the W4 Games console fork of
+account. Exporting to XBOX Series X|S additionally requires a middleware console fork of
 Godot.
 
 Full setup lives in the NetRumble repository's own README and `docs/`.

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -1,0 +1,58 @@
+# XBOX Godot NetRumble
+
+**This folder is a pointer, not a project.** NetRumble lives in its own repository:
+**https://github.com/microsoft/XBOX-Godot-NetRumble**
+
+## What it is
+
+NetRumble is a complete Godot 4 multiplayer game that integrates the Microsoft Game
+Development Kit (GDK) and PlayFab. It is a 2D top-down space shooter: up to 8 players fly
+ships around a wrapping asteroid field, collect weapon power-ups, and shoot each other for
+points.
+
+Where the tutorial samples in this repository demonstrate one surface at a time, NetRumble
+wires every service into actual gameplay. It is the reference for what a full title looks
+like once the addons are in use. It is a working sample, not a certified title.
+
+## What it demonstrates
+
+- GDK sign-in exchanged for a PlayFab identity, and a sign-in screen that cooperates with
+  the system account picker
+- Join-code matchmaking with PlayFab Lobby, and PlayFab Party as a drop-in Godot
+  `MultiplayerPeer`
+- Host-authoritative replication with client prediction
+- Multiplayer and communications privilege checks, plus per-player mute, block and avoid
+- Voice chat, and text verification before user-authored content is published
+- One-shot and incremental achievements
+- Cloud saves written to the Game Save folder rather than `user://`
+- Suspend, resume and constrain handling
+- Activity publishing, join-from-guide invites, and connectivity detection
+
+Every platform call goes through a single services facade, so gameplay and UI never reach
+into GDK or PlayFab directly.
+
+## Relationship to this repository
+
+NetRumble consumes the addons authored here. It pins this repository as a submodule at
+`external/xbox-godot-sample` and builds it into its own `addons/` folder, so changes to the
+GDK, PlayFab and GameInput addons flow into NetRumble when it moves that pin.
+
+## Requirements
+
+Godot 4.6 or later on Windows, with the addons built once from the submodule. Sign-in,
+multiplayer and achievements need the PC in the **XDKS.1** sandbox and a signed-in test
+account. Exporting to XBOX Series X|S additionally requires the W4 Games console fork of
+Godot.
+
+Full setup lives in the NetRumble repository's own README and `docs/`.
+
+> [!NOTE]
+> The NetRumble repository is currently private, so the link above will return a 404 unless
+> you have been granted access. Request access from the XBOX Developer Middleware, Samples
+> and Skills squad.
+
+## See also
+
+- [Tutorials index](../../docs/tutorials/README.md)
+- [Getting started](../../docs/getting-started.md)
+- Integrated Xbox + PlayFab sample: [`sample/tutorial_integrated/`](../tutorial_integrated/README.md)

--- a/sample/tutorial_netrumble/README.md
+++ b/sample/tutorial_netrumble/README.md
@@ -6,9 +6,9 @@
 ## What it is
 
 NetRumble is a complete Godot 4 multiplayer game that integrates the Microsoft Game
-Development Kit (GDK) and PlayFab. It is a 2D top-down space shooter: up to 8 players fly
-ships around a wrapping asteroid field, collect weapon power-ups, and shoot each other for
-points.
+Development Kit (GDK) and PlayFab. It is a 2D top-down space shooter: players fly ships
+through an asteroid field inside a walled arena, collect weapon power-ups, and shoot each
+other for points.
 
 Where the tutorial samples in this repository demonstrate one surface at a time, NetRumble
 wires every service into actual gameplay. It is the reference for what a full title looks

--- a/sample/tutorial_playfab/README.md
+++ b/sample/tutorial_playfab/README.md
@@ -65,4 +65,4 @@ The P1 sign-in scene and the picker status show the active custom id.
 - [Tutorials index](../../docs/tutorials/README.md)
 - [PlayFab prerequisites](../../docs/playfab/prerequisites.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_playfab/README.md
+++ b/sample/tutorial_playfab/README.md
@@ -65,3 +65,4 @@ The P1 sign-in scene and the picker status show the active custom id.
 - [Tutorials index](../../docs/tutorials/README.md)
 - [PlayFab prerequisites](../../docs/playfab/prerequisites.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)

--- a/sample/tutorial_playfab_csharp/README.md
+++ b/sample/tutorial_playfab_csharp/README.md
@@ -86,5 +86,5 @@ separate PlayFab account (namespaced as `godot-playfab-tutorial-<name>`).
 - [Tutorials index](../../docs/tutorials/README.md)
 - [PlayFab prerequisites](../../docs/playfab/prerequisites.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
-- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
+- Full game reference (external): [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
 

--- a/sample/tutorial_playfab_csharp/README.md
+++ b/sample/tutorial_playfab_csharp/README.md
@@ -86,4 +86,5 @@ separate PlayFab account (namespaced as `godot-playfab-tutorial-<name>`).
 - [Tutorials index](../../docs/tutorials/README.md)
 - [PlayFab prerequisites](../../docs/playfab/prerequisites.md)
 - [Troubleshooting](../../docs/troubleshooting.md)
+- Full game sample: [`sample/tutorial_netrumble/`](../tutorial_netrumble/README.md)
 


### PR DESCRIPTION
Adds `sample/tutorial_netrumble/` containing a single `README.md` that describes XBOX Godot NetRumble and points at its repository, [microsoft/XBOX-Godot-NetRumble](https://github.com/microsoft/XBOX-Godot-NetRumble).

NetRumble is a complete Godot 4 multiplayer game built on this repository's addons, which it pins as a submodule at `external/xbox-godot-sample`. Where the tutorial samples here demonstrate one surface at a time, NetRumble wires every service into real gameplay, so it is worth surfacing from the sample docs.

### The folder is a pointer, not a project

`sample/tutorial_netrumble/` holds documentation only. There is no `project.godot` and nothing is mirrored into it by the CMake build. The docs that enumerate the four tutorial sample projects therefore keep saying **four** and reference NetRumble in a separate sentence, so no existing statement about building or opening a sample becomes untrue.

For the same reason `tools/export_samples.ps1` is left alone: it takes explicit sample names and there is nothing here to export.

### Places updated

Every doc that enumerates the samples now mentions it:

- `README.md`
- `docs/README.md`
- `docs/getting-started.md` (bundled samples section and the repository tree)
- `docs/tutorials/README.md`
- `docs/gdk/sample-and-tests.md`
- the `See also` section of all seven sample `README.md` files

Specs under `spec/` and the build-oriented `docs/gdk/build-and-loading.md` were deliberately not touched: they reference sample paths as build and test targets, which NetRumble is not.

### Validation

No `.gd`, C++, or build files are touched, so the parse gate and test orchestrator are not applicable; this is documentation only. Note that `pr-gates.yml` uses `paths-ignore` for `**.md` and `docs/**`, so this PR intentionally starts no gate jobs.

All 12 relative links to the new page were verified to resolve on disk, along with the three outbound links from it.